### PR TITLE
fix(google-sync): skip null items and await initial sync

### DIFF
--- a/server/routes/calendar.js
+++ b/server/routes/calendar.js
@@ -268,9 +268,7 @@ router.get('/google/callback', async (req, res) => {
     delete req.session.googleOAuthState;
 
     await googleCalendar.handleCallback(code);
-
-    // Initialen Sync im Hintergrund starten (kein await - Redirect soll sofort erfolgen)
-    googleCalendar.sync().catch((e) => log.error('Initial sync failed:', e.message));
+    await googleCalendar.sync();
 
     res.redirect('/settings?sync_ok=google');
   } catch (err) {

--- a/server/services/google-calendar.js
+++ b/server/services/google-calendar.js
@@ -303,10 +303,11 @@ function upsertGoogleEvents(items, calRefId = null, calColor = GOOGLE_COLOR) {
   });
 
   for (const item of items) {
+    if (!item) continue;
     try {
       insertOrUpdate(item);
     } catch (err) {
-      log.error(`Upsert error for event ${item.id}:`, err.message);
+      log.error(`Upsert error for event ${item?.id}:`, err.message);
     }
   }
 }


### PR DESCRIPTION
## Summary

- **Null-Item-Guard:** `upsertGoogleEvents` now skips `null`/`undefined` entries in the Google API response with an early `continue`, preventing `TypeError: Cannot read properties of undefined (reading 'status')`.
- **Await initial sync:** The OAuth callback now `await`s `sync()` instead of fire-and-forgetting it. If the initial sync fails the user is redirected to `sync_error=google` instead of falsely seeing `sync_ok=google`.

## Test plan

- [ ] Connect Google Calendar via OAuth → verify initial sync completes before redirect
- [ ] Simulate null item in response → verify no crash, remaining items processed correctly
- [ ] Force a sync error → verify UI shows error, not success
- [ ] All existing tests pass (`npm test`)

Resolves #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)