### PR TITLE
fix: add missing i18n keys across all non-German locales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.23.15] - 2026-04-24
+
+### Fixed
+- All non-German locales (ar, el, en, es, fr, hi, it, ja, pt, ru, sv, tr, uk, zh): added missing translation keys for `nav.more`, `calendar.ics.reset/resetToast`, `settings.ics.*`, `tasks.filter*`, `tasks.swiped*`, `search.*`, and `reminders.*` — these were falling back to German strings for all non-German users
+
 ## [0.23.14] - 2026-04-23
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oikos",
-  "version": "0.23.13",
+  "version": "0.23.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oikos",
-      "version": "0.23.13",
+      "version": "0.23.15",
       "license": "MIT",
       "dependencies": {
         "bcrypt": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oikos",
-  "version": "0.23.14",
+  "version": "0.23.15",
   "description": "Self-hosted family planner - calendar, tasks, shopping, meal planning, budget and more. Private, open-source, no subscription.",
   "main": "server/index.js",
   "type": "module",

--- a/public/locales/ar.json
+++ b/public/locales/ar.json
@@ -43,7 +43,8 @@
     "main": "القائمة الرئيسية",
     "navigation": "التنقل",
     "quickActions": "الإجراءات السريعة",
-    "recipes": "Recipes"
+    "recipes": "Recipes",
+    "more": "المزيد"
   },
   "dashboard": {
     "title": "لوحة التحكم",
@@ -156,7 +157,14 @@
     "kanbanMoveToOpen": "إعادة الفتح",
     "recurring": "متكرر",
     "listView": "عرض القائمة",
-    "kanbanView": "عرض كانبان"
+    "kanbanView": "عرض كانبان",
+    "filterBtn": "تصفية",
+    "filterClearAll": "مسح جميع الفلاتر",
+    "filterGroupPerson": "الشخص",
+    "filterGroupPriority": "الأولوية",
+    "filterGroupStatus": "الحالة",
+    "swipedDoneToast": "تم وضع علامة مكتمل.",
+    "swipedOpenToast": "تم وضع علامة مفتوح."
   },
   "shopping": {
     "title": "التسوق",
@@ -322,7 +330,11 @@
     "dayLongThursday": "الخميس",
     "dayLongFriday": "الجمعة",
     "dayLongSaturday": "السبت",
-    "timeSuffix": ""
+    "timeSuffix": "",
+    "ics": {
+      "reset": "إعادة التعيين للأصل",
+      "resetToast": "تم إعادة تعيين التغييرات."
+    }
   },
   "notes": {
     "title": "لوحة الملاحظات",
@@ -564,7 +576,40 @@
     "sectionBudget": "الميزانية",
     "currencyLabel": "العملة",
     "currencyHint": "تحدد العملة المستخدمة في منطقة الميزانية بأكملها.",
-    "currencySaved": "تم حفظ العملة."
+    "currencySaved": "تم حفظ العملة.",
+    "ics": {
+      "title": "اشتراكات ICS",
+      "add": "إضافة اشتراك",
+      "addedToast": "تمت إضافة الاشتراك.",
+      "deletedToast": "تم حذف الاشتراك.",
+      "syncedToast": "تمت مزامنة الاشتراك.",
+      "confirm_delete": "هل تريد حقًا حذف هذا الاشتراك؟ ستُحذف أيضًا جميع الأحداث المرتبطة.",
+      "empty": "لا توجد اشتراكات بعد.",
+      "form": {
+        "name": "الاسم",
+        "url": "رابط ICS",
+        "color": "اللون",
+        "shared": "مرئي للجميع"
+      },
+      "actions": {
+        "submit": "إضافة",
+        "save": "حفظ",
+        "cancel": "إلغاء",
+        "delete": "حذف",
+        "edit": "تعديل",
+        "sync": "مزامنة الآن"
+      },
+      "status": {
+        "lastSync": "آخر مزامنة:",
+        "never": "لم تتم المزامنة بعد",
+        "syncing": "جارٍ المزامنة...",
+        "syncError": "خطأ في المزامنة"
+      },
+      "badges": {
+        "private": "خاص",
+        "shared": "مشترك"
+      }
+    }
   },
   "login": {
     "tagline": "تخطيط عائلي. آمن. يحترم الخصوصية. مفتوح المصدر.",
@@ -636,5 +681,32 @@
     "duplicate": "Duplicate",
     "duplicated": "Recipe duplicated.",
     "copySuffix": "copy"
+  },
+  "search": {
+    "title": "بحث",
+    "open": "فتح البحث",
+    "placeholder": "بحث…",
+    "noResults": "لم يتم العثور على نتائج."
+  },
+  "reminders": {
+    "sectionTitle": "تذكير",
+    "enableLabel": "تعيين تذكير",
+    "offsetLabel": "تذكير",
+    "offsetNone": "لا شيء",
+    "offsetAtTime": "في وقت البدء",
+    "offset15min": "قبل 15 دقيقة",
+    "offset1hour": "قبل ساعة واحدة",
+    "offset1day": "قبل يوم واحد",
+    "dateLabel": "التاريخ",
+    "timeLabel": "الوقت",
+    "toastTitle": "تذكير",
+    "dismiss": "تجاهل",
+    "pendingBadgeTitle": "{{count}} تذكير معلق",
+    "pendingBadgeTitlePlural": "{{count}} تذكيرات معلقة",
+    "notificationPermission": "إشعارات المتصفح",
+    "notificationEnable": "تفعيل الإشعارات",
+    "notificationEnabled": "الإشعارات نشطة",
+    "notificationDenied": "الإشعارات محظورة",
+    "notificationHint": "احصل على إشعارات حتى عندما يكون التطبيق مفتوحًا."
   }
 }

--- a/public/locales/el.json
+++ b/public/locales/el.json
@@ -43,7 +43,8 @@
     "main": "Κύρια πλοήγηση",
     "navigation": "Πλοήγηση",
     "quickActions": "Γρήγορες ενέργειες",
-    "recipes": "Recipes"
+    "recipes": "Recipes",
+    "more": "Περισσότερα"
   },
   "dashboard": {
     "title": "Επισκόπηση",
@@ -156,7 +157,14 @@
     "kanbanMoveToOpen": "Επαναφορά",
     "recurring": "Επαναλαμβανόμενο",
     "listView": "Προβολή λίστας",
-    "kanbanView": "Προβολή Kanban"
+    "kanbanView": "Προβολή Kanban",
+    "filterBtn": "Φίλτρο",
+    "filterClearAll": "Εκκαθάριση όλων των φίλτρων",
+    "filterGroupPerson": "Άτομο",
+    "filterGroupPriority": "Προτεραιότητα",
+    "filterGroupStatus": "Κατάσταση",
+    "swipedDoneToast": "Επισημάνθηκε ως ολοκληρωμένο.",
+    "swipedOpenToast": "Επισημάνθηκε ως ανοιχτό."
   },
   "shopping": {
     "title": "Αγορές",
@@ -322,7 +330,11 @@
     "dayLongThursday": "Πέμπτη",
     "dayLongFriday": "Παρασκευή",
     "dayLongSaturday": "Σάββατο",
-    "timeSuffix": ""
+    "timeSuffix": "",
+    "ics": {
+      "reset": "Επαναφορά στο αρχικό",
+      "resetToast": "Οι αλλαγές επαναφέρθηκαν."
+    }
   },
   "notes": {
     "title": "Σημειώσεις",
@@ -564,7 +576,40 @@
     "sectionBudget": "Προϋπολογισμός",
     "currencyLabel": "Νόμισμα",
     "currencyHint": "Ορίζει το νόμισμα για ολόκληρη την ενότητα προϋπολογισμού.",
-    "currencySaved": "Το νόμισμα αποθηκεύτηκε."
+    "currencySaved": "Το νόμισμα αποθηκεύτηκε.",
+    "ics": {
+      "title": "Συνδρομές ICS",
+      "add": "Προσθήκη συνδρομής",
+      "addedToast": "Η συνδρομή προστέθηκε.",
+      "deletedToast": "Η συνδρομή διαγράφηκε.",
+      "syncedToast": "Η συνδρομή συγχρονίστηκε.",
+      "confirm_delete": "Θέλετε πραγματικά να διαγράψετε αυτή τη συνδρομή; Όλα τα σχετικά γεγονότα θα διαγραφούν επίσης.",
+      "empty": "Δεν υπάρχουν ακόμα συνδρομές.",
+      "form": {
+        "name": "Όνομα",
+        "url": "URL ICS",
+        "color": "Χρώμα",
+        "shared": "Ορατό σε όλους"
+      },
+      "actions": {
+        "submit": "Προσθήκη",
+        "save": "Αποθήκευση",
+        "cancel": "Ακύρωση",
+        "delete": "Διαγραφή",
+        "edit": "Επεξεργασία",
+        "sync": "Συγχρονισμός τώρα"
+      },
+      "status": {
+        "lastSync": "Τελευταίος συγχρονισμός:",
+        "never": "Δεν έχει συγχρονιστεί ακόμα",
+        "syncing": "Συγχρονισμός...",
+        "syncError": "Σφάλμα συγχρονισμού"
+      },
+      "badges": {
+        "private": "Ιδιωτικό",
+        "shared": "Κοινόχρηστο"
+      }
+    }
   },
   "login": {
     "tagline": "Οικογενειακός προγραμματισμός. Ασφαλής. Φιλικός προς την ιδιωτικότητα. Ανοιχτός κώδικας.",
@@ -636,5 +681,32 @@
     "duplicate": "Duplicate",
     "duplicated": "Recipe duplicated.",
     "copySuffix": "copy"
+  },
+  "search": {
+    "title": "Αναζήτηση",
+    "open": "Άνοιγμα αναζήτησης",
+    "placeholder": "Αναζήτηση…",
+    "noResults": "Δεν βρέθηκαν αποτελέσματα."
+  },
+  "reminders": {
+    "sectionTitle": "Υπενθύμιση",
+    "enableLabel": "Ορισμός υπενθύμισης",
+    "offsetLabel": "Υπενθύμιση",
+    "offsetNone": "Κανένα",
+    "offsetAtTime": "Κατά την ώρα έναρξης",
+    "offset15min": "15 λεπτά πριν",
+    "offset1hour": "1 ώρα πριν",
+    "offset1day": "1 ημέρα πριν",
+    "dateLabel": "Ημερομηνία",
+    "timeLabel": "Ώρα",
+    "toastTitle": "Υπενθύμιση",
+    "dismiss": "Απόρριψη",
+    "pendingBadgeTitle": "{{count}} εκκρεμής υπενθύμιση",
+    "pendingBadgeTitlePlural": "{{count}} εκκρεμείς υπενθυμίσεις",
+    "notificationPermission": "Ειδοποιήσεις προγράμματος περιήγησης",
+    "notificationEnable": "Ενεργοποίηση ειδοποιήσεων",
+    "notificationEnabled": "Ειδοποιήσεις ενεργές",
+    "notificationDenied": "Ειδοποιήσεις αποκλεισμένες",
+    "notificationHint": "Λάβετε ειδοποιήσεις ακόμα και όταν η εφαρμογή είναι ανοιχτή."
   }
 }

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -43,7 +43,8 @@
     "main": "Main navigation",
     "navigation": "Navigation",
     "quickActions": "Quick actions",
-    "recipes": "Recipes"
+    "recipes": "Recipes",
+    "more": "More"
   },
   "dashboard": {
     "title": "Overview",
@@ -156,7 +157,14 @@
     "kanbanMoveToOpen": "Reopen",
     "recurring": "Recurring",
     "listView": "List view",
-    "kanbanView": "Kanban view"
+    "kanbanView": "Kanban view",
+    "filterBtn": "Filter",
+    "filterClearAll": "Clear all filters",
+    "filterGroupPerson": "Person",
+    "filterGroupPriority": "Priority",
+    "filterGroupStatus": "Status",
+    "swipedDoneToast": "Marked as done.",
+    "swipedOpenToast": "Marked as open."
   },
   "shopping": {
     "title": "Shopping",
@@ -322,7 +330,11 @@
     "dayLongThursday": "Thursday",
     "dayLongFriday": "Friday",
     "dayLongSaturday": "Saturday",
-    "timeSuffix": ""
+    "timeSuffix": "",
+    "ics": {
+      "reset": "Reset to original",
+      "resetToast": "Changes reset."
+    }
   },
   "notes": {
     "title": "Board",
@@ -564,7 +576,40 @@
     "sectionBudget": "Budget",
     "currencyLabel": "Currency",
     "currencyHint": "Sets the currency used throughout the budget section.",
-    "currencySaved": "Currency saved."
+    "currencySaved": "Currency saved.",
+    "ics": {
+      "title": "ICS Subscriptions",
+      "add": "Add subscription",
+      "addedToast": "Subscription added.",
+      "deletedToast": "Subscription deleted.",
+      "syncedToast": "Subscription synced.",
+      "confirm_delete": "Do you really want to delete this subscription? All associated events will also be deleted.",
+      "empty": "No subscriptions yet.",
+      "form": {
+        "name": "Name",
+        "url": "ICS URL",
+        "color": "Color",
+        "shared": "Visible to everyone"
+      },
+      "actions": {
+        "submit": "Add",
+        "save": "Save",
+        "cancel": "Cancel",
+        "delete": "Delete",
+        "edit": "Edit",
+        "sync": "Sync now"
+      },
+      "status": {
+        "lastSync": "Last synced:",
+        "never": "Not yet synced",
+        "syncing": "Syncing...",
+        "syncError": "Sync error"
+      },
+      "badges": {
+        "private": "Private",
+        "shared": "Shared"
+      }
+    }
   },
   "login": {
     "tagline": "Family planning. Secure. Privacy-friendly. Open source.",
@@ -657,5 +702,11 @@
     "duplicate": "Duplicate",
     "duplicated": "Recipe duplicated.",
     "copySuffix": "copy"
+  },
+  "search": {
+    "title": "Search",
+    "open": "Open search",
+    "placeholder": "Search…",
+    "noResults": "No results found."
   }
 }

--- a/public/locales/es.json
+++ b/public/locales/es.json
@@ -43,7 +43,8 @@
     "main": "Navegación principal",
     "navigation": "Navegación",
     "quickActions": "Acciones rápidas",
-    "recipes": "Recipes"
+    "recipes": "Recipes",
+    "more": "Más"
   },
   "dashboard": {
     "title": "Inicio",
@@ -156,7 +157,14 @@
     "kanbanMoveToOpen": "Reabrir",
     "recurring": "Recurrente",
     "listView": "Vista de lista",
-    "kanbanView": "Vista Kanban"
+    "kanbanView": "Vista Kanban",
+    "filterBtn": "Filtrar",
+    "filterClearAll": "Borrar todos los filtros",
+    "filterGroupPerson": "Persona",
+    "filterGroupPriority": "Prioridad",
+    "filterGroupStatus": "Estado",
+    "swipedDoneToast": "Marcado como hecho.",
+    "swipedOpenToast": "Marcado como abierto."
   },
   "shopping": {
     "title": "Compras",
@@ -322,7 +330,11 @@
     "dayLongThursday": "Jueves",
     "dayLongFriday": "Viernes",
     "dayLongSaturday": "Sábado",
-    "timeSuffix": ""
+    "timeSuffix": "",
+    "ics": {
+      "reset": "Restaurar original",
+      "resetToast": "Cambios restablecidos."
+    }
   },
   "notes": {
     "title": "Notas",
@@ -564,7 +576,40 @@
     "sectionBudget": "Presupuesto",
     "currencyLabel": "Moneda",
     "currencyHint": "Establece la moneda para toda la sección de presupuesto.",
-    "currencySaved": "Moneda guardada."
+    "currencySaved": "Moneda guardada.",
+    "ics": {
+      "title": "Suscripciones ICS",
+      "add": "Añadir suscripción",
+      "addedToast": "Suscripción añadida.",
+      "deletedToast": "Suscripción eliminada.",
+      "syncedToast": "Suscripción sincronizada.",
+      "confirm_delete": "¿Realmente deseas eliminar esta suscripción? Todos los eventos asociados también se eliminarán.",
+      "empty": "Aún no hay suscripciones.",
+      "form": {
+        "name": "Nombre",
+        "url": "URL ICS",
+        "color": "Color",
+        "shared": "Visible para todos"
+      },
+      "actions": {
+        "submit": "Añadir",
+        "save": "Guardar",
+        "cancel": "Cancelar",
+        "delete": "Eliminar",
+        "edit": "Editar",
+        "sync": "Sincronizar ahora"
+      },
+      "status": {
+        "lastSync": "Última sincronización:",
+        "never": "Aún no sincronizado",
+        "syncing": "Sincronizando...",
+        "syncError": "Error de sincronización"
+      },
+      "badges": {
+        "private": "Privado",
+        "shared": "Compartido"
+      }
+    }
   },
   "login": {
     "tagline": "Planificación familiar. Segura. Privada. Código abierto.",
@@ -636,5 +681,32 @@
     "duplicate": "Duplicate",
     "duplicated": "Recipe duplicated.",
     "copySuffix": "copy"
+  },
+  "search": {
+    "title": "Búsqueda",
+    "open": "Abrir búsqueda",
+    "placeholder": "Buscar…",
+    "noResults": "No se encontraron resultados."
+  },
+  "reminders": {
+    "sectionTitle": "Recordatorio",
+    "enableLabel": "Establecer recordatorio",
+    "offsetLabel": "Recordar",
+    "offsetNone": "Ninguno",
+    "offsetAtTime": "A la hora de inicio",
+    "offset15min": "15 minutos antes",
+    "offset1hour": "1 hora antes",
+    "offset1day": "1 día antes",
+    "dateLabel": "Fecha",
+    "timeLabel": "Hora",
+    "toastTitle": "Recordatorio",
+    "dismiss": "Descartar",
+    "pendingBadgeTitle": "{{count}} recordatorio pendiente",
+    "pendingBadgeTitlePlural": "{{count}} recordatorios pendientes",
+    "notificationPermission": "Notificaciones del navegador",
+    "notificationEnable": "Activar notificaciones",
+    "notificationEnabled": "Notificaciones activas",
+    "notificationDenied": "Notificaciones bloqueadas",
+    "notificationHint": "Recibe notificaciones incluso cuando la aplicación está abierta."
   }
 }

--- a/public/locales/fr.json
+++ b/public/locales/fr.json
@@ -43,7 +43,8 @@
     "main": "Navigation principale",
     "navigation": "Navigation",
     "quickActions": "Actions rapides",
-    "recipes": "Recipes"
+    "recipes": "Recipes",
+    "more": "Plus"
   },
   "dashboard": {
     "title": "Accueil",
@@ -156,7 +157,14 @@
     "kanbanMoveToOpen": "Rouvrir",
     "recurring": "Récurrent",
     "listView": "Vue liste",
-    "kanbanView": "Vue Kanban"
+    "kanbanView": "Vue Kanban",
+    "filterBtn": "Filtrer",
+    "filterClearAll": "Effacer tous les filtres",
+    "filterGroupPerson": "Personne",
+    "filterGroupPriority": "Priorité",
+    "filterGroupStatus": "Statut",
+    "swipedDoneToast": "Marqué comme terminé.",
+    "swipedOpenToast": "Marqué comme ouvert."
   },
   "shopping": {
     "title": "Courses",
@@ -322,7 +330,11 @@
     "dayLongThursday": "Jeudi",
     "dayLongFriday": "Vendredi",
     "dayLongSaturday": "Samedi",
-    "timeSuffix": ""
+    "timeSuffix": "",
+    "ics": {
+      "reset": "Réinitialiser",
+      "resetToast": "Modifications annulées."
+    }
   },
   "notes": {
     "title": "Notes",
@@ -564,7 +576,40 @@
     "sectionBudget": "Budget",
     "currencyLabel": "Devise",
     "currencyHint": "Définit la devise utilisée dans toute la section budget.",
-    "currencySaved": "Devise enregistrée."
+    "currencySaved": "Devise enregistrée.",
+    "ics": {
+      "title": "Abonnements ICS",
+      "add": "Ajouter un abonnement",
+      "addedToast": "Abonnement ajouté.",
+      "deletedToast": "Abonnement supprimé.",
+      "syncedToast": "Abonnement synchronisé.",
+      "confirm_delete": "Voulez-vous vraiment supprimer cet abonnement ? Tous les événements associés seront également supprimés.",
+      "empty": "Aucun abonnement pour le moment.",
+      "form": {
+        "name": "Nom",
+        "url": "URL ICS",
+        "color": "Couleur",
+        "shared": "Visible par tous"
+      },
+      "actions": {
+        "submit": "Ajouter",
+        "save": "Enregistrer",
+        "cancel": "Annuler",
+        "delete": "Supprimer",
+        "edit": "Modifier",
+        "sync": "Synchroniser maintenant"
+      },
+      "status": {
+        "lastSync": "Dernière sync. :",
+        "never": "Pas encore synchronisé",
+        "syncing": "Synchronisation...",
+        "syncError": "Erreur de sync."
+      },
+      "badges": {
+        "private": "Privé",
+        "shared": "Partagé"
+      }
+    }
   },
   "login": {
     "tagline": "Planification familiale. Sécurisée. Respectueuse de la vie privée. Open source.",
@@ -636,5 +681,32 @@
     "duplicate": "Duplicate",
     "duplicated": "Recipe duplicated.",
     "copySuffix": "copy"
+  },
+  "search": {
+    "title": "Recherche",
+    "open": "Ouvrir la recherche",
+    "placeholder": "Rechercher…",
+    "noResults": "Aucun résultat trouvé."
+  },
+  "reminders": {
+    "sectionTitle": "Rappel",
+    "enableLabel": "Définir un rappel",
+    "offsetLabel": "Rappeler",
+    "offsetNone": "Aucun",
+    "offsetAtTime": "À l'heure de début",
+    "offset15min": "15 minutes avant",
+    "offset1hour": "1 heure avant",
+    "offset1day": "1 jour avant",
+    "dateLabel": "Date",
+    "timeLabel": "Heure",
+    "toastTitle": "Rappel",
+    "dismiss": "Ignorer",
+    "pendingBadgeTitle": "{{count}} rappel en attente",
+    "pendingBadgeTitlePlural": "{{count}} rappels en attente",
+    "notificationPermission": "Notifications du navigateur",
+    "notificationEnable": "Activer les notifications",
+    "notificationEnabled": "Notifications actives",
+    "notificationDenied": "Notifications bloquées",
+    "notificationHint": "Recevez des notifications même lorsque l'application est ouverte."
   }
 }

--- a/public/locales/hi.json
+++ b/public/locales/hi.json
@@ -43,7 +43,8 @@
     "main": "मुख्य नेविगेशन",
     "navigation": "नेविगेशन",
     "quickActions": "त्वरित क्रियाएं",
-    "recipes": "Recipes"
+    "recipes": "Recipes",
+    "more": "और"
   },
   "dashboard": {
     "title": "डैशबोर्ड",
@@ -156,7 +157,14 @@
     "kanbanMoveToOpen": "फिर से खोलें",
     "recurring": "आवर्ती",
     "listView": "सूची दृश्य",
-    "kanbanView": "कानबान दृश्य"
+    "kanbanView": "कानबान दृश्य",
+    "filterBtn": "फ़िल्टर",
+    "filterClearAll": "सभी फ़िल्टर हटाएं",
+    "filterGroupPerson": "व्यक्ति",
+    "filterGroupPriority": "प्राथमिकता",
+    "filterGroupStatus": "स्थिति",
+    "swipedDoneToast": "पूर्ण के रूप में चिह्नित।",
+    "swipedOpenToast": "खुले के रूप में चिह्नित।"
   },
   "shopping": {
     "title": "खरीदारी",
@@ -322,7 +330,11 @@
     "dayLongThursday": "गुरुवार",
     "dayLongFriday": "शुक्रवार",
     "dayLongSaturday": "शनिवार",
-    "timeSuffix": ""
+    "timeSuffix": "",
+    "ics": {
+      "reset": "मूल पर वापस जाएं",
+      "resetToast": "परिवर्तन रीसेट हो गए।"
+    }
   },
   "notes": {
     "title": "नोट बोर्ड",
@@ -564,7 +576,40 @@
     "sectionBudget": "बजट",
     "currencyLabel": "मुद्रा",
     "currencyHint": "पूरे बजट अनुभाग में उपयोग की जाने वाली मुद्रा सेट करता है।",
-    "currencySaved": "मुद्रा सहेजी गई।"
+    "currencySaved": "मुद्रा सहेजी गई।",
+    "ics": {
+      "title": "ICS सदस्यताएं",
+      "add": "सदस्यता जोड़ें",
+      "addedToast": "सदस्यता जोड़ी गई।",
+      "deletedToast": "सदस्यता हटाई गई।",
+      "syncedToast": "सदस्यता सिंक हुई।",
+      "confirm_delete": "क्या आप वाकई इस सदस्यता को हटाना चाहते हैं? सभी संबंधित इवेंट भी हटा दिए जाएंगे।",
+      "empty": "अभी तक कोई सदस्यता नहीं।",
+      "form": {
+        "name": "नाम",
+        "url": "ICS URL",
+        "color": "रंग",
+        "shared": "सभी के लिए दृश्यमान"
+      },
+      "actions": {
+        "submit": "जोड़ें",
+        "save": "सहेजें",
+        "cancel": "रद्द करें",
+        "delete": "हटाएं",
+        "edit": "संपादित करें",
+        "sync": "अभी सिंक करें"
+      },
+      "status": {
+        "lastSync": "अंतिम सिंक:",
+        "never": "अभी तक सिंक नहीं हुआ",
+        "syncing": "सिंक हो रहा है...",
+        "syncError": "सिंक त्रुटि"
+      },
+      "badges": {
+        "private": "निजी",
+        "shared": "साझा"
+      }
+    }
   },
   "login": {
     "tagline": "पारिवारिक योजना। सुरक्षित। गोपनीयता-अनुकूल। ओपन सोर्स।",
@@ -636,5 +681,32 @@
     "duplicate": "Duplicate",
     "duplicated": "Recipe duplicated.",
     "copySuffix": "copy"
+  },
+  "search": {
+    "title": "खोज",
+    "open": "खोज खोलें",
+    "placeholder": "खोजें…",
+    "noResults": "कोई परिणाम नहीं मिला।"
+  },
+  "reminders": {
+    "sectionTitle": "अनुस्मारक",
+    "enableLabel": "अनुस्मारक सेट करें",
+    "offsetLabel": "याद दिलाएं",
+    "offsetNone": "कोई नहीं",
+    "offsetAtTime": "प्रारंभ समय पर",
+    "offset15min": "15 मिनट पहले",
+    "offset1hour": "1 घंटे पहले",
+    "offset1day": "1 दिन पहले",
+    "dateLabel": "तारीख",
+    "timeLabel": "समय",
+    "toastTitle": "अनुस्मारक",
+    "dismiss": "खारिज करें",
+    "pendingBadgeTitle": "{{count}} लंबित अनुस्मारक",
+    "pendingBadgeTitlePlural": "{{count}} लंबित अनुस्मारक",
+    "notificationPermission": "ब्राउज़र सूचनाएं",
+    "notificationEnable": "सूचनाएं सक्षम करें",
+    "notificationEnabled": "सूचनाएं सक्रिय",
+    "notificationDenied": "सूचनाएं अवरुद्ध",
+    "notificationHint": "ऐप खुली होने पर भी सूचनाएं प्राप्त करें।"
   }
 }

--- a/public/locales/it.json
+++ b/public/locales/it.json
@@ -43,7 +43,8 @@
     "main": "Navigazione principale",
     "navigation": "Navigazione",
     "quickActions": "Azioni rapide",
-    "recipes": "Recipes"
+    "recipes": "Recipes",
+    "more": "Altro"
   },
   "dashboard": {
     "title": "Panoramica",
@@ -156,7 +157,14 @@
     "kanbanMoveToOpen": "Riapri",
     "recurring": "Ricorrente",
     "listView": "Vista elenco",
-    "kanbanView": "Vista Kanban"
+    "kanbanView": "Vista Kanban",
+    "filterBtn": "Filtro",
+    "filterClearAll": "Cancella tutti i filtri",
+    "filterGroupPerson": "Persona",
+    "filterGroupPriority": "Priorità",
+    "filterGroupStatus": "Stato",
+    "swipedDoneToast": "Contrassegnato come fatto.",
+    "swipedOpenToast": "Contrassegnato come aperto."
   },
   "shopping": {
     "title": "Spesa",
@@ -322,7 +330,11 @@
     "dayLongThursday": "Giovedì",
     "dayLongFriday": "Venerdì",
     "dayLongSaturday": "Sabato",
-    "timeSuffix": ""
+    "timeSuffix": "",
+    "ics": {
+      "reset": "Ripristina originale",
+      "resetToast": "Modifiche ripristinate."
+    }
   },
   "notes": {
     "title": "Bacheca",
@@ -564,7 +576,40 @@
     "sectionBudget": "Bilancio",
     "currencyLabel": "Valuta",
     "currencyHint": "Imposta la valuta utilizzata in tutta la sezione budget.",
-    "currencySaved": "Valuta salvata."
+    "currencySaved": "Valuta salvata.",
+    "ics": {
+      "title": "Abbonamenti ICS",
+      "add": "Aggiungi abbonamento",
+      "addedToast": "Abbonamento aggiunto.",
+      "deletedToast": "Abbonamento eliminato.",
+      "syncedToast": "Abbonamento sincronizzato.",
+      "confirm_delete": "Vuoi davvero eliminare questo abbonamento? Anche tutti gli eventi associati verranno eliminati.",
+      "empty": "Nessun abbonamento ancora.",
+      "form": {
+        "name": "Nome",
+        "url": "URL ICS",
+        "color": "Colore",
+        "shared": "Visibile a tutti"
+      },
+      "actions": {
+        "submit": "Aggiungi",
+        "save": "Salva",
+        "cancel": "Annulla",
+        "delete": "Elimina",
+        "edit": "Modifica",
+        "sync": "Sincronizza ora"
+      },
+      "status": {
+        "lastSync": "Ultima sincronizzazione:",
+        "never": "Non ancora sincronizzato",
+        "syncing": "Sincronizzazione...",
+        "syncError": "Errore di sincronizzazione"
+      },
+      "badges": {
+        "private": "Privato",
+        "shared": "Condiviso"
+      }
+    }
   },
   "login": {
     "tagline": "Pianificazione familiare. Sicura. Rispettosa della privacy. Open source.",
@@ -636,5 +681,32 @@
     "duplicate": "Duplicate",
     "duplicated": "Recipe duplicated.",
     "copySuffix": "copy"
+  },
+  "search": {
+    "title": "Ricerca",
+    "open": "Apri ricerca",
+    "placeholder": "Cerca…",
+    "noResults": "Nessun risultato trovato."
+  },
+  "reminders": {
+    "sectionTitle": "Promemoria",
+    "enableLabel": "Imposta promemoria",
+    "offsetLabel": "Ricordami",
+    "offsetNone": "Nessuno",
+    "offsetAtTime": "All'ora di inizio",
+    "offset15min": "15 minuti prima",
+    "offset1hour": "1 ora prima",
+    "offset1day": "1 giorno prima",
+    "dateLabel": "Data",
+    "timeLabel": "Ora",
+    "toastTitle": "Promemoria",
+    "dismiss": "Ignora",
+    "pendingBadgeTitle": "{{count}} promemoria in attesa",
+    "pendingBadgeTitlePlural": "{{count}} promemoria in attesa",
+    "notificationPermission": "Notifiche del browser",
+    "notificationEnable": "Attiva notifiche",
+    "notificationEnabled": "Notifiche attive",
+    "notificationDenied": "Notifiche bloccate",
+    "notificationHint": "Ricevi notifiche anche quando l'app è aperta."
   }
 }

--- a/public/locales/ja.json
+++ b/public/locales/ja.json
@@ -43,7 +43,8 @@
     "main": "メインナビゲーション",
     "navigation": "ナビゲーション",
     "quickActions": "クイックアクション",
-    "recipes": "Recipes"
+    "recipes": "Recipes",
+    "more": "もっと見る"
   },
   "dashboard": {
     "title": "ダッシュボード",
@@ -156,7 +157,14 @@
     "kanbanMoveToOpen": "再度開く",
     "recurring": "繰り返し",
     "listView": "リスト表示",
-    "kanbanView": "かんばん表示"
+    "kanbanView": "かんばん表示",
+    "filterBtn": "フィルター",
+    "filterClearAll": "すべてのフィルターをクリア",
+    "filterGroupPerson": "人物",
+    "filterGroupPriority": "優先度",
+    "filterGroupStatus": "ステータス",
+    "swipedDoneToast": "完了としてマーク。",
+    "swipedOpenToast": "未完了としてマーク。"
   },
   "shopping": {
     "title": "買い物",
@@ -322,7 +330,11 @@
     "dayLongThursday": "木曜日",
     "dayLongFriday": "金曜日",
     "dayLongSaturday": "土曜日",
-    "timeSuffix": ""
+    "timeSuffix": "",
+    "ics": {
+      "reset": "元に戻す",
+      "resetToast": "変更がリセットされました。"
+    }
   },
   "notes": {
     "title": "メモボード",
@@ -564,7 +576,40 @@
     "sectionBudget": "家計",
     "currencyLabel": "通貨",
     "currencyHint": "家計全体で使用する通貨を設定します。",
-    "currencySaved": "通貨を保存しました。"
+    "currencySaved": "通貨を保存しました。",
+    "ics": {
+      "title": "ICSサブスクリプション",
+      "add": "サブスクリプションを追加",
+      "addedToast": "サブスクリプションが追加されました。",
+      "deletedToast": "サブスクリプションが削除されました。",
+      "syncedToast": "サブスクリプションが同期されました。",
+      "confirm_delete": "このサブスクリプションを本当に削除しますか？関連するすべてのイベントも削除されます。",
+      "empty": "まだサブスクリプションはありません。",
+      "form": {
+        "name": "名前",
+        "url": "ICS URL",
+        "color": "色",
+        "shared": "全員に表示"
+      },
+      "actions": {
+        "submit": "追加",
+        "save": "保存",
+        "cancel": "キャンセル",
+        "delete": "削除",
+        "edit": "編集",
+        "sync": "今すぐ同期"
+      },
+      "status": {
+        "lastSync": "最終同期:",
+        "never": "まだ同期していません",
+        "syncing": "同期中...",
+        "syncError": "同期エラー"
+      },
+      "badges": {
+        "private": "プライベート",
+        "shared": "共有"
+      }
+    }
   },
   "login": {
     "tagline": "家族計画。安全。プライバシー重視。オープンソース。",
@@ -636,5 +681,32 @@
     "duplicate": "Duplicate",
     "duplicated": "Recipe duplicated.",
     "copySuffix": "copy"
+  },
+  "search": {
+    "title": "検索",
+    "open": "検索を開く",
+    "placeholder": "検索…",
+    "noResults": "結果が見つかりませんでした。"
+  },
+  "reminders": {
+    "sectionTitle": "リマインダー",
+    "enableLabel": "リマインダーを設定",
+    "offsetLabel": "リマインド",
+    "offsetNone": "なし",
+    "offsetAtTime": "開始時刻に",
+    "offset15min": "15分前",
+    "offset1hour": "1時間前",
+    "offset1day": "1日前",
+    "dateLabel": "日付",
+    "timeLabel": "時刻",
+    "toastTitle": "リマインダー",
+    "dismiss": "解除",
+    "pendingBadgeTitle": "{{count}}件の未処理リマインダー",
+    "pendingBadgeTitlePlural": "{{count}}件の未処理リマインダー",
+    "notificationPermission": "ブラウザ通知",
+    "notificationEnable": "通知を有効にする",
+    "notificationEnabled": "通知が有効",
+    "notificationDenied": "通知がブロックされています",
+    "notificationHint": "アプリが開いているときでも通知を受け取ります。"
   }
 }

--- a/public/locales/pt.json
+++ b/public/locales/pt.json
@@ -43,7 +43,8 @@
     "main": "Navegação principal",
     "navigation": "Navegação",
     "quickActions": "Ações rápidas",
-    "recipes": "Recipes"
+    "recipes": "Recipes",
+    "more": "Mais"
   },
   "dashboard": {
     "title": "Painel",
@@ -156,7 +157,14 @@
     "kanbanMoveToOpen": "Reabrir",
     "recurring": "Recorrente",
     "listView": "Visualização em lista",
-    "kanbanView": "Visualização Kanban"
+    "kanbanView": "Visualização Kanban",
+    "filterBtn": "Filtrar",
+    "filterClearAll": "Limpar todos os filtros",
+    "filterGroupPerson": "Pessoa",
+    "filterGroupPriority": "Prioridade",
+    "filterGroupStatus": "Estado",
+    "swipedDoneToast": "Marcado como concluído.",
+    "swipedOpenToast": "Marcado como aberto."
   },
   "shopping": {
     "title": "Compras",
@@ -322,7 +330,11 @@
     "dayLongThursday": "Quinta-feira",
     "dayLongFriday": "Sexta-feira",
     "dayLongSaturday": "Sábado",
-    "timeSuffix": ""
+    "timeSuffix": "",
+    "ics": {
+      "reset": "Restaurar original",
+      "resetToast": "Alterações restauradas."
+    }
   },
   "notes": {
     "title": "Quadro de notas",
@@ -564,7 +576,40 @@
     "sectionBudget": "Orçamento",
     "currencyLabel": "Moeda",
     "currencyHint": "Define a moeda usada em toda a área de orçamento.",
-    "currencySaved": "Moeda salva."
+    "currencySaved": "Moeda salva.",
+    "ics": {
+      "title": "Assinaturas ICS",
+      "add": "Adicionar assinatura",
+      "addedToast": "Assinatura adicionada.",
+      "deletedToast": "Assinatura excluída.",
+      "syncedToast": "Assinatura sincronizada.",
+      "confirm_delete": "Tens a certeza que queres apagar esta assinatura? Todos os eventos associados também serão apagados.",
+      "empty": "Ainda sem assinaturas.",
+      "form": {
+        "name": "Nome",
+        "url": "URL ICS",
+        "color": "Cor",
+        "shared": "Visível para todos"
+      },
+      "actions": {
+        "submit": "Adicionar",
+        "save": "Guardar",
+        "cancel": "Cancelar",
+        "delete": "Apagar",
+        "edit": "Editar",
+        "sync": "Sincronizar agora"
+      },
+      "status": {
+        "lastSync": "Última sincronização:",
+        "never": "Ainda não sincronizado",
+        "syncing": "A sincronizar...",
+        "syncError": "Erro de sincronização"
+      },
+      "badges": {
+        "private": "Privado",
+        "shared": "Partilhado"
+      }
+    }
   },
   "login": {
     "tagline": "Planejamento familiar. Seguro. Privado. Código aberto.",
@@ -636,5 +681,32 @@
     "duplicate": "Duplicate",
     "duplicated": "Recipe duplicated.",
     "copySuffix": "copy"
+  },
+  "search": {
+    "title": "Pesquisa",
+    "open": "Abrir pesquisa",
+    "placeholder": "Pesquisar…",
+    "noResults": "Nenhum resultado encontrado."
+  },
+  "reminders": {
+    "sectionTitle": "Lembrete",
+    "enableLabel": "Definir lembrete",
+    "offsetLabel": "Lembrar",
+    "offsetNone": "Nenhum",
+    "offsetAtTime": "Na hora de início",
+    "offset15min": "15 minutos antes",
+    "offset1hour": "1 hora antes",
+    "offset1day": "1 dia antes",
+    "dateLabel": "Data",
+    "timeLabel": "Hora",
+    "toastTitle": "Lembrete",
+    "dismiss": "Ignorar",
+    "pendingBadgeTitle": "{{count}} lembrete pendente",
+    "pendingBadgeTitlePlural": "{{count}} lembretes pendentes",
+    "notificationPermission": "Notificações do browser",
+    "notificationEnable": "Ativar notificações",
+    "notificationEnabled": "Notificações ativas",
+    "notificationDenied": "Notificações bloqueadas",
+    "notificationHint": "Receba notificações mesmo quando a aplicação está aberta."
   }
 }

--- a/public/locales/ru.json
+++ b/public/locales/ru.json
@@ -43,7 +43,8 @@
     "main": "Главная навигация",
     "navigation": "Навигация",
     "quickActions": "Быстрые действия",
-    "recipes": "Recipes"
+    "recipes": "Recipes",
+    "more": "Ещё"
   },
   "dashboard": {
     "title": "Обзор",
@@ -156,7 +157,14 @@
     "kanbanMoveToOpen": "Открыть снова",
     "recurring": "Повторяющееся",
     "listView": "Список",
-    "kanbanView": "Канбан"
+    "kanbanView": "Канбан",
+    "filterBtn": "Фильтр",
+    "filterClearAll": "Сбросить все фильтры",
+    "filterGroupPerson": "Человек",
+    "filterGroupPriority": "Приоритет",
+    "filterGroupStatus": "Статус",
+    "swipedDoneToast": "Отмечено как выполненное.",
+    "swipedOpenToast": "Отмечено как открытое."
   },
   "shopping": {
     "title": "Покупки",
@@ -322,7 +330,11 @@
     "dayLongThursday": "Четверг",
     "dayLongFriday": "Пятница",
     "dayLongSaturday": "Суббота",
-    "timeSuffix": ""
+    "timeSuffix": "",
+    "ics": {
+      "reset": "Сбросить к исходному",
+      "resetToast": "Изменения сброшены."
+    }
   },
   "notes": {
     "title": "Заметки",
@@ -564,7 +576,40 @@
     "sectionBudget": "Бюджет",
     "currencyLabel": "Валюта",
     "currencyHint": "Устанавливает валюту для всего раздела бюджета.",
-    "currencySaved": "Валюта сохранена."
+    "currencySaved": "Валюта сохранена.",
+    "ics": {
+      "title": "ICS-подписки",
+      "add": "Добавить подписку",
+      "addedToast": "Подписка добавлена.",
+      "deletedToast": "Подписка удалена.",
+      "syncedToast": "Подписка синхронизирована.",
+      "confirm_delete": "Вы действительно хотите удалить эту подписку? Все связанные события также будут удалены.",
+      "empty": "Подписок пока нет.",
+      "form": {
+        "name": "Название",
+        "url": "URL ICS",
+        "color": "Цвет",
+        "shared": "Видно всем"
+      },
+      "actions": {
+        "submit": "Добавить",
+        "save": "Сохранить",
+        "cancel": "Отмена",
+        "delete": "Удалить",
+        "edit": "Изменить",
+        "sync": "Синхронизировать сейчас"
+      },
+      "status": {
+        "lastSync": "Последняя синхронизация:",
+        "never": "Ещё не синхронизировано",
+        "syncing": "Синхронизация...",
+        "syncError": "Ошибка синхронизации"
+      },
+      "badges": {
+        "private": "Личное",
+        "shared": "Общее"
+      }
+    }
   },
   "login": {
     "tagline": "Семейное планирование. Безопасно. С уважением к приватности. Открытый исходный код.",
@@ -636,5 +681,32 @@
     "duplicate": "Duplicate",
     "duplicated": "Recipe duplicated.",
     "copySuffix": "copy"
+  },
+  "search": {
+    "title": "Поиск",
+    "open": "Открыть поиск",
+    "placeholder": "Поиск…",
+    "noResults": "Результаты не найдены."
+  },
+  "reminders": {
+    "sectionTitle": "Напоминание",
+    "enableLabel": "Установить напоминание",
+    "offsetLabel": "Напомнить",
+    "offsetNone": "Нет",
+    "offsetAtTime": "В момент начала",
+    "offset15min": "За 15 минут",
+    "offset1hour": "За 1 час",
+    "offset1day": "За 1 день",
+    "dateLabel": "Дата",
+    "timeLabel": "Время",
+    "toastTitle": "Напоминание",
+    "dismiss": "Отклонить",
+    "pendingBadgeTitle": "{{count}} ожидающее напоминание",
+    "pendingBadgeTitlePlural": "{{count}} ожидающих напоминания",
+    "notificationPermission": "Уведомления браузера",
+    "notificationEnable": "Включить уведомления",
+    "notificationEnabled": "Уведомления активны",
+    "notificationDenied": "Уведомления заблокированы",
+    "notificationHint": "Получайте уведомления, даже когда приложение открыто."
   }
 }

--- a/public/locales/sv.json
+++ b/public/locales/sv.json
@@ -43,7 +43,8 @@
     "main": "Huvudnavigering",
     "navigation": "Navigering",
     "quickActions": "Snabba åtgärder",
-    "recipes": "Recept"
+    "recipes": "Recept",
+    "more": "Mer"
   },
   "dashboard": {
     "title": "Översikt",
@@ -156,7 +157,14 @@
     "kanbanMoveToOpen": "Öppna igen",
     "recurring": "Återkommande",
     "listView": "Listvy",
-    "kanbanView": "Kanban-vy"
+    "kanbanView": "Kanban-vy",
+    "filterBtn": "Filtrera",
+    "filterClearAll": "Rensa alla filter",
+    "filterGroupPerson": "Person",
+    "filterGroupPriority": "Prioritet",
+    "filterGroupStatus": "Status",
+    "swipedDoneToast": "Markerad som klar.",
+    "swipedOpenToast": "Markerad som öppen."
   },
   "shopping": {
     "title": "Shopping",
@@ -322,7 +330,11 @@
     "dayLongThursday": "Torsdag",
     "dayLongFriday": "Fredag",
     "dayLongSaturday": "Lördag",
-    "timeSuffix": ""
+    "timeSuffix": "",
+    "ics": {
+      "reset": "Återställ till original",
+      "resetToast": "Ändringar återställda."
+    }
   },
   "notes": {
     "title": "Anteckningar",
@@ -564,7 +576,40 @@
     "sectionBudget": "Budget",
     "currencyLabel": "Valuta",
     "currencyHint": "Ställer in valutan som används i hela budgetavsnittet.",
-    "currencySaved": "Valuta sparad."
+    "currencySaved": "Valuta sparad.",
+    "ics": {
+      "title": "ICS-prenumerationer",
+      "add": "Lägg till prenumeration",
+      "addedToast": "Prenumeration tillagd.",
+      "deletedToast": "Prenumeration borttagen.",
+      "syncedToast": "Prenumeration synkroniserad.",
+      "confirm_delete": "Vill du verkligen ta bort denna prenumeration? Alla tillhörande händelser tas också bort.",
+      "empty": "Inga prenumerationer ännu.",
+      "form": {
+        "name": "Namn",
+        "url": "ICS-URL",
+        "color": "Färg",
+        "shared": "Synlig för alla"
+      },
+      "actions": {
+        "submit": "Lägg till",
+        "save": "Spara",
+        "cancel": "Avbryt",
+        "delete": "Ta bort",
+        "edit": "Redigera",
+        "sync": "Synkronisera nu"
+      },
+      "status": {
+        "lastSync": "Senast synkroniserad:",
+        "never": "Inte synkroniserad ännu",
+        "syncing": "Synkroniserar...",
+        "syncError": "Synkroniseringsfel"
+      },
+      "badges": {
+        "private": "Privat",
+        "shared": "Delad"
+      }
+    }
   },
   "login": {
     "tagline": "Familjeplanering. Säker. Sekretessvänlig. Öppen källkod.",
@@ -636,5 +681,32 @@
     "duplicate": "Duplicera",
     "duplicated": "Recept duplicerat.",
     "copySuffix": "kopia"
+  },
+  "search": {
+    "title": "Sök",
+    "open": "Öppna sökning",
+    "placeholder": "Sök…",
+    "noResults": "Inga resultat hittades."
+  },
+  "reminders": {
+    "sectionTitle": "Påminnelse",
+    "enableLabel": "Ange påminnelse",
+    "offsetLabel": "Påminn",
+    "offsetNone": "Ingen",
+    "offsetAtTime": "Vid starttid",
+    "offset15min": "15 minuter innan",
+    "offset1hour": "1 timme innan",
+    "offset1day": "1 dag innan",
+    "dateLabel": "Datum",
+    "timeLabel": "Tid",
+    "toastTitle": "Påminnelse",
+    "dismiss": "Avfärda",
+    "pendingBadgeTitle": "{{count}} väntande påminnelse",
+    "pendingBadgeTitlePlural": "{{count}} väntande påminnelser",
+    "notificationPermission": "Webbläsarnotiser",
+    "notificationEnable": "Aktivera notiser",
+    "notificationEnabled": "Notiser aktiva",
+    "notificationDenied": "Notiser blockerade",
+    "notificationHint": "Få notiser även när appen är öppen."
   }
 }

--- a/public/locales/tr.json
+++ b/public/locales/tr.json
@@ -43,7 +43,8 @@
     "main": "Ana gezinme",
     "navigation": "Gezinme",
     "quickActions": "Hızlı işlemler",
-    "recipes": "Recipes"
+    "recipes": "Recipes",
+    "more": "Daha Fazla"
   },
   "dashboard": {
     "title": "Genel Bakış",
@@ -156,7 +157,14 @@
     "kanbanMoveToOpen": "Yeniden aç",
     "recurring": "Yinelenen",
     "listView": "Liste görünümü",
-    "kanbanView": "Kanban görünümü"
+    "kanbanView": "Kanban görünümü",
+    "filterBtn": "Filtrele",
+    "filterClearAll": "Tüm filtreleri temizle",
+    "filterGroupPerson": "Kişi",
+    "filterGroupPriority": "Öncelik",
+    "filterGroupStatus": "Durum",
+    "swipedDoneToast": "Tamamlandı olarak işaretlendi.",
+    "swipedOpenToast": "Açık olarak işaretlendi."
   },
   "shopping": {
     "title": "Alışveriş",
@@ -322,7 +330,11 @@
     "dayLongThursday": "Perşembe",
     "dayLongFriday": "Cuma",
     "dayLongSaturday": "Cumartesi",
-    "timeSuffix": ""
+    "timeSuffix": "",
+    "ics": {
+      "reset": "Orijinale sıfırla",
+      "resetToast": "Değişiklikler sıfırlandı."
+    }
   },
   "notes": {
     "title": "Notlar",
@@ -564,7 +576,40 @@
     "sectionBudget": "Bütçe",
     "currencyLabel": "Para birimi",
     "currencyHint": "Bütçe bölümünde kullanılan para birimini belirler.",
-    "currencySaved": "Para birimi kaydedildi."
+    "currencySaved": "Para birimi kaydedildi.",
+    "ics": {
+      "title": "ICS Abonelikleri",
+      "add": "Abonelik ekle",
+      "addedToast": "Abonelik eklendi.",
+      "deletedToast": "Abonelik silindi.",
+      "syncedToast": "Abonelik senkronize edildi.",
+      "confirm_delete": "Bu aboneliği gerçekten silmek istiyor musunuz? İlgili tüm etkinlikler de silinecek.",
+      "empty": "Henüz abonelik yok.",
+      "form": {
+        "name": "Ad",
+        "url": "ICS URL",
+        "color": "Renk",
+        "shared": "Herkes tarafından görülebilir"
+      },
+      "actions": {
+        "submit": "Ekle",
+        "save": "Kaydet",
+        "cancel": "İptal",
+        "delete": "Sil",
+        "edit": "Düzenle",
+        "sync": "Şimdi senkronize et"
+      },
+      "status": {
+        "lastSync": "Son senkronizasyon:",
+        "never": "Henüz senkronize edilmedi",
+        "syncing": "Senkronize ediliyor...",
+        "syncError": "Senkronizasyon hatası"
+      },
+      "badges": {
+        "private": "Özel",
+        "shared": "Paylaşımlı"
+      }
+    }
   },
   "login": {
     "tagline": "Aile planlaması. Güvenli. Gizlilik dostu. Açık kaynak.",
@@ -636,5 +681,32 @@
     "duplicate": "Duplicate",
     "duplicated": "Recipe duplicated.",
     "copySuffix": "copy"
+  },
+  "search": {
+    "title": "Arama",
+    "open": "Aramayı aç",
+    "placeholder": "Ara…",
+    "noResults": "Sonuç bulunamadı."
+  },
+  "reminders": {
+    "sectionTitle": "Hatırlatıcı",
+    "enableLabel": "Hatırlatıcı ayarla",
+    "offsetLabel": "Hatırlat",
+    "offsetNone": "Yok",
+    "offsetAtTime": "Başlangıç saatinde",
+    "offset15min": "15 dakika önce",
+    "offset1hour": "1 saat önce",
+    "offset1day": "1 gün önce",
+    "dateLabel": "Tarih",
+    "timeLabel": "Saat",
+    "toastTitle": "Hatırlatıcı",
+    "dismiss": "Kapat",
+    "pendingBadgeTitle": "{{count}} bekleyen hatırlatıcı",
+    "pendingBadgeTitlePlural": "{{count}} bekleyen hatırlatıcı",
+    "notificationPermission": "Tarayıcı bildirimleri",
+    "notificationEnable": "Bildirimleri etkinleştir",
+    "notificationEnabled": "Bildirimler etkin",
+    "notificationDenied": "Bildirimler engellendi",
+    "notificationHint": "Uygulama açıkken bile bildirim alın."
   }
 }

--- a/public/locales/uk.json
+++ b/public/locales/uk.json
@@ -43,7 +43,8 @@
     "main": "Головна навігація",
     "navigation": "Навігація",
     "quickActions": "Швидкі дії",
-    "recipes": "Recipes"
+    "recipes": "Recipes",
+    "more": "Більше"
   },
   "dashboard": {
     "title": "Огляд",
@@ -156,7 +157,14 @@
     "kanbanMoveToOpen": "Відкрити знову",
     "recurring": "Повторюване",
     "listView": "Список",
-    "kanbanView": "Канбан"
+    "kanbanView": "Канбан",
+    "filterBtn": "Фільтр",
+    "filterClearAll": "Скинути всі фільтри",
+    "filterGroupPerson": "Особа",
+    "filterGroupPriority": "Пріоритет",
+    "filterGroupStatus": "Статус",
+    "swipedDoneToast": "Позначено як виконане.",
+    "swipedOpenToast": "Позначено як відкрите."
   },
   "shopping": {
     "title": "Покупки",
@@ -322,7 +330,11 @@
     "dayLongThursday": "Четвер",
     "dayLongFriday": "П'ятниця",
     "dayLongSaturday": "Субота",
-    "timeSuffix": ""
+    "timeSuffix": "",
+    "ics": {
+      "reset": "Скинути до оригіналу",
+      "resetToast": "Зміни скинуто."
+    }
   },
   "notes": {
     "title": "Нотатки",
@@ -564,7 +576,40 @@
     "sectionBudget": "Бюджет",
     "currencyLabel": "Валюта",
     "currencyHint": "Встановлює валюту, що використовується в розділі бюджету.",
-    "currencySaved": "Валюту збережено."
+    "currencySaved": "Валюту збережено.",
+    "ics": {
+      "title": "ICS-підписки",
+      "add": "Додати підписку",
+      "addedToast": "Підписку додано.",
+      "deletedToast": "Підписку видалено.",
+      "syncedToast": "Підписку синхронізовано.",
+      "confirm_delete": "Ви справді хочете видалити цю підписку? Всі пов'язані події також будуть видалені.",
+      "empty": "Підписок поки немає.",
+      "form": {
+        "name": "Назва",
+        "url": "URL ICS",
+        "color": "Колір",
+        "shared": "Видно всім"
+      },
+      "actions": {
+        "submit": "Додати",
+        "save": "Зберегти",
+        "cancel": "Скасувати",
+        "delete": "Видалити",
+        "edit": "Редагувати",
+        "sync": "Синхронізувати зараз"
+      },
+      "status": {
+        "lastSync": "Остання синхронізація:",
+        "never": "Ще не синхронізовано",
+        "syncing": "Синхронізація...",
+        "syncError": "Помилка синхронізації"
+      },
+      "badges": {
+        "private": "Приватне",
+        "shared": "Спільне"
+      }
+    }
   },
   "login": {
     "tagline": "Планування для родини. Безпечно. Конфіденційно. Відкритий код.",
@@ -657,5 +702,11 @@
     "duplicate": "Duplicate",
     "duplicated": "Recipe duplicated.",
     "copySuffix": "copy"
+  },
+  "search": {
+    "title": "Пошук",
+    "open": "Відкрити пошук",
+    "placeholder": "Пошук…",
+    "noResults": "Результатів не знайдено."
   }
 }

--- a/public/locales/zh.json
+++ b/public/locales/zh.json
@@ -43,7 +43,8 @@
     "main": "主导航",
     "navigation": "导航",
     "quickActions": "快捷操作",
-    "recipes": "Recipes"
+    "recipes": "Recipes",
+    "more": "更多"
   },
   "dashboard": {
     "title": "概览",
@@ -156,7 +157,14 @@
     "kanbanMoveToOpen": "重新打开",
     "recurring": "重复",
     "listView": "列表视图",
-    "kanbanView": "看板视图"
+    "kanbanView": "看板视图",
+    "filterBtn": "筛选",
+    "filterClearAll": "清除所有筛选",
+    "filterGroupPerson": "人员",
+    "filterGroupPriority": "优先级",
+    "filterGroupStatus": "状态",
+    "swipedDoneToast": "已标记为完成。",
+    "swipedOpenToast": "已标记为未完成。"
   },
   "shopping": {
     "title": "购物",
@@ -322,7 +330,11 @@
     "dayLongThursday": "星期四",
     "dayLongFriday": "星期五",
     "dayLongSaturday": "星期六",
-    "timeSuffix": ""
+    "timeSuffix": "",
+    "ics": {
+      "reset": "重置为原始",
+      "resetToast": "更改已重置。"
+    }
   },
   "notes": {
     "title": "便签板",
@@ -564,7 +576,40 @@
     "sectionBudget": "预算",
     "currencyLabel": "货币",
     "currencyHint": "设置整个预算区域使用的货币。",
-    "currencySaved": "货币已保存。"
+    "currencySaved": "货币已保存。",
+    "ics": {
+      "title": "ICS 订阅",
+      "add": "添加订阅",
+      "addedToast": "订阅已添加。",
+      "deletedToast": "订阅已删除。",
+      "syncedToast": "订阅已同步。",
+      "confirm_delete": "确定要删除此订阅吗？所有相关事件也将被删除。",
+      "empty": "暂无订阅。",
+      "form": {
+        "name": "名称",
+        "url": "ICS 链接",
+        "color": "颜色",
+        "shared": "所有人可见"
+      },
+      "actions": {
+        "submit": "添加",
+        "save": "保存",
+        "cancel": "取消",
+        "delete": "删除",
+        "edit": "编辑",
+        "sync": "立即同步"
+      },
+      "status": {
+        "lastSync": "上次同步:",
+        "never": "尚未同步",
+        "syncing": "同步中...",
+        "syncError": "同步错误"
+      },
+      "badges": {
+        "private": "私人",
+        "shared": "共享"
+      }
+    }
   },
   "login": {
     "tagline": "家庭规划。安全。注重隐私。开源。",
@@ -636,5 +681,32 @@
     "duplicate": "Duplicate",
     "duplicated": "Recipe duplicated.",
     "copySuffix": "copy"
+  },
+  "search": {
+    "title": "搜索",
+    "open": "打开搜索",
+    "placeholder": "搜索…",
+    "noResults": "未找到结果。"
+  },
+  "reminders": {
+    "sectionTitle": "提醒",
+    "enableLabel": "设置提醒",
+    "offsetLabel": "提醒时间",
+    "offsetNone": "无",
+    "offsetAtTime": "在开始时",
+    "offset15min": "提前15分钟",
+    "offset1hour": "提前1小时",
+    "offset1day": "提前1天",
+    "dateLabel": "日期",
+    "timeLabel": "时间",
+    "toastTitle": "提醒",
+    "dismiss": "关闭",
+    "pendingBadgeTitle": "{{count}}个待处理提醒",
+    "pendingBadgeTitlePlural": "{{count}}个待处理提醒",
+    "notificationPermission": "浏览器通知",
+    "notificationEnable": "启用通知",
+    "notificationEnabled": "通知已启用",
+    "notificationDenied": "通知已被阻止",
+    "notificationHint": "即使应用程序打开时也能收到通知。"
   }
 }


### PR DESCRIPTION
## Summary

- `nav.more` ("Mehr" / "More" etc.) was missing in all 14 non-German locale files, causing the bottom navigation to show German text in every other language
- `calendar.ics.reset`, `calendar.ics.resetToast`, `settings.ics.*`, `tasks.filter*`, `tasks.swiped*`, `search.*`, and `reminders.*` keys were also missing in most locales — all falling back to German strings
- Added proper translations for all missing keys in: ar, el, en, es, fr, hi, it, ja, pt, ru, sv, tr, uk, zh

## Test plan

- [x] All existing tests pass (`npm test` — 26 tests, 0 failures)
- [x] Verified zero missing keys across all 14 locale files after the fix
- [x] Translations match the semantic meaning of the German reference strings

Resolves #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)