### PR TITLE
fix: system theme immediately applies OS preference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.27] - 2026-04-20
+
+### Fixed
+- Selecting "System" theme in settings now immediately applies the OS dark/light preference instead of reverting to light mode until the next page reload
+
 ## [0.20.26] - 2026-04-20
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oikos",
-  "version": "0.20.26",
+  "version": "0.20.27",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oikos",
-      "version": "0.20.26",
+      "version": "0.20.27",
       "license": "MIT",
       "dependencies": {
         "bcrypt": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oikos",
-  "version": "0.20.26",
+  "version": "0.20.27",
   "description": "Self-hosted family planner - calendar, tasks, shopping, meal planning, budget and more. Private, open-source, no subscription.",
   "main": "server/index.js",
   "type": "module",

--- a/public/pages/settings.js
+++ b/public/pages/settings.js
@@ -854,7 +854,8 @@ function applyTheme(value) {
   if (value === 'light' || value === 'dark') {
     document.documentElement.setAttribute('data-theme', value);
   } else {
-    document.documentElement.removeAttribute('data-theme');
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    document.documentElement.setAttribute('data-theme', prefersDark ? 'dark' : 'light');
   }
 }
 


### PR DESCRIPTION
## Summary

- `applyTheme('system')` was removing the `data-theme` attribute entirely
- Since the CSS has no `@media (prefers-color-scheme: dark)` block (it relies solely on `[data-theme="dark"]`), removing the attribute always resulted in light mode — even when the OS was in dark mode
- Fix: when "System" is selected, read `prefers-color-scheme` immediately and set `data-theme` accordingly

## Root cause

The CSS architecture was changed to use only `[data-theme="dark"]` (no media query fallback), but `applyTheme` was not updated to reflect this — it still assumed removing the attribute would "auto-follow" the OS, which it can't do without a media query in CSS.

## Test plan

- [ ] System in dark mode → open Settings → select "System" → page immediately switches to dark
- [ ] System in light mode → open Settings → select "System" → page immediately stays light
- [ ] Select "Dark" explicitly → page is dark regardless of OS
- [ ] Select "Light" explicitly → page is light regardless of OS
- [ ] Reload after each step → preference persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)