### PR TITLE
fix(css): reset overflow:clip + isolation:isolate on .dashboard to fix blank-screen on scroll

### DIFF
--- a/public/styles/dashboard.css
+++ b/public/styles/dashboard.css
@@ -2029,6 +2029,10 @@
  * -------------------------------------------------------- */
 .dashboard {
   max-width: min(1680px, 100%);
+  /* isolation:isolate + overflow:clip (Modern Skin) cause blank-screen on scroll on iOS WebKit.
+   * The blob decorations they were meant to contain are hidden, so both can be reset. */
+  isolation: auto;
+  overflow: visible;
 }
 
 .dashboard::before,


### PR DESCRIPTION
## Summary

- The Modern Dashboard Skin section of `dashboard.css` set `overflow: clip` and `isolation: isolate` on `.dashboard` to contain decorative blob pseudo-elements (`.dashboard::before/::after`)
- The Admin Dashboard Layout section later hid those blobs with `display: none` but never reset the `overflow` and `isolation` properties
- On iOS 26+ WebKit, `overflow: clip` inside an `overflow: auto` scroll container blocks the browser from repainting scroll content during scroll → blank screen, with only compositor-promoted elements (e.g. the dashboard-overview border-top) remaining visible
- Fix: reset both properties to their initial values (`isolation: auto`, `overflow: visible`) in the Admin Dashboard Layout section

## Test plan

- [ ] Open Dashboard on iOS (Safari or PWA) and scroll/swipe — page content must remain visible
- [ ] Verify all widgets render correctly (no layout regressions)
- [ ] Verify the Dashboard on desktop still looks correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)