### PR TITLE
fix(layout): FAB folgt Bottom-Nav beim Ausblenden (H4)

### DIFF
--- a/public/router.js
+++ b/public/router.js
@@ -829,16 +829,24 @@ function initNavHideOnScroll(container) {
 
   let lastY = 0;
 
+  const setNavHidden = (hidden) => {
+    nav.classList.toggle('nav-bottom--hidden', hidden);
+    document.documentElement.classList.toggle('nav-bottom--hidden', hidden);
+  };
+
   content.addEventListener('scroll', () => {
-    if (window.innerWidth >= 1024) return;
+    if (window.innerWidth >= 1024) {
+      setNavHidden(false);
+      return;
+    }
 
     const y = content.scrollTop;
     if (y < 10) {
-      nav.classList.remove('nav-bottom--hidden');
+      setNavHidden(false);
     } else if (y > lastY + 4) {
-      nav.classList.add('nav-bottom--hidden');
+      setNavHidden(true);
     } else if (y < lastY - 4) {
-      nav.classList.remove('nav-bottom--hidden');
+      setNavHidden(false);
     }
     lastY = y;
   }, { passive: true });

--- a/public/styles/layout.css
+++ b/public/styles/layout.css
@@ -559,7 +559,7 @@
   cursor: pointer;
   border: none;
   z-index: calc(var(--z-nav) - 1);
-  transition: transform var(--transition-base), background-color var(--transition-fast);
+  transition: transform var(--transition-base), background-color var(--transition-fast), bottom 0.2s var(--ease-out);
   -webkit-tap-highlight-color: transparent;
   animation: fab-in 0.35s var(--ease-out) backwards;
 }
@@ -590,6 +590,13 @@ html.fab-anim-done .page-fab {
     right: var(--space-8);
     width: var(--target-lg);
     height: var(--target-lg);
+  }
+}
+
+/* FAB folgt der Bottom-Nav wenn diese beim Scrollen ausblendet */
+@media (max-width: 1023px) {
+  html.nav-bottom--hidden .page-fab {
+    bottom: calc(var(--space-6) + var(--safe-area-inset-bottom));
   }
 }
 


### PR DESCRIPTION
## Summary

- `initNavHideOnScroll()` spiegelt `nav-bottom--hidden` jetzt auf `document.documentElement`, damit CSS die FAB-Position über einen einfachen Descendant-Selektor steuern kann
- FAB-Transition um `bottom 0.2s var(--ease-out)` erweitert — gleiche Dauer wie die Nav-Animation
- Neue CSS-Regel `@media (max-width: 1023px) { html.nav-bottom--hidden .page-fab { bottom: calc(var(--space-6) + var(--safe-area-inset-bottom)) } }` verschiebt den FAB an den unteren Rand, wenn die Nav ausblendet
- Resize-Edge-Case (Mobile → Desktop) wird abgefangen: Scroll-Handler ruft `setNavHidden(false)` wenn Viewport ≥ 1024px

## Test plan

- [ ] Mobile-Viewport (390px): Seite mit FAB (z.B. /tasks) öffnen, scrollen — Nav und FAB blenden synchron aus
- [ ] Scrollen zurück — Nav und FAB erscheinen synchron
- [ ] Desktop-Viewport (≥ 1024px): kein FAB-Jumping, keine versteckte Nav
- [ ] Safe-Area-Gerät (iPhone mit Home-Indicator): FAB hält korrekten Abstand

Part of UX-Audit Phase 6 (H4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)