### PR TITLE
fix(css): disable backdrop-filter inside scroll container to fix blank screen on scroll

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The goal is a single, private place for everything that keeps a household runnin
 
 | Module | Description |
 |---|---|
-| **Tasks** | Shared tasks with deadlines, priorities, subtasks, and recurring schedules. Assign to multiple family members simultaneously with stacked avatar display. Kanban board with touch-friendly one-tap status buttons. Archive completed tasks to keep lists clean. Inline reminder presets (15 min to 2 weeks before due). |
+| **Tasks** | Shared tasks with deadlines, priorities, subtasks, and recurring schedules. Assign to multiple family members simultaneously with stacked avatar display. Kanban board with touch-friendly one-tap status buttons. Archive completed tasks to keep lists clean. Inline reminder presets (15 min to 2 weeks before due). Schedule tasks with a future start date — future tasks are hidden by default and revealed via a "Show scheduled" toggle. |
 | **Shopping Lists** | Collaborative lists organized by aisle. Import ingredients from meal plans in one click. |
 | **Meal Planning** | Weekly drag-and-drop planner. Export ingredient lists directly to your shopping list. |
 | **Recipes** | Create, duplicate, and scale reusable recipes. Pre-fill meal slots from a recipe or save any meal as a recipe. |

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -29,6 +29,7 @@ Every table: `id INTEGER PRIMARY KEY`, `created_at TEXT`, `updated_at TEXT` (ISO
 | status | TEXT | open, in_progress, done, archived |
 | due_date | TEXT | DATE, nullable |
 | due_time | TEXT | TIME, nullable |
+| start_date | TEXT | DATE, nullable — tasks with a future start date are hidden from the default list view |
 | assigned_to | INTEGER | FK → Users (legacy single-user field, kept for backwards compat) |
 | created_by | INTEGER | FK → Users, NOT NULL |
 | is_recurring | INTEGER | 0/1 |
@@ -674,12 +675,12 @@ Key-value table for OAuth tokens and CalDAV credentials.
 Responsive grid: 1 column on mobile, 2 on tablet, 3 on desktop.
 
 **Widgets:**
-- Greeting: "Good [morning/afternoon/evening], [Name]" + date
+- Greeting: "Good [morning/afternoon/evening], [Name]" + date; auto-refreshes on `visibilitychange` so the greeting stays current during long sessions
 - Weather: OpenWeatherMap proxy, 3-day preview, refresh every 30 min, hide widget on API error
 - Upcoming events: next 3–5, color-coded by person
 - Urgent tasks: priority urgent/high + due_date ≤48h
 - Today's meals: meals for the current day
-- Pinboard preview: 2–3 pinned notes
+- Pinboard preview: 2–3 pinned notes (Markdown formatting rendered)
 - FAB (quick actions): + Task, + Event, + Shopping list item, + Note
 
 **Widget sizes:** each widget has a configurable size using named presets (Tiny, Narrow, Standard, Large, Full) that map to `columns × rows` in the CSS grid. Sizes are persisted in user preferences and survive page reloads.
@@ -701,6 +702,7 @@ Skeleton loading instead of spinners. Clicking any widget navigates to that modu
 - Archive: completed tasks can be archived (status = 'archived'); visible in a separate Archived filter
 - Inline reminder presets: offset from due date/time — 15 min, 1 h, 1 d, 2 d, 1 w, 2 w, or fully custom offset
 - **Bulk actions (list view only):** select multiple tasks via checkboxes and apply batch operations (mark done, mark open, archive, delete); bulk select toggle in toolbar
+- **Start date:** tasks can have an optional start date; tasks with a future start date are hidden from the default list view to reduce cognitive load. A "Show scheduled" toggle chip in the filter bar reveals all upcoming planned tasks. Task cards display a "Starts on …" badge when a start date is set.
 - Mobile swipe: left = done, right = edit
 - Badge for overdue tasks
 
@@ -811,6 +813,7 @@ Unauthenticated users are redirected here. No public registration form - admin c
 - Username + password form
 - Error display for wrong credentials
 - Rate limiting: 5 attempts/min/IP, 15-min lockout
+- Password visibility toggle (eye/eye-off icon) to verify input before submitting
 - After successful login: redirect to dashboard
 
 ### Settings (`/settings`)
@@ -996,7 +999,7 @@ Source of truth: `public/styles/tokens.css`. Key values (as of v0.20.39):
 
 ### Typography
 - System font stack, headings 600–700
-- Body: 16px mobile, 15px desktop, line-height 1.5
+- Body: 16px, line-height 1.5
 - Caption: 13px, `var(--color-text-secondary)`
 
 ### Glass Layer (`public/styles/glass.css`)
@@ -1025,12 +1028,13 @@ Additive CSS file loaded globally after `layout.css`. Implements a Liquid Glass 
 - **Inputs:** `var(--radius-sm)`, 1.5px border, padding 12px 16px. Search inputs use `--radius-glass-button` and `--glass-border-subtle`. `[required]` fields receive validation status on blur (`.form-field--error` / `.form-field--valid`). Enter moves focus to the next field; Enter on the last field triggers submit.
 - **FAB (Floating Action Button):** Color follows the module accent token (`--module-accent`) - each module defines its own accent color. Specular inner highlight + attention ring pulse. Hidden when the virtual keyboard is open (`visualViewport.resize`, threshold 75% of window height).
 - **Module accent colors:** `--module-accent` is applied on three visual layers - (1) active nav tab (bottom bar + sidebar stripe), (2) toolbar `border-top: 3px`, (3) cards/rows `border-left: 3px`. The active accent is written to `--active-module-accent` on `:root` on every navigation change. Falls back to `--color-accent` for pages without a module context.
-- **Navigation:** Bottom tab bar on mobile (Dashboard, Tasks, Calendar, Meals, More), auto-hides on scroll-down. Sidebar on desktop. Both use glass blur surface.
+- **Navigation:** Bottom tab bar on mobile (Dashboard, Calendar, Tasks, Notes + Kitchen button + More button), auto-hides on scroll-down. Sidebar on desktop. Both use glass blur surface. The Kitchen button dynamically shows the icon and label of the last visited kitchen section (Meals / Recipes / Shopping).
 - **Transitions:** Directional slide-X animation on page change (forward = from right, back = from left, 200ms) with spring easing. Respects `prefers-reduced-motion`.
 - **Empty states:** Consistent `.empty-state` class across all modules (icon + title + description, centered). Compact variant `.empty-state--compact` for meal slots.
 - **Modals:** Centered panel on desktop with glass overlay. On mobile (< 768px) bottom sheet - spring slide-in from below, sheet handle visible, swipe-to-close (> 80px downward). `focusin` scrolls inputs into view when the virtual keyboard is open.
 - **List animation:** Staggered spring fade-in on load (`stagger()` from `public/utils/ux.js`) - max 5 elements staggered (30ms gap), rest appear immediately.
 - **Vibration:** `vibrate()` from `public/utils/ux.js` - short pulses for light actions (10-40ms), pattern `[30, 50, 30]` for destructive actions (delete). Respects `prefers-reduced-motion`.
+- **Global search overlay:** Full-text search across tasks, calendar events, notes, contacts, and shopping items. Results are grouped by module and trigger deep-link navigation: contacts via `?open=<id>` (opens edit modal directly), calendar events via `?open=<id>`, notes via `?open=<id>`, shopping items via `?list=<id>&highlight=<id>` (activates the correct list tab and scrolls the item into view). Activated from the search bar in the More-Sheet.
 - **PWA install prompt:** Appears only after 2 user interactions. Dismiss window 7 days; interaction counter resets after dismiss.
 - **PWA offline fallback:** Service worker serves `/offline.html` when the network is unreachable and `index.html` is not cached. Includes a reload button.
 

--- a/public/styles/glass.css
+++ b/public/styles/glass.css
@@ -412,10 +412,23 @@ textarea.form-input {
   animation-timing-function: var(--ease-out);
 }
 
+/* Blank-Screen-on-Scroll Prevention (iOS 26+ WebKit + Android Blink):
+ * Jedes Element mit backdrop-filter innerhalb von overflow:auto wird vom Browser
+ * als eigenständige Compositor-GPU-Layer gerendert. Bei vielen solchen Layern
+ * (Task-Cards, Note-Items, Widgets, Inputs) scheitert der Compositor auf mobilen
+ * Geräten beim Scrollen → kompletter Weißbild-/Leerbild-Fehler.
+ * Elemente AUSSERHALB von .app-content (nav-bottom, Modals, Toasts) behalten
+ * ihren backdrop-filter-Blur unverändert — nur der Scroll-Container ist betroffen.
+ * Referenz: Issue #166 (iOS), nachgemeldet auch auf Android. */
+.app-content *,
+.app-content *::before,
+.app-content *::after {
+  backdrop-filter: none !important;
+  -webkit-backdrop-filter: none !important;
+}
+
 /* Performance: backdrop-filter deaktivieren während Seitenübergängen.
- * Auf Android verursachen viele gleichzeitige backdrop-filter-Layer
- * (Widgets, Cards, Inputs) hohen GPU-Aufwand → Transition wirkt träge.
- * html.navigating wird von router.js für die Dauer des Übergangs gesetzt. */
+ * (Superset der obigen Regel — bleibt für semantische Klarheit erhalten.) */
 html.navigating .app-content *,
 html.navigating .app-content *::before,
 html.navigating .app-content *::after {


### PR DESCRIPTION
## Summary

- Fixes the blank screen on scroll bug (#166), which persisted on both iOS (Safari/WebKit) and Android (Chrome/Blink) after the partial fix in v0.52.22
- Root cause: `glass.css` applied `backdrop-filter` to all task cards, note items, dashboard widgets, form inputs, meal slots, group-toggles and skeleton loaders inside the `overflow:auto` scroll container — each becoming a separate GPU compositor layer, causing the mobile compositor to fail when scrolling begins
- Fix: a single permanent CSS rule disables `backdrop-filter` for all `.app-content` children; elements outside the scroll container (nav-bottom, modals, toasts) retain their blur effects

## Test plan

- [ ] Open Oikos on an iOS device (Safari) and scroll on any page — no blank screen
- [ ] Open Oikos on an Android device (Chrome) and scroll on any page — no blank screen
- [ ] Open Oikos in a narrow-viewport desktop Chrome — no blank screen on scroll
- [ ] Verify Bottom-Nav still shows glass blur effect (outside scroll container)
- [ ] Verify modals still show glass blur effect (inserted into `body`, outside `.app-content`)
- [ ] Verify toast notifications still show glass blur effect (position: fixed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)