### PR TITLE
feat: add FAB to meals page for quick meal creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.26] - 2026-04-20
+
+### Added
+- Meals: floating action button (FAB) now appears fixed at the bottom-right corner, opening a quick-add modal for today with the first visible meal type pre-selected
+
 ## [0.20.25] - 2026-04-20
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oikos",
-  "version": "0.20.25",
+  "version": "0.20.26",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oikos",
-      "version": "0.20.25",
+      "version": "0.20.26",
       "license": "MIT",
       "dependencies": {
         "bcrypt": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oikos",
-  "version": "0.20.25",
+  "version": "0.20.26",
   "description": "Self-hosted family planner - calendar, tasks, shopping, meal planning, budget and more. Private, open-source, no subscription.",
   "main": "server/index.js",
   "type": "module",

--- a/public/pages/meals.js
+++ b/public/pages/meals.js
@@ -146,6 +146,9 @@ export async function render(container, { user }) {
       <div class="week-grid" id="week-grid">
         <div style="margin:auto;padding:2rem;text-align:center;color:var(--color-text-disabled)">${t('meals.loadingIndicator')}</div>
       </div>
+      <button class="page-fab" id="fab-new-meal" aria-label="${t('meals.addMealTitle')}">
+        <i data-lucide="plus" style="width:24px;height:24px" aria-hidden="true"></i>
+      </button>
     </div>
   `;
 
@@ -157,6 +160,11 @@ export async function render(container, { user }) {
   await Promise.all([loadWeek(monday), loadLists(), loadPreferences(), loadCategories()]);
   renderWeekGrid();
   wireNav();
+
+  container.querySelector('#fab-new-meal').addEventListener('click', () => {
+    const firstType = state.visibleMealTypes[0] ?? 'lunch';
+    openMealModal({ mode: 'create', date: today, mealType: firstType });
+  });
 }
 
 // --------------------------------------------------------


### PR DESCRIPTION
## Summary

- All pages in scope (Tasks, Notes, Contacts, Budget, Calendar) already had a fixed-position `page-fab` implemented
- The Meals page was the only missing one — it only had contextual `+` buttons inside each meal slot
- Added a `page-fab` to the Meals page that opens the add-meal modal pre-set to today's date and the first visible meal type

## Test plan

- [ ] Open Meals page → FAB appears fixed at bottom-right corner
- [ ] Tap FAB → modal opens with today's date and first visible meal type pre-selected
- [ ] FAB is hidden when virtual keyboard is open (existing `keyboard-visible` CSS rule)
- [ ] FAB renders correctly in dark and light theme

Resolves #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)