### PR TITLE
fix: theme reverts to light on reload (system preference)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.25] - 2026-04-20
+
+### Fixed
+- Theme selection no longer reverts to light mode on page reload when "System" is chosen; the init script now correctly resolves the `system` preference to the OS dark/light state instead of treating it as a literal `data-theme` value
+
 ## [0.20.24] - 2026-04-20
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oikos",
-  "version": "0.20.24",
+  "version": "0.20.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oikos",
-      "version": "0.20.24",
+      "version": "0.20.25",
       "license": "MIT",
       "dependencies": {
         "bcrypt": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oikos",
-  "version": "0.20.24",
+  "version": "0.20.25",
   "description": "Self-hosted family planner - calendar, tasks, shopping, meal planning, budget and more. Private, open-source, no subscription.",
   "main": "server/index.js",
   "type": "module",

--- a/public/index.html
+++ b/public/index.html
@@ -47,9 +47,14 @@
     (function() {
       var stored = localStorage.getItem('oikos-theme');
       var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-      document.documentElement.setAttribute('data-theme', stored || (prefersDark ? 'dark' : 'light'));
+      if (stored === 'dark' || stored === 'light') {
+        document.documentElement.setAttribute('data-theme', stored);
+      } else {
+        document.documentElement.setAttribute('data-theme', prefersDark ? 'dark' : 'light');
+      }
       window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', function(e) {
-        if (!localStorage.getItem('oikos-theme')) {
+        var current = localStorage.getItem('oikos-theme');
+        if (!current || current === 'system') {
           document.documentElement.setAttribute('data-theme', e.matches ? 'dark' : 'light');
         }
       });


### PR DESCRIPTION
## Summary

- The theme initialization script in `index.html` stored `'system'` as a literal `data-theme` attribute value, which CSS does not handle — causing the app to appear in light mode on every reload when system preference was selected
- The `matchMedia` change listener also failed to update the theme when `'system'` was stored in `localStorage`
- Fixed by checking for explicit `'dark'`/`'light'` values only, and falling back to OS preference for anything else (including `'system'`)

## Test plan

- [ ] Set theme to "System" with OS in dark mode → reload → app stays dark
- [ ] Set theme to "System" with OS in light mode → reload → app stays light
- [ ] Set theme to "Dark" explicitly → reload → app stays dark
- [ ] Set theme to "Light" explicitly → reload → app stays light
- [ ] Change OS theme while app is open with "System" selected → app updates immediately

Resolves #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)