### PR TITLE
fix: position overdue nav-badge absolutely to fix flex layout distortion

### DIFF
--- a/public/pages/tasks.js
+++ b/public/pages/tasks.js
@@ -828,7 +828,10 @@ function updateOverdueBadge() {
   document.querySelectorAll('[data-route="/tasks"] .nav-badge').forEach((el) => el.remove());
   if (overdue > 0) {
     document.querySelectorAll('[data-route="/tasks"]').forEach((el) => {
-      el.insertAdjacentHTML('beforeend', `<span class="nav-badge">${overdue}</span>`);
+      const badge = document.createElement('span');
+      badge.className = 'nav-badge';
+      badge.textContent = String(overdue);
+      el.appendChild(badge);
     });
   }
 }

--- a/public/styles/layout.css
+++ b/public/styles/layout.css
@@ -193,6 +193,14 @@
   min-height: var(--target-lg);
   min-width: var(--target-lg);
   text-decoration: none;
+  position: relative;
+}
+
+.nav-item .nav-badge {
+  position: absolute;
+  top: var(--space-1);
+  right: var(--space-1);
+  margin-left: 0;
 }
 
 .nav-item:active {


### PR DESCRIPTION
Resolves #56.

## Root Cause

`updateOverdueBadge()` appended `<span class="nav-badge">` as an **in-flow flex child** into `[data-route="/tasks"]` nav elements via `insertAdjacentHTML`. This broke layout in two ways:

- **Mobile bottom nav** (`flex-direction: column`): badge appeared as a third stacked item *below* the label, stretching the nav item height
- **Desktop sidebar** (`flex-direction: row` + `justify-content: center`): `margin-left: auto` on the badge pushed it to the far right edge, disconnected from the icon

## Changes

- **`layout.css`**: Added `position: relative` to `.nav-item` and a `.nav-item .nav-badge` rule that positions the badge absolutely at `top/right: var(--space-1)`, taking it out of flow so it overlays the nav item corner without distorting the flex layout
- **`tasks.js`**: Replaced `insertAdjacentHTML` with DOM API (`createElement` + `textContent` + `appendChild`) per project convention