### PR TITLE
fix(i18n): correct quotation marks in delete confirmation message for recipes

### DIFF
--- a/public/locales/de.json
+++ b/public/locales/de.json
@@ -697,7 +697,7 @@
     "ingredientsLabel": "Zutaten",
     "addToMeals": "In Essensplan übernehmen",
     "openLink": "Rezept-Link öffnen",
-    "deleteConfirm": "Rezept „{{title}}" löschen?",
+    "deleteConfirm": "Rezept \"{{title}}\" löschen?",
     "created": "Rezept gespeichert.",
     "updated": "Rezept aktualisiert.",
     "deleted": "Rezept gelöscht.",


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Link the related issue: Closes #73  -->
fix #73 

## Changes

replaced
```
    "deleteConfirm": "Rezept „{{title}}" löschen?",
```
to
```
    "deleteConfirm": "Rezept \"{{title}}\" löschen?",
```

## Checklist

- [x] `npm test` passes
- [x] Follows [CONTRIBUTING.md](../CONTRIBUTING.md) conventions
- [x] No new frontend dependencies (vanilla JS, no frameworks)
- [ ] UI strings use `t('key')` (no hardcoded text)
- [ ] CHANGELOG.md updated (if user-facing change)
