### PR TITLE
feat(locales): update recipe translations across multiple languages

### DIFF
--- a/public/locales/ar.json
+++ b/public/locales/ar.json
@@ -44,7 +44,7 @@
     "main": "القائمة الرئيسية",
     "navigation": "التنقل",
     "quickActions": "الإجراءات السريعة",
-    "recipes": "Recipes",
+    "recipes": "الوصفات",
     "more": "المزيد"
   },
   "dashboard": {
@@ -782,28 +782,28 @@
     "unitMonths": "أشهر"
   },
   "recipes": {
-    "title": "Recipes",
-    "addRecipe": "Add recipe",
-    "editRecipe": "Edit recipe",
-    "emptyTitle": "No recipes yet",
-    "emptyDescription": "Save your favorite recipes and reuse them in meal planning.",
-    "titleLabel": "Title *",
-    "titlePlaceholder": "e.g. Pasta Carbonara",
-    "notesLabel": "Notes",
-    "notesPlaceholder": "Optional...",
-    "urlLabel": "Recipe link",
+    "title": "الوصفات",
+    "addRecipe": "إضافة وصفة",
+    "editRecipe": "تعديل الوصفة",
+    "emptyTitle": "لا توجد وصفات حتى الآن",
+    "emptyDescription": "احفظ وصفاتك المفضلة وأعد استخدامها في التخطيط للوجبات.",
+    "titleLabel": "العنوان *",
+    "titlePlaceholder": "مثال: معكرونة كربونارا",
+    "notesLabel": "ملاحظات",
+    "notesPlaceholder": "اختياري...",
+    "urlLabel": "رابط الوصفة",
     "urlPlaceholder": "https://...",
-    "ingredientsLabel": "Ingredients",
-    "addToMeals": "Add to meal plan",
-    "openLink": "Open recipe link",
-    "deleteConfirm": "Delete recipe \"{{title}}\"?",
-    "created": "Recipe saved.",
-    "updated": "Recipe updated.",
-    "deleted": "Recipe deleted.",
-    "titleRequired": "Title is required",
-    "duplicate": "Duplicate",
-    "duplicated": "Recipe duplicated.",
-    "copySuffix": "copy"
+    "ingredientsLabel": "المكونات",
+    "addToMeals": "إضافة إلى خطة الوجبات",
+    "openLink": "فتح رابط الوصفة",
+    "deleteConfirm": "حذف الوصفة \"{{title}}\"؟",
+    "created": "تم حفظ الوصفة.",
+    "updated": "تم تحديث الوصفة.",
+    "deleted": "تم حذف الوصفة.",
+    "titleRequired": "العنوان مطلوب",
+    "duplicate": "نسخ",
+    "duplicated": "تم نسخ الوصفة.",
+    "copySuffix": "نسخة"
   },
   "search": {
     "title": "بحث",
@@ -883,5 +883,8 @@
   },
   "offline": {
     "banner": "Offline – reconnecting…"
+  },
+  "emptyHint": {
+    "recipes": "أنشئ وصفات واربطها بمخطط الوجبات."
   }
 }

--- a/public/locales/el.json
+++ b/public/locales/el.json
@@ -44,7 +44,7 @@
     "main": "Κύρια πλοήγηση",
     "navigation": "Πλοήγηση",
     "quickActions": "Γρήγορες ενέργειες",
-    "recipes": "Recipes",
+    "recipes": "Συνταγές",
     "more": "Περισσότερα"
   },
   "dashboard": {
@@ -782,28 +782,28 @@
     "unitMonths": "μήνες"
   },
   "recipes": {
-    "title": "Recipes",
-    "addRecipe": "Add recipe",
-    "editRecipe": "Edit recipe",
-    "emptyTitle": "No recipes yet",
-    "emptyDescription": "Save your favorite recipes and reuse them in meal planning.",
-    "titleLabel": "Title *",
-    "titlePlaceholder": "e.g. Pasta Carbonara",
-    "notesLabel": "Notes",
-    "notesPlaceholder": "Optional...",
-    "urlLabel": "Recipe link",
+    "title": "Συνταγές",
+    "addRecipe": "Προσθήκη συνταγής",
+    "editRecipe": "Επεξεργασία συνταγής",
+    "emptyTitle": "Δεν υπάρχουν ακόμη συνταγές",
+    "emptyDescription": "Αποθηκεύστε τις αγαπημένες σας συνταγές και χρησιμοποιήστε τις ξανά στον σχεδιασμό γευμάτων.",
+    "titleLabel": "Τίτλος *",
+    "titlePlaceholder": "π.χ. Μακαρόνια Ανθρωπογαίας",
+    "notesLabel": "Σημειώσεις",
+    "notesPlaceholder": "Προαιρετικό...",
+    "urlLabel": "Σύνδεσμος συνταγής",
     "urlPlaceholder": "https://...",
-    "ingredientsLabel": "Ingredients",
-    "addToMeals": "Add to meal plan",
-    "openLink": "Open recipe link",
-    "deleteConfirm": "Delete recipe \"{{title}}\"?",
-    "created": "Recipe saved.",
-    "updated": "Recipe updated.",
-    "deleted": "Recipe deleted.",
-    "titleRequired": "Title is required",
-    "duplicate": "Duplicate",
-    "duplicated": "Recipe duplicated.",
-    "copySuffix": "copy"
+    "ingredientsLabel": "Συστατικά",
+    "addToMeals": "Προσθήκη στο σχέδιο γευμάτων",
+    "openLink": "Άνοιγμα συνδέσμου συνταγής",
+    "deleteConfirm": "Διδαγραφή συνταγής \"{{title}}\";",
+    "created": "Η συνταγή αποθηκεύτηκε.",
+    "updated": "Η συνταγή ενημερώθηκε.",
+    "deleted": "Η συνταγή διαγράφηκε.",
+    "titleRequired": "Ο τίτλος είναι υποχρεωτικός",
+    "duplicate": "Διπλότυπο",
+    "duplicated": "Η συνταγή αντιγράφηκε.",
+    "copySuffix": "αντίγραφο"
   },
   "search": {
     "title": "Αναζήτηση",
@@ -883,5 +883,8 @@
   },
   "offline": {
     "banner": "Offline – reconnecting…"
+  },
+  "emptyHint": {
+    "recipes": "Δημιουργήστε συνταγές και συνδέστε τις με τον προγραμματισμό γευμάτων."
   }
 }

--- a/public/locales/es.json
+++ b/public/locales/es.json
@@ -44,7 +44,7 @@
     "main": "Navegación principal",
     "navigation": "Navegación",
     "quickActions": "Acciones rápidas",
-    "recipes": "Recipes",
+    "recipes": "Recetas",
     "more": "Más"
   },
   "dashboard": {
@@ -782,28 +782,28 @@
     "unitMonths": "meses"
   },
   "recipes": {
-    "title": "Recipes",
-    "addRecipe": "Add recipe",
-    "editRecipe": "Edit recipe",
-    "emptyTitle": "No recipes yet",
-    "emptyDescription": "Save your favorite recipes and reuse them in meal planning.",
-    "titleLabel": "Title *",
-    "titlePlaceholder": "e.g. Pasta Carbonara",
-    "notesLabel": "Notes",
-    "notesPlaceholder": "Optional...",
-    "urlLabel": "Recipe link",
+    "title": "Recetas",
+    "addRecipe": "Agregar receta",
+    "editRecipe": "Editar receta",
+    "emptyTitle": "Sin recetas aún",
+    "emptyDescription": "Guarda tus recetas favoritas y reutilízalas en la planificación de comidas.",
+    "titleLabel": "Título *",
+    "titlePlaceholder": "ej. Pasta a la Carbonara",
+    "notesLabel": "Notas",
+    "notesPlaceholder": "Opcional...",
+    "urlLabel": "Enlace de receta",
     "urlPlaceholder": "https://...",
-    "ingredientsLabel": "Ingredients",
-    "addToMeals": "Add to meal plan",
-    "openLink": "Open recipe link",
-    "deleteConfirm": "Delete recipe \"{{title}}\"?",
-    "created": "Recipe saved.",
-    "updated": "Recipe updated.",
-    "deleted": "Recipe deleted.",
-    "titleRequired": "Title is required",
-    "duplicate": "Duplicate",
-    "duplicated": "Recipe duplicated.",
-    "copySuffix": "copy"
+    "ingredientsLabel": "Ingredientes",
+    "addToMeals": "Agregar al plan de comidas",
+    "openLink": "Abrir enlace de receta",
+    "deleteConfirm": "¿Eliminar receta \"{{title}}\"?",
+    "created": "Receta guardada.",
+    "updated": "Receta actualizada.",
+    "deleted": "Receta eliminada.",
+    "titleRequired": "El título es obligatorio",
+    "duplicate": "Duplicar",
+    "duplicated": "Receta duplicada.",
+    "copySuffix": "copia"
   },
   "search": {
     "title": "Búsqueda",
@@ -883,5 +883,8 @@
   },
   "offline": {
     "banner": "Offline – reconnecting…"
+  },
+  "emptyHint": {
+    "recipes": "Crea recetas y vincúlalas con tu planificador de comidas."
   }
 }

--- a/public/locales/fr.json
+++ b/public/locales/fr.json
@@ -44,7 +44,7 @@
     "main": "Navigation principale",
     "navigation": "Navigation",
     "quickActions": "Actions rapides",
-    "recipes": "Recipes",
+    "recipes": "Recettes",
     "more": "Plus"
   },
   "dashboard": {
@@ -782,28 +782,28 @@
     "unitMonths": "mois"
   },
   "recipes": {
-    "title": "Recipes",
-    "addRecipe": "Add recipe",
-    "editRecipe": "Edit recipe",
-    "emptyTitle": "No recipes yet",
-    "emptyDescription": "Save your favorite recipes and reuse them in meal planning.",
-    "titleLabel": "Title *",
-    "titlePlaceholder": "e.g. Pasta Carbonara",
+    "title": "Recettes",
+    "addRecipe": "Ajouter une recette",
+    "editRecipe": "Modifier la recette",
+    "emptyTitle": "Aucune recette pour le moment",
+    "emptyDescription": "Enregistrez vos recettes préférées et réutilisez-les dans la planification des repas.",
+    "titleLabel": "Titre *",
+    "titlePlaceholder": "ex. Pâtes à la Carbonara",
     "notesLabel": "Notes",
-    "notesPlaceholder": "Optional...",
-    "urlLabel": "Recipe link",
+    "notesPlaceholder": "Facultatif...",
+    "urlLabel": "Lien de recette",
     "urlPlaceholder": "https://...",
-    "ingredientsLabel": "Ingredients",
-    "addToMeals": "Add to meal plan",
-    "openLink": "Open recipe link",
-    "deleteConfirm": "Delete recipe \"{{title}}\"?",
-    "created": "Recipe saved.",
-    "updated": "Recipe updated.",
-    "deleted": "Recipe deleted.",
-    "titleRequired": "Title is required",
-    "duplicate": "Duplicate",
-    "duplicated": "Recipe duplicated.",
-    "copySuffix": "copy"
+    "ingredientsLabel": "Ingrédients",
+    "addToMeals": "Ajouter au plan de repas",
+    "openLink": "Ouvrir le lien de recette",
+    "deleteConfirm": "Supprimer la recette \"{{title}}\" ?",
+    "created": "Recette enregistrée.",
+    "updated": "Recette mise à jour.",
+    "deleted": "Recette supprimée.",
+    "titleRequired": "Le titre est requis",
+    "duplicate": "Dupliquer",
+    "duplicated": "Recette dupliquée.",
+    "copySuffix": "copie"
   },
   "search": {
     "title": "Recherche",
@@ -883,5 +883,8 @@
   },
   "offline": {
     "banner": "Offline – reconnecting…"
+  },
+  "emptyHint": {
+    "recipes": "Créez des recettes et associez-les à votre planification des repas."
   }
 }

--- a/public/locales/hi.json
+++ b/public/locales/hi.json
@@ -44,7 +44,7 @@
     "main": "मुख्य नेविगेशन",
     "navigation": "नेविगेशन",
     "quickActions": "त्वरित क्रियाएं",
-    "recipes": "Recipes",
+    "recipes": "रेसिपी",
     "more": "और"
   },
   "dashboard": {
@@ -782,28 +782,28 @@
     "unitMonths": "माह"
   },
   "recipes": {
-    "title": "Recipes",
-    "addRecipe": "Add recipe",
-    "editRecipe": "Edit recipe",
-    "emptyTitle": "No recipes yet",
-    "emptyDescription": "Save your favorite recipes and reuse them in meal planning.",
-    "titleLabel": "Title *",
-    "titlePlaceholder": "e.g. Pasta Carbonara",
-    "notesLabel": "Notes",
-    "notesPlaceholder": "Optional...",
-    "urlLabel": "Recipe link",
+    "title": "रेसिपी",
+    "addRecipe": "रेसिपी जोड़ें",
+    "editRecipe": "रेसिपी संपादित करें",
+    "emptyTitle": "अभी तक कोई रेसिपी नहीं",
+    "emptyDescription": "अपनी पसंदीदा रेसिपी सहेजें और उन्हें भोजन योजना में दोबारा उपयोग करें।",
+    "titleLabel": "शीर्षक *",
+    "titlePlaceholder": "जैसे। पास्ता कार्बोनारा",
+    "notesLabel": "नोट्स",
+    "notesPlaceholder": "वैकल्पिक...",
+    "urlLabel": "रेसिपी लिंक",
     "urlPlaceholder": "https://...",
-    "ingredientsLabel": "Ingredients",
-    "addToMeals": "Add to meal plan",
-    "openLink": "Open recipe link",
-    "deleteConfirm": "Delete recipe \"{{title}}\"?",
-    "created": "Recipe saved.",
-    "updated": "Recipe updated.",
-    "deleted": "Recipe deleted.",
-    "titleRequired": "Title is required",
-    "duplicate": "Duplicate",
-    "duplicated": "Recipe duplicated.",
-    "copySuffix": "copy"
+    "ingredientsLabel": "सामग्री",
+    "addToMeals": "भोजन योजना में जोड़ें",
+    "openLink": "रेसिपी लिंक खोलें",
+    "deleteConfirm": "रेसिपी \"{{title}}\" हटाएं?",
+    "created": "रेसिपी सहेजी गई।",
+    "updated": "रेसिपी अपडेट की गई।",
+    "deleted": "रेसिपी हटाई गई।",
+    "titleRequired": "शीर्षक आवश्यक है",
+    "duplicate": "डुप्लिकेट",
+    "duplicated": "रेसिपी डुप्लिकेट की गई।",
+    "copySuffix": "कॉपी"
   },
   "search": {
     "title": "खोज",
@@ -883,5 +883,8 @@
   },
   "offline": {
     "banner": "Offline – reconnecting…"
+  },
+  "emptyHint": {
+    "recipes": "रेसिपी बनाएं और उन्हें अपने भोजन योजनाकार से जोड़ें।"
   }
 }

--- a/public/locales/it.json
+++ b/public/locales/it.json
@@ -44,7 +44,7 @@
     "main": "Navigazione principale",
     "navigation": "Navigazione",
     "quickActions": "Azioni rapide",
-    "recipes": "Recipes",
+    "recipes": "Ricette",
     "more": "Altro"
   },
   "dashboard": {
@@ -782,28 +782,28 @@
     "unitMonths": "mesi"
   },
   "recipes": {
-    "title": "Recipes",
-    "addRecipe": "Add recipe",
-    "editRecipe": "Edit recipe",
-    "emptyTitle": "No recipes yet",
-    "emptyDescription": "Save your favorite recipes and reuse them in meal planning.",
-    "titleLabel": "Title *",
-    "titlePlaceholder": "e.g. Pasta Carbonara",
-    "notesLabel": "Notes",
-    "notesPlaceholder": "Optional...",
-    "urlLabel": "Recipe link",
+    "title": "Ricette",
+    "addRecipe": "Aggiungi ricetta",
+    "editRecipe": "Modifica ricetta",
+    "emptyTitle": "Nessuna ricetta ancora",
+    "emptyDescription": "Salva le tue ricette preferite e riutilizzale nella pianificazione dei pasti.",
+    "titleLabel": "Titolo *",
+    "titlePlaceholder": "es. Pasta alla Carbonara",
+    "notesLabel": "Note",
+    "notesPlaceholder": "Opzionale...",
+    "urlLabel": "Link ricetta",
     "urlPlaceholder": "https://...",
-    "ingredientsLabel": "Ingredients",
-    "addToMeals": "Add to meal plan",
-    "openLink": "Open recipe link",
-    "deleteConfirm": "Delete recipe \"{{title}}\"?",
-    "created": "Recipe saved.",
-    "updated": "Recipe updated.",
-    "deleted": "Recipe deleted.",
-    "titleRequired": "Title is required",
-    "duplicate": "Duplicate",
-    "duplicated": "Recipe duplicated.",
-    "copySuffix": "copy"
+    "ingredientsLabel": "Ingredienti",
+    "addToMeals": "Aggiungi al piano pasti",
+    "openLink": "Apri link ricetta",
+    "deleteConfirm": "Eliminare ricetta \"{{title}}\"?",
+    "created": "Ricetta salvata.",
+    "updated": "Ricetta aggiornata.",
+    "deleted": "Ricetta eliminata.",
+    "titleRequired": "Il titolo è obbligatorio",
+    "duplicate": "Duplica",
+    "duplicated": "Ricetta duplicata.",
+    "copySuffix": "copia"
   },
   "search": {
     "title": "Ricerca",
@@ -883,5 +883,8 @@
   },
   "offline": {
     "banner": "Offline – reconnecting…"
+  },
+  "emptyHint": {
+    "recipes": "Crea ricette e collegale al tuo piano pasti."
   }
 }

--- a/public/locales/ja.json
+++ b/public/locales/ja.json
@@ -44,7 +44,7 @@
     "main": "メインナビゲーション",
     "navigation": "ナビゲーション",
     "quickActions": "クイックアクション",
-    "recipes": "Recipes",
+    "recipes": "レシピ",
     "more": "もっと見る"
   },
   "dashboard": {
@@ -782,28 +782,28 @@
     "unitMonths": "ヶ月"
   },
   "recipes": {
-    "title": "Recipes",
-    "addRecipe": "Add recipe",
-    "editRecipe": "Edit recipe",
-    "emptyTitle": "No recipes yet",
-    "emptyDescription": "Save your favorite recipes and reuse them in meal planning.",
-    "titleLabel": "Title *",
-    "titlePlaceholder": "e.g. Pasta Carbonara",
-    "notesLabel": "Notes",
-    "notesPlaceholder": "Optional...",
-    "urlLabel": "Recipe link",
+    "title": "レシピ",
+    "addRecipe": "レシピを追加",
+    "editRecipe": "レシピを編集",
+    "emptyTitle": "まだレシピがありません",
+    "emptyDescription": "お気に入りのレシピを保存して、食事計画で再利用できます。",
+    "titleLabel": "タイトル *",
+    "titlePlaceholder": "例：パスタカルボナーラ",
+    "notesLabel": "メモ",
+    "notesPlaceholder": "オプション...",
+    "urlLabel": "レシピリンク",
     "urlPlaceholder": "https://...",
-    "ingredientsLabel": "Ingredients",
-    "addToMeals": "Add to meal plan",
-    "openLink": "Open recipe link",
-    "deleteConfirm": "Delete recipe \"{{title}}\"?",
-    "created": "Recipe saved.",
-    "updated": "Recipe updated.",
-    "deleted": "Recipe deleted.",
-    "titleRequired": "Title is required",
-    "duplicate": "Duplicate",
-    "duplicated": "Recipe duplicated.",
-    "copySuffix": "copy"
+    "ingredientsLabel": "材料",
+    "addToMeals": "食事計画に追加",
+    "openLink": "レシピリンクを開く",
+    "deleteConfirm": "レシピ \"{{title}}\" を削除しますか？",
+    "created": "レシピが保存されました。",
+    "updated": "レシピが更新されました。",
+    "deleted": "レシピが削除されました。",
+    "titleRequired": "タイトルが必要です",
+    "duplicate": "複製",
+    "duplicated": "レシピが複製されました。",
+    "copySuffix": "コピー"
   },
   "search": {
     "title": "検索",
@@ -883,5 +883,8 @@
   },
   "offline": {
     "banner": "Offline – reconnecting…"
+  },
+  "emptyHint": {
+    "recipes": "レシピを作成して、食事プランに関連付けましょう。"
   }
 }

--- a/public/locales/pt.json
+++ b/public/locales/pt.json
@@ -44,7 +44,7 @@
     "main": "Navegação principal",
     "navigation": "Navegação",
     "quickActions": "Ações rápidas",
-    "recipes": "Recipes",
+    "recipes": "Receitas",
     "more": "Mais"
   },
   "dashboard": {
@@ -782,28 +782,28 @@
     "unitMonths": "meses"
   },
   "recipes": {
-    "title": "Recipes",
-    "addRecipe": "Add recipe",
-    "editRecipe": "Edit recipe",
-    "emptyTitle": "No recipes yet",
-    "emptyDescription": "Save your favorite recipes and reuse them in meal planning.",
-    "titleLabel": "Title *",
-    "titlePlaceholder": "e.g. Pasta Carbonara",
-    "notesLabel": "Notes",
-    "notesPlaceholder": "Optional...",
-    "urlLabel": "Recipe link",
+    "title": "Receitas",
+    "addRecipe": "Adicionar receita",
+    "editRecipe": "Editar receita",
+    "emptyTitle": "Nenhuma receita ainda",
+    "emptyDescription": "Salve suas receitas favoritas e reutilize-as no planejamento de refeições.",
+    "titleLabel": "Título *",
+    "titlePlaceholder": "ex. Massa à Carbonara",
+    "notesLabel": "Notas",
+    "notesPlaceholder": "Opcional...",
+    "urlLabel": "Link da receita",
     "urlPlaceholder": "https://...",
-    "ingredientsLabel": "Ingredients",
-    "addToMeals": "Add to meal plan",
-    "openLink": "Open recipe link",
-    "deleteConfirm": "Delete recipe \"{{title}}\"?",
-    "created": "Recipe saved.",
-    "updated": "Recipe updated.",
-    "deleted": "Recipe deleted.",
-    "titleRequired": "Title is required",
-    "duplicate": "Duplicate",
-    "duplicated": "Recipe duplicated.",
-    "copySuffix": "copy"
+    "ingredientsLabel": "Ingredientes",
+    "addToMeals": "Adicionar ao plano de refeições",
+    "openLink": "Abrir link da receita",
+    "deleteConfirm": "Excluir receita \"{{title}}\"?",
+    "created": "Receita salva.",
+    "updated": "Receita atualizada.",
+    "deleted": "Receita excluída.",
+    "titleRequired": "O título é obrigatório",
+    "duplicate": "Duplicar",
+    "duplicated": "Receita duplicada.",
+    "copySuffix": "cópia"
   },
   "search": {
     "title": "Pesquisa",
@@ -884,5 +884,8 @@
   },
   "offline": {
     "banner": "Offline – reconnecting…"
+  },
+  "emptyHint": {
+    "recipes": "Crie receitas e vincule-as ao seu planejador de refeições."
   }
 }

--- a/public/locales/ru.json
+++ b/public/locales/ru.json
@@ -44,7 +44,7 @@
     "main": "Главная навигация",
     "navigation": "Навигация",
     "quickActions": "Быстрые действия",
-    "recipes": "Recipes",
+    "recipes": "Рецепты",
     "more": "Ещё"
   },
   "dashboard": {
@@ -782,28 +782,28 @@
     "unitMonths": "месяцев"
   },
   "recipes": {
-    "title": "Recipes",
-    "addRecipe": "Add recipe",
-    "editRecipe": "Edit recipe",
-    "emptyTitle": "No recipes yet",
-    "emptyDescription": "Save your favorite recipes and reuse them in meal planning.",
-    "titleLabel": "Title *",
-    "titlePlaceholder": "e.g. Pasta Carbonara",
-    "notesLabel": "Notes",
-    "notesPlaceholder": "Optional...",
-    "urlLabel": "Recipe link",
+    "title": "Рецепты",
+    "addRecipe": "Добавить рецепт",
+    "editRecipe": "Редактировать рецепт",
+    "emptyTitle": "Рецептов еще нет",
+    "emptyDescription": "Сохраняйте свои любимые рецепты и используйте их повторно при планировании питания.",
+    "titleLabel": "Название *",
+    "titlePlaceholder": "напр. Паста Карбонара",
+    "notesLabel": "Заметки",
+    "notesPlaceholder": "Необязательно...",
+    "urlLabel": "Ссылка на рецепт",
     "urlPlaceholder": "https://...",
-    "ingredientsLabel": "Ingredients",
-    "addToMeals": "Add to meal plan",
-    "openLink": "Open recipe link",
-    "deleteConfirm": "Delete recipe \"{{title}}\"?",
-    "created": "Recipe saved.",
-    "updated": "Recipe updated.",
-    "deleted": "Recipe deleted.",
-    "titleRequired": "Title is required",
-    "duplicate": "Duplicate",
-    "duplicated": "Recipe duplicated.",
-    "copySuffix": "copy"
+    "ingredientsLabel": "Ингредиенты",
+    "addToMeals": "Добавить в план питания",
+    "openLink": "Открыть ссылку на рецепт",
+    "deleteConfirm": "Удалить рецепт \"{{title}}\"?",
+    "created": "Рецепт сохранен.",
+    "updated": "Рецепт обновлен.",
+    "deleted": "Рецепт удален.",
+    "titleRequired": "Название обязательно",
+    "duplicate": "Дублировать",
+    "duplicated": "Рецепт дублирован.",
+    "copySuffix": "копия"
   },
   "search": {
     "title": "Поиск",
@@ -883,5 +883,8 @@
   },
   "offline": {
     "banner": "Offline – reconnecting…"
+  },
+  "emptyHint": {
+    "recipes": "Создавайте рецепты и связывайте их с вашим планом питания."
   }
 }

--- a/public/locales/sv.json
+++ b/public/locales/sv.json
@@ -883,5 +883,8 @@
   },
   "offline": {
     "banner": "Offline – reconnecting…"
+  },
+  "emptyHint": {
+    "recipes": "Skapa recept och koppla dem till din måltidsplanering."
   }
 }

--- a/public/locales/tr.json
+++ b/public/locales/tr.json
@@ -44,7 +44,7 @@
     "main": "Ana gezinme",
     "navigation": "Gezinme",
     "quickActions": "Hızlı işlemler",
-    "recipes": "Recipes",
+    "recipes": "Tarifler",
     "more": "Daha Fazla"
   },
   "dashboard": {
@@ -782,28 +782,28 @@
     "unitMonths": "ay"
   },
   "recipes": {
-    "title": "Recipes",
-    "addRecipe": "Add recipe",
-    "editRecipe": "Edit recipe",
-    "emptyTitle": "No recipes yet",
-    "emptyDescription": "Save your favorite recipes and reuse them in meal planning.",
-    "titleLabel": "Title *",
-    "titlePlaceholder": "e.g. Pasta Carbonara",
-    "notesLabel": "Notes",
-    "notesPlaceholder": "Optional...",
-    "urlLabel": "Recipe link",
+    "title": "Tarifler",
+    "addRecipe": "Tarif ekle",
+    "editRecipe": "Tarifi düzenle",
+    "emptyTitle": "Henüz tarif yok",
+    "emptyDescription": "Favori tariflerinizi kaydedin ve yemek planlama sırasında yeniden kullanın.",
+    "titleLabel": "Başlık *",
+    "titlePlaceholder": "ör. Pasta Carbonara",
+    "notesLabel": "Notlar",
+    "notesPlaceholder": "İsteğe bağlı...",
+    "urlLabel": "Tarif bağlantısı",
     "urlPlaceholder": "https://...",
-    "ingredientsLabel": "Ingredients",
-    "addToMeals": "Add to meal plan",
-    "openLink": "Open recipe link",
-    "deleteConfirm": "Delete recipe \"{{title}}\"?",
-    "created": "Recipe saved.",
-    "updated": "Recipe updated.",
-    "deleted": "Recipe deleted.",
-    "titleRequired": "Title is required",
-    "duplicate": "Duplicate",
-    "duplicated": "Recipe duplicated.",
-    "copySuffix": "copy"
+    "ingredientsLabel": "Malzemeler",
+    "addToMeals": "Yemek planına ekle",
+    "openLink": "Tarif bağlantısını aç",
+    "deleteConfirm": "\"{{title}}\" tarifini sil?",
+    "created": "Tarif kaydedildi.",
+    "updated": "Tarif güncellendi.",
+    "deleted": "Tarif silindi.",
+    "titleRequired": "Başlık gerekli",
+    "duplicate": "Çoğalt",
+    "duplicated": "Tarif çoğaltıldı.",
+    "copySuffix": "kopya"
   },
   "search": {
     "title": "Arama",
@@ -883,5 +883,8 @@
   },
   "offline": {
     "banner": "Offline – reconnecting…"
+  },
+  "emptyHint": {
+    "recipes": "Tarifler oluşturun ve yemek planlayıcınıza bağlayın."
   }
 }

--- a/public/locales/uk.json
+++ b/public/locales/uk.json
@@ -44,7 +44,7 @@
     "main": "Головна навігація",
     "navigation": "Навігація",
     "quickActions": "Швидкі дії",
-    "recipes": "Recipes",
+    "recipes": "Рецепти",
     "more": "Більше"
   },
   "dashboard": {
@@ -813,28 +813,28 @@
     "customWeeks": "Weeks"
   },
   "recipes": {
-    "title": "Recipes",
-    "addRecipe": "Add recipe",
-    "editRecipe": "Edit recipe",
-    "emptyTitle": "No recipes yet",
-    "emptyDescription": "Save your favorite recipes and reuse them in meal planning.",
-    "titleLabel": "Title *",
-    "titlePlaceholder": "e.g. Pasta Carbonara",
-    "notesLabel": "Notes",
-    "notesPlaceholder": "Optional...",
-    "urlLabel": "Recipe link",
+    "title": "Рецепти",
+    "addRecipe": "Додати рецепт",
+    "editRecipe": "Редагувати рецепт",
+    "emptyTitle": "Немає рецептів",
+    "emptyDescription": "Збережіть свої улюблені рецепти й повторно використовуйте їх у плануванні їжі.",
+    "titleLabel": "Назва *",
+    "titlePlaceholder": "наприклад, Паста Карбонара",
+    "notesLabel": "Нотатки",
+    "notesPlaceholder": "Необов'язково...",
+    "urlLabel": "Посилання на рецепт",
     "urlPlaceholder": "https://...",
-    "ingredientsLabel": "Ingredients",
-    "addToMeals": "Add to meal plan",
-    "openLink": "Open recipe link",
-    "deleteConfirm": "Delete recipe \"{{title}}\"?",
-    "created": "Recipe saved.",
-    "updated": "Recipe updated.",
-    "deleted": "Recipe deleted.",
-    "titleRequired": "Title is required",
-    "duplicate": "Duplicate",
-    "duplicated": "Recipe duplicated.",
-    "copySuffix": "copy"
+    "ingredientsLabel": "Інгредієнти",
+    "addToMeals": "Додати до плану харчування",
+    "openLink": "Відкрити посилання на рецепт",
+    "deleteConfirm": "Видалити рецепт \"{{title}}\"?",
+    "created": "Рецепт збережено.",
+    "updated": "Рецепт оновлено.",
+    "deleted": "Рецепт видалено.",
+    "titleRequired": "Назва обов'язкова",
+    "duplicate": "Дублювати",
+    "duplicated": "Рецепт продубльовано.",
+    "copySuffix": "копія"
   },
   "search": {
     "title": "Пошук",
@@ -883,5 +883,16 @@
   },
   "offline": {
     "banner": "Offline – reconnecting…"
+  },
+  "emptyHint": {
+    "tasks": "Натисніть +, щоб створити перше завдання. Проведіть картку вліво, щоб видалити.",
+    "calendar": "Підключіть Google Календар у Налаштування → Інтеграції для автоматичної синхронізації.",
+    "shopping": "Додавайте товари й проводьте, щоб позначити або видалити.",
+    "notes": "Натисніть +, щоб створити нову нотатку. Нотатки шукаються за повним текстом.",
+    "contacts": "Додайте важливі контакти — лікар, школа, екстрені служби — для швидкого доступу.",
+    "budget": "Створіть категорії та вносіть доходи й витрати.",
+    "meals": "Плануйте харчування на тиждень і пов'язуйте рецепти.",
+    "birthdays": "Додайте дні народження — ви отримаєте нагадування завчасно.",
+    "recipes": "Створюйте рецепти та пов'язуйте їх із планувальником харчування."
   }
 }

--- a/public/locales/zh.json
+++ b/public/locales/zh.json
@@ -44,7 +44,7 @@
     "main": "主导航",
     "navigation": "导航",
     "quickActions": "快捷操作",
-    "recipes": "Recipes",
+    "recipes": "食谱",
     "more": "更多"
   },
   "dashboard": {
@@ -782,28 +782,28 @@
     "unitMonths": "个月"
   },
   "recipes": {
-    "title": "Recipes",
-    "addRecipe": "Add recipe",
-    "editRecipe": "Edit recipe",
-    "emptyTitle": "No recipes yet",
-    "emptyDescription": "Save your favorite recipes and reuse them in meal planning.",
-    "titleLabel": "Title *",
-    "titlePlaceholder": "e.g. Pasta Carbonara",
-    "notesLabel": "Notes",
-    "notesPlaceholder": "Optional...",
-    "urlLabel": "Recipe link",
+    "title": "食谱",
+    "addRecipe": "添加食谱",
+    "editRecipe": "编辑食谱",
+    "emptyTitle": "还没有食谱",
+    "emptyDescription": "保存你喜爱的食谱，在餐食规划中重复使用。",
+    "titleLabel": "标题 *",
+    "titlePlaceholder": "例如：意大利面卡邦尼",
+    "notesLabel": "备注",
+    "notesPlaceholder": "可选...",
+    "urlLabel": "食谱链接",
     "urlPlaceholder": "https://...",
-    "ingredientsLabel": "Ingredients",
-    "addToMeals": "Add to meal plan",
-    "openLink": "Open recipe link",
-    "deleteConfirm": "Delete recipe \"{{title}}\"?",
-    "created": "Recipe saved.",
-    "updated": "Recipe updated.",
-    "deleted": "Recipe deleted.",
-    "titleRequired": "Title is required",
-    "duplicate": "Duplicate",
-    "duplicated": "Recipe duplicated.",
-    "copySuffix": "copy"
+    "ingredientsLabel": "材料",
+    "addToMeals": "添加到餐食计划",
+    "openLink": "打开食谱链接",
+    "deleteConfirm": "删除食谱\"{{title}}\"？",
+    "created": "食谱已保存。",
+    "updated": "食谱已更新。",
+    "deleted": "食谱已删除。",
+    "titleRequired": "标题必填",
+    "duplicate": "复制",
+    "duplicated": "食谱已复制。",
+    "copySuffix": "副本"
   },
   "search": {
     "title": "搜索",
@@ -883,5 +883,8 @@
   },
   "offline": {
     "banner": "Offline – reconnecting…"
+  },
+  "emptyHint": {
+    "recipes": "创建食谱并将其关联到你的膳食计划。"
   }
 }


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Link the related issue: Closes #123 -->

## Changes

- update recipe translations across multiple languages

## Checklist

- [x] `npm test` passes
- [x] Follows [CONTRIBUTING.md](../CONTRIBUTING.md) conventions
- [x] No new frontend dependencies (vanilla JS, no frameworks)
- [x] UI strings use `t('key')` (no hardcoded text)
- [ ] CHANGELOG.md updated (if user-facing change)
