### PR TITLE
fix: prevent dashboard horizontal overflow on portrait mobile

### DIFF
--- a/public/styles/dashboard.css
+++ b/public/styles/dashboard.css
@@ -1941,7 +1941,6 @@
  * -------------------------------------------------------- */
 .dashboard {
   max-width: min(1680px, 100%);
-  overflow: visible;
 }
 
 .dashboard::before,

--- a/public/styles/layout.css
+++ b/public/styles/layout.css
@@ -128,7 +128,7 @@
   flex: 1;
   min-height: 0;
   overflow-y: auto;
-  overflow-x: clip;
+  overflow-x: hidden;
   overscroll-behavior-y: contain;
   -webkit-overflow-scrolling: touch;
 }


### PR DESCRIPTION
## Summary

- Removes `overflow: visible` from the "Admin Dashboard Layout" block in `dashboard.css` that was silently overriding the earlier `overflow: clip` declaration, allowing child content to escape the dashboard container and cause horizontal layout overflow
- Changes `overflow-x: clip` → `overflow-x: hidden` on `.app-content` in `layout.css` — `clip` only clips painting, not layout, so overflow was still propagating to the root scroll container and making the page scrollable horizontally

## Root cause

`overflow-x: clip` (added in v0.38.3) prevents content from *painting* outside the container but does not create a block formatting context, so *layout* overflow still propagates up to `<html>`. Combined with `.dashboard { overflow: visible }` in a later CSS section overriding the `overflow: clip` set earlier, the dashboard's child content could expand the root scroll container to landscape width even in portrait mode.

## Test plan

- [ ] Verify dashboard fits within viewport in portrait mode on a narrow Android device
- [ ] Verify no horizontal scrollbar appears in portrait mode
- [ ] Verify landscape mode still shows multi-column grid layout as expected
- [ ] Verify no visual regressions on desktop dashboard

Resolves #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)