### PR TITLE
fix: restore settings page broken by missing closing parenthesis (v0.52.12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.52.12] - 2026-05-20
+
+### Fixed
+- Settings page is accessible again after the v0.52.10 update; a missing closing parenthesis on the `insertAdjacentHTML` call in `settings.js` caused a JavaScript syntax error that prevented the entire settings page from loading
+
 ## [0.52.11] - 2026-05-20
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oikos",
-  "version": "0.52.11",
+  "version": "0.52.12",
   "description": "Self-hosted family planner - calendar, tasks, shopping, meal planning, budget and more. Private, open-source, no subscription.",
   "main": "server/index.js",
   "type": "module",

--- a/public/pages/settings.js
+++ b/public/pages/settings.js
@@ -862,7 +862,7 @@ docker cp oikos:/data/oikos-backup.db ./oikos-backup.db</code></pre>
       </div>
       ` : ''}
     </div>
-  `;
+  `);
 
   // Meal-Type-Checkboxen initialisieren
   const toggles = container.querySelector('#meal-type-toggles');


### PR DESCRIPTION
## Summary

- The `insertAdjacentHTML` call introduced in v0.52.10 (commit 40eed94) was missing its closing `)` after the template literal in `public/pages/settings.js`
- This caused a JavaScript syntax error that prevented the settings module from loading entirely, making the settings page inaccessible
- Fix: added the missing `)` to close the `insertAdjacentHTML(...)` call at line 865

## Test plan

- [ ] Open Settings page — it should load without errors
- [ ] Navigate to Settings > Synchronization and verify CalDAV accounts still display correctly

Fixes #156 (follow-up regression after v0.52.10)

https://claude.ai/code/session_01UaKZfhXUnmX1cb1LmWvHjG

---
_Generated by [Claude Code](https://claude.ai/code/session_01UaKZfhXUnmX1cb1LmWvHjG)_