### PR TITLE
fix(weather): correct wind speed value and unit label for imperial units

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.23.3] - 2026-04-22
+
+### Fixed
+- Weather widget: wind speed is no longer multiplied by 3.6 when `OPENWEATHER_UNITS=imperial` (the API already returns mph; the conversion was only correct for metric/standard)
+- Weather widget: wind unit label now shows `mph` for imperial and `km/h` for metric/standard instead of always showing `km/h`
+
 ## [0.23.2] - 2026-04-22
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oikos",
-  "version": "0.23.2",
+  "version": "0.23.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oikos",
-      "version": "0.23.2",
+      "version": "0.23.3",
       "license": "MIT",
       "dependencies": {
         "bcrypt": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oikos",
-  "version": "0.23.2",
+  "version": "0.23.3",
   "description": "Self-hosted family planner - calendar, tasks, shopping, meal planning, budget and more. Private, open-source, no subscription.",
   "main": "server/index.js",
   "type": "module",

--- a/public/locales/ar.json
+++ b/public/locales/ar.json
@@ -65,7 +65,7 @@
     "weatherRefresh": "تحديث الطقس",
     "weatherRefreshTitle": "تحديث",
     "weatherUpdated": "تم تحديث الطقس",
-    "weatherFeelsLike": "الإحساس {{temp}}° · {{humidity}}% · الريح {{wind}} كم/س",
+    "weatherFeelsLike": "الإحساس {{temp}}° · {{humidity}}% · الريح {{wind}} {{windUnit}}",
     "fabTaskLabel": "إضافة مهمة",
     "fabCalendarLabel": "إضافة حدث",
     "fabShoppingLabel": "إضافة تسوق",

--- a/public/locales/de.json
+++ b/public/locales/de.json
@@ -72,7 +72,7 @@
     "weatherRefresh": "Wetter aktualisieren",
     "weatherRefreshTitle": "Aktualisieren",
     "weatherUpdated": "Wetter aktualisiert",
-    "weatherFeelsLike": "Gefühlt {{temp}}° · {{humidity}}% · Wind {{wind}} km/h",
+    "weatherFeelsLike": "Gefühlt {{temp}}° · {{humidity}}% · Wind {{wind}} {{windUnit}}",
     "fabTaskLabel": "Aufgabe hinzufügen",
     "fabCalendarLabel": "Termin hinzufügen",
     "fabShoppingLabel": "Einkauf hinzufügen",

--- a/public/locales/el.json
+++ b/public/locales/el.json
@@ -65,7 +65,7 @@
     "weatherRefresh": "Ανανέωση καιρού",
     "weatherRefreshTitle": "Ανανέωση",
     "weatherUpdated": "Καιρός ενημερώθηκε",
-    "weatherFeelsLike": "Αίσθηση {{temp}}° · {{humidity}}% · Άνεμος {{wind}} χλμ/ώ",
+    "weatherFeelsLike": "Αίσθηση {{temp}}° · {{humidity}}% · Άνεμος {{wind}} {{windUnit}}",
     "fabTaskLabel": "Προσθήκη εργασίας",
     "fabCalendarLabel": "Προσθήκη εκδήλωσης",
     "fabShoppingLabel": "Προσθήκη αγοράς",

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -65,7 +65,7 @@
     "weatherRefresh": "Refresh weather",
     "weatherRefreshTitle": "Refresh",
     "weatherUpdated": "Weather updated",
-    "weatherFeelsLike": "Feels like {{temp}}° · {{humidity}}% · Wind {{wind}} km/h",
+    "weatherFeelsLike": "Feels like {{temp}}° · {{humidity}}% · Wind {{wind}} {{windUnit}}",
     "fabTaskLabel": "Add task",
     "fabCalendarLabel": "Add event",
     "fabShoppingLabel": "Add shopping",

--- a/public/locales/es.json
+++ b/public/locales/es.json
@@ -65,7 +65,7 @@
     "weatherRefresh": "Actualizar tiempo",
     "weatherRefreshTitle": "Actualizar",
     "weatherUpdated": "Tiempo actualizado",
-    "weatherFeelsLike": "Sensación {{temp}}° · {{humidity}}% · Viento {{wind}} km/h",
+    "weatherFeelsLike": "Sensación {{temp}}° · {{humidity}}% · Viento {{wind}} {{windUnit}}",
     "fabTaskLabel": "Añadir tarea",
     "fabCalendarLabel": "Añadir evento",
     "fabShoppingLabel": "Añadir compra",

--- a/public/locales/fr.json
+++ b/public/locales/fr.json
@@ -65,7 +65,7 @@
     "weatherRefresh": "Actualiser la météo",
     "weatherRefreshTitle": "Actualiser",
     "weatherUpdated": "Météo mise à jour",
-    "weatherFeelsLike": "Ressenti {{temp}}° · {{humidity}}% · Vent {{wind}} km/h",
+    "weatherFeelsLike": "Ressenti {{temp}}° · {{humidity}}% · Vent {{wind}} {{windUnit}}",
     "fabTaskLabel": "Ajouter une tâche",
     "fabCalendarLabel": "Ajouter un événement",
     "fabShoppingLabel": "Ajouter une course",

--- a/public/locales/hi.json
+++ b/public/locales/hi.json
@@ -65,7 +65,7 @@
     "weatherRefresh": "मौसम अपडेट करें",
     "weatherRefreshTitle": "अपडेट",
     "weatherUpdated": "मौसम अपडेट हो गया",
-    "weatherFeelsLike": "महसूस होता है {{temp}}° · {{humidity}}% · हवा {{wind}} km/h",
+    "weatherFeelsLike": "महसूस होता है {{temp}}° · {{humidity}}% · हवा {{wind}} {{windUnit}}",
     "fabTaskLabel": "कार्य जोड़ें",
     "fabCalendarLabel": "कार्यक्रम जोड़ें",
     "fabShoppingLabel": "खरीदारी जोड़ें",

--- a/public/locales/it.json
+++ b/public/locales/it.json
@@ -65,7 +65,7 @@
     "weatherRefresh": "Aggiorna meteo",
     "weatherRefreshTitle": "Aggiorna",
     "weatherUpdated": "Meteo aggiornato",
-    "weatherFeelsLike": "Percepiti {{temp}}° · {{humidity}}% · Vento {{wind}} km/h",
+    "weatherFeelsLike": "Percepiti {{temp}}° · {{humidity}}% · Vento {{wind}} {{windUnit}}",
     "fabTaskLabel": "Aggiungi compito",
     "fabCalendarLabel": "Aggiungi evento",
     "fabShoppingLabel": "Aggiungi spesa",

--- a/public/locales/ja.json
+++ b/public/locales/ja.json
@@ -65,7 +65,7 @@
     "weatherRefresh": "天気を更新",
     "weatherRefreshTitle": "更新",
     "weatherUpdated": "天気を更新しました",
-    "weatherFeelsLike": "体感 {{temp}}° · {{humidity}}% · 風速 {{wind}} km/h",
+    "weatherFeelsLike": "体感 {{temp}}° · {{humidity}}% · 風速 {{wind}} {{windUnit}}",
     "fabTaskLabel": "タスクを追加",
     "fabCalendarLabel": "予定を追加",
     "fabShoppingLabel": "買い物を追加",

--- a/public/locales/pt.json
+++ b/public/locales/pt.json
@@ -65,7 +65,7 @@
     "weatherRefresh": "Atualizar clima",
     "weatherRefreshTitle": "Atualizar",
     "weatherUpdated": "Clima atualizado",
-    "weatherFeelsLike": "Sensação {{temp}}° · {{humidity}}% · Vento {{wind}} km/h",
+    "weatherFeelsLike": "Sensação {{temp}}° · {{humidity}}% · Vento {{wind}} {{windUnit}}",
     "fabTaskLabel": "Adicionar tarefa",
     "fabCalendarLabel": "Adicionar evento",
     "fabShoppingLabel": "Adicionar compra",

--- a/public/locales/ru.json
+++ b/public/locales/ru.json
@@ -65,7 +65,7 @@
     "weatherRefresh": "Обновить погоду",
     "weatherRefreshTitle": "Обновить",
     "weatherUpdated": "Погода обновлена",
-    "weatherFeelsLike": "Ощущается как {{temp}}° · {{humidity}}% · Ветер {{wind}} км/ч",
+    "weatherFeelsLike": "Ощущается как {{temp}}° · {{humidity}}% · Ветер {{wind}} {{windUnit}}",
     "fabTaskLabel": "Добавить задачу",
     "fabCalendarLabel": "Добавить событие",
     "fabShoppingLabel": "Добавить покупку",

--- a/public/locales/sv.json
+++ b/public/locales/sv.json
@@ -65,7 +65,7 @@
     "weatherRefresh": "Uppdatera vädret",
     "weatherRefreshTitle": "Uppdatera",
     "weatherUpdated": "Väder uppdaterat",
-    "weatherFeelsLike": "Känns som {{temp}}° · {{humidity}}% · Vind {{wind}} km/h",
+    "weatherFeelsLike": "Känns som {{temp}}° · {{humidity}}% · Vind {{wind}} {{windUnit}}",
     "fabTaskLabel": "Lägg till uppgift",
     "fabCalendarLabel": "Lägg till händelse",
     "fabShoppingLabel": "Lägg till shopping",

--- a/public/locales/tr.json
+++ b/public/locales/tr.json
@@ -65,7 +65,7 @@
     "weatherRefresh": "Hava durumunu yenile",
     "weatherRefreshTitle": "Yenile",
     "weatherUpdated": "Hava durumu güncellendi",
-    "weatherFeelsLike": "Hissedilen {{temp}}° · {{humidity}}% · Rüzgar {{wind}} km/s",
+    "weatherFeelsLike": "Hissedilen {{temp}}° · {{humidity}}% · Rüzgar {{wind}} {{windUnit}}",
     "fabTaskLabel": "Görev ekle",
     "fabCalendarLabel": "Etkinlik ekle",
     "fabShoppingLabel": "Alışveriş ekle",

--- a/public/locales/uk.json
+++ b/public/locales/uk.json
@@ -65,7 +65,7 @@
     "weatherRefresh": "Оновити погоду",
     "weatherRefreshTitle": "Оновити",
     "weatherUpdated": "Погоду оновлено",
-    "weatherFeelsLike": "Відчувається як {{temp}}° · {{humidity}}% · Вітер {{wind}} км/год",
+    "weatherFeelsLike": "Відчувається як {{temp}}° · {{humidity}}% · Вітер {{wind}} {{windUnit}}",
     "fabTaskLabel": "Додати завдання",
     "fabCalendarLabel": "Додати подію",
     "fabShoppingLabel": "Додати покупку",

--- a/public/locales/zh.json
+++ b/public/locales/zh.json
@@ -65,7 +65,7 @@
     "weatherRefresh": "刷新天气",
     "weatherRefreshTitle": "刷新",
     "weatherUpdated": "天气已更新",
-    "weatherFeelsLike": "体感 {{temp}}° · {{humidity}}% · 风速 {{wind}} km/h",
+    "weatherFeelsLike": "体感 {{temp}}° · {{humidity}}% · 风速 {{wind}} {{windUnit}}",
     "fabTaskLabel": "添加任务",
     "fabCalendarLabel": "添加日程",
     "fabShoppingLabel": "添加购物",

--- a/public/pages/dashboard.js
+++ b/public/pages/dashboard.js
@@ -390,6 +390,7 @@ function renderWeatherWidget(weather) {
 
   const { city, current, forecast, units } = weather;
   const unitSymbol = units === 'imperial' ? '°F' : units === 'standard' ? 'K' : '°C';
+  const windUnit   = units === 'imperial' ? 'mph' : 'km/h';
 
   const forecastHtml = forecast.map((d, i) => {
     const date = new Date(d.date + 'T12:00:00');
@@ -419,7 +420,7 @@ function renderWeatherWidget(weather) {
             <div class="weather-widget__desc">${esc(current.desc)}</div>
             <div class="weather-widget__city">${esc(city)}</div>
             <div class="weather-widget__meta">
-              ${t('dashboard.weatherFeelsLike', { temp: current.feels_like, humidity: current.humidity, wind: current.wind_speed })}
+              ${t('dashboard.weatherFeelsLike', { temp: current.feels_like, humidity: current.humidity, wind: current.wind_speed, windUnit })}
             </div>
           </div>
           <img class="weather-widget__icon" src="${WEATHER_ICON_BASE}${current.icon}"

--- a/server/routes/weather.js
+++ b/server/routes/weather.js
@@ -105,7 +105,10 @@ router.get('/', async (req, res) => {
         humidity:   currentJson.main.humidity,
         icon:       currentJson.weather[0]?.icon,
         desc:       currentJson.weather[0]?.description,
-        wind_speed: Math.round((currentJson.wind?.speed ?? 0) * 3.6), // m/s → km/h
+        // metric/standard: m/s → km/h; imperial: already mph
+        wind_speed: units === 'imperial'
+          ? Math.round(currentJson.wind?.speed ?? 0)
+          : Math.round((currentJson.wind?.speed ?? 0) * 3.6),
       },
       forecast: forecastDays,
     };


### PR DESCRIPTION
## Summary

- **Server** (`server/routes/weather.js`): When `OPENWEATHER_UNITS=imperial`, the OpenWeatherMap API already returns wind speed in mph — the code was incorrectly multiplying by 3.6 (the m/s→km/h factor), inflating the value. Now only applies the conversion for `metric`/`standard`.
- **Frontend** (`public/pages/dashboard.js`): Computes `windUnit` (`mph` vs `km/h`) from the `units` field returned by the API, matching the existing `unitSymbol` pattern.
- **All locales** (15 files): Replaced hardcoded wind unit strings (km/h, км/ч, etc.) with a `{{windUnit}}` interpolation placeholder so the label reflects the configured unit system.

## Test plan

- [ ] `npm test` — all suites pass (verified locally, 0 failures)
- [ ] With `OPENWEATHER_UNITS=imperial`: wind speed shows a reasonable mph value and label reads `mph`
- [ ] With `OPENWEATHER_UNITS=metric` (default): wind speed and `km/h` label unchanged

Resolves #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)