### PR TITLE
fix(dashboard): Skeleton-Grid mit korrekten Widget-Größen versehen (H7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.52.20] - 2026-05-21
+
+### Fixed
+- Dashboard skeleton screen now renders all 9 widgets with correct grid-spanning sizes (matching `DEFAULT_WIDGET_CONFIG`) instead of 6 fixed-width placeholders, preventing content layout shift on initial load
+
 ## [0.52.19] - 2026-05-21
 
 ### Fixed

--- a/docs/UX-AUDIT.md
+++ b/docs/UX-AUDIT.md
@@ -177,7 +177,7 @@ Status-Spalte beim Abarbeiten: `[ ]` offen → `[x]` erledigt
   ).join(''));
   // Nach API-Daten: grid.replaceChildren() + echte Widgets
   ```
-- **Status:** [ ]
+- **Status:** [x]
 
 ---
 
@@ -398,7 +398,8 @@ Diese Aspekte sind gut umgesetzt und sollten nicht verändert werden:
 - **Phase 4 abgeschlossen (v0.52.17):** H1 ✅
 - **Phase 5 abgeschlossen (v0.52.18):** H3 ✅
 - **Phase 6 abgeschlossen (v0.52.19):** H4 ✅
-- **Nächste Phase:** Phase 7 — H7 (Dashboard Skeleton-Screen)
+- **Phase 7 abgeschlossen (v0.52.20):** H7 ✅
+- **Nächste Phase:** Phase 8 — K2 + H6 (Such-Deep-Links)
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oikos",
-  "version": "0.52.19",
+  "version": "0.52.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oikos",
-      "version": "0.52.19",
+      "version": "0.52.20",
       "license": "MIT",
       "dependencies": {
         "bcrypt": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oikos",
-  "version": "0.52.19",
+  "version": "0.52.20",
   "description": "Self-hosted family planner - calendar, tasks, shopping, meal planning, budget and more. Private, open-source, no subscription.",
   "main": "server/index.js",
   "type": "module",

--- a/public/pages/dashboard.js
+++ b/public/pages/dashboard.js
@@ -693,6 +693,10 @@ function renderDashboardLayout(cfg, data, weather, currency, { editing = false }
 }
 
 function renderDashboardSkeleton() {
+  const tiles = DEFAULT_WIDGET_CONFIG
+    .filter((w) => w.visible)
+    .map((w) => `<div class="widget-wrapper ${widgetSizeClass(w.size)}">${skeletonWidget(3)}</div>`)
+    .join('');
   return `
     <section class="dashboard-overview">
       <div class="dashboard-overview__header">
@@ -702,14 +706,7 @@ function renderDashboardSkeleton() {
         </div>
       </div>
     </section>
-    <div class="dashboard__grid">
-      ${skeletonWidget(3)}
-      ${skeletonWidget(3)}
-      ${skeletonWidget(2)}
-      ${skeletonWidget(3)}
-      ${skeletonWidget(3)}
-      ${skeletonWidget(2)}
-    </div>
+    <div class="dashboard__grid">${tiles}</div>
   `;
 }
 


### PR DESCRIPTION
## Summary

- `renderDashboardSkeleton()` iteriert jetzt über `DEFAULT_WIDGET_CONFIG` statt 6 hartcodierten `skeletonWidget()`-Aufrufen ohne Grid-Wrapper
- Jedes Skeleton-Item erhält `widget-wrapper widget-size--{size}`, sodass Grid-Spanning identisch mit echtem Widget-Layout ist
- Verhindert CLS (Content Layout Shift) beim initialen Dashboard-Load (UX-AUDIT H7)

## Test plan

- [ ] Dashboard öffnen — Skeleton zeigt 9 Items in korrekten Größen (tasks/calendar als 2×2, weather/shopping/notes als 2×1, Rest als 1×1)
- [ ] Nach Laden kein sichtbarer Layout-Sprung
- [ ] Nutzerkonfiguration (gespeicherte Widget-Reihenfolge/-Sichtbarkeit) wird nach dem Laden korrekt übernommen

🤖 Generated with [Claude Code](https://claude.com/claude-code)