### PR TITLE
Fix Min/Max Temperature Aggregation for Forecast in Weather Widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.33] - 2026-04-20
+
+### Fixed
+- Min/Max Temperature Aggregation for Forecast in Weather Widget
+
 ## [0.20.32] - 2026-04-20
 
 ### Changed

--- a/server/routes/weather.js
+++ b/server/routes/weather.js
@@ -50,25 +50,48 @@ router.get('/', async (req, res) => {
     }
     const currentJson = await currentRes.json();
 
-    // 5-Tage-Forecast (3h-Intervalle → wir nehmen Mittags-Werte für Tagesvorschau)
+    // 5-Tage-Forecast (3h-Intervalle → aggregiert zu Tageswerten)
     const forecastUrl = `https://api.openweathermap.org/data/2.5/forecast?q=${encodeURIComponent(city)}&appid=${apiKey}&units=${units}&lang=${lang}&cnt=40`;
     const forecastRes = await fetch(forecastUrl, { signal: AbortSignal.timeout(8000) });
     let forecastDays = [];
+
     if (forecastRes.ok) {
       const forecastJson = await forecastRes.json();
-      // Ein Eintrag pro Tag: nächstgelegener Mittags-Wert (12:00 Uhr)
-      const seen = new Set();
-      for (const item of forecastJson.list ?? []) {
-        const dateStr = item.dt_txt.slice(0, 10); // YYYY-MM-DD
-        if (seen.has(dateStr)) continue;
-        seen.add(dateStr);
+      const list = forecastJson.list ?? [];
+
+      // Alle Einträge nach Tag gruppieren
+      const dayMap = new Map(); // "YYYY-MM-DD" → { temps: [], items: [] }
+
+      for (const item of list) {
+        const dateStr = item.dt_txt.slice(0, 10);
+        if (!dayMap.has(dateStr)) {
+          dayMap.set(dateStr, { temps: [], items: [] });
+        }
+        const day = dayMap.get(dateStr);
+        day.temps.push(item.main.temp);
+        day.items.push(item);
+      }
+
+      // Heute überspringen (Forecast),
+      const today = new Date().toISOString().slice(0, 10);
+
+      for (const [dateStr, { temps, items }] of dayMap) {
+        if (dateStr === today) continue; // optional
+
+        // Mittags-Wert (12:00) für Icon/Desc nutzen, falls nicht vorhanden Fallback auf 15:00 / mitte des Tages
+        const noonItem =
+          items.find(i => i.dt_txt.includes("12:00:00")) ??
+          items.find(i => i.dt_txt.includes("15:00:00")) ??
+          items[Math.floor(items.length / 2)];
+
         forecastDays.push({
-          date:      dateStr,
-          temp_min:  Math.round(item.main.temp_min),
-          temp_max:  Math.round(item.main.temp_max),
-          icon:      item.weather[0]?.icon,
-          desc:      item.weather[0]?.description,
+          date:     dateStr,
+          temp_min: Math.round(Math.min(...temps)),
+          temp_max: Math.round(Math.max(...temps)),
+          icon:     noonItem.weather[0]?.icon,
+          desc:     noonItem.weather[0]?.description,
         });
+
         if (forecastDays.length >= 5) break;
       }
     }


### PR DESCRIPTION
## Summary

The min/max temperature values on dashboard were taken from the 12:00 entry from OWM. In that case and endpoint, this provides only a snapshot of 12:00 so min/max values are same most of the time for that snapshot.
To get min/max values correctly from this free API endpoint we have to aggregate one day and get the min/max out of the series of values per day.
To get a matching icon we could still use the icon for the 12:00 entry (or maybe use some AI in future to forecast a day by the series of weather information of one day.. :D)

## Changes

- changed the block which fetches and aggregates forecast data from OWM API in server/routes/weather.js

## Checklist

- [x] `npm test` passes
- [x] Follows [CONTRIBUTING.md](../CONTRIBUTING.md) conventions
- [x] No new frontend dependencies (vanilla JS, no frameworks)
- [x] UI strings use `t('key')` (no hardcoded text)
- [x] CHANGELOG.md updated (if user-facing change)
