### PR TITLE
feat: UX/UI Phase 1–3 – fluid type, module-tinted bg, glass forms, colored more-sheet icon wells

### DIFF
--- a/public/router.js
+++ b/public/router.js
@@ -1167,19 +1167,23 @@ function sidebarKitchenEl() {
   return a;
 }
 
-function moreItemEl({ path, label, icon }) {
+function moreItemEl({ path, label, icon, module: mod }) {
   const a = document.createElement('a');
   a.href = path;
   a.dataset.route = path;
   a.className = 'more-item';
+  if (mod) a.style.setProperty('--item-module-accent', `var(--module-${mod})`);
+  const well = document.createElement('div');
+  well.className = 'more-item__icon-well';
   const i = document.createElement('i');
   i.dataset.lucide = icon;
   i.className = 'more-item__icon';
   i.setAttribute('aria-hidden', 'true');
+  well.appendChild(i);
   const span = document.createElement('span');
   span.className = 'more-item__label';
   span.textContent = label;
-  a.appendChild(i);
+  a.appendChild(well);
   a.appendChild(span);
   return a;
 }

--- a/public/styles/glass.css
+++ b/public/styles/glass.css
@@ -223,9 +223,9 @@ textarea.form-input {
 
 .input:focus,
 .form-input:focus {
-  border-color: var(--color-accent);
+  border-color: var(--active-module-accent, var(--color-accent));
   box-shadow:
-    0 0 0 3px color-mix(in srgb, var(--color-accent) 20%, transparent),
+    0 0 0 3px color-mix(in srgb, var(--active-module-accent, var(--color-accent)) 20%, transparent),
     var(--glass-inset-input);
 }
 
@@ -742,8 +742,13 @@ html.navigating .app-content *::after {
   background:
     radial-gradient(
       ellipse at 20% 0%,
-      color-mix(in srgb, var(--module-accent, var(--color-accent)) 3%, transparent),
+      color-mix(in srgb, var(--active-module-accent, var(--color-accent)) 5%, transparent),
       transparent 60%
+    ),
+    radial-gradient(
+      ellipse at 85% 90%,
+      color-mix(in srgb, var(--active-module-accent, var(--color-accent)) 3%, transparent),
+      transparent 50%
     ),
     var(--color-bg);
 }

--- a/public/styles/layout.css
+++ b/public/styles/layout.css
@@ -341,9 +341,27 @@
   background-color: color-mix(in srgb, var(--active-module-accent, var(--color-accent)) 12%, transparent);
 }
 
+.more-item__icon-well {
+  width: 36px;
+  height: 36px;
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--item-module-accent, var(--color-text-secondary)) 12%, transparent);
+  color: var(--item-module-accent, var(--color-text-secondary));
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  transition: background-color var(--transition-fast), color var(--transition-fast);
+}
+
+.more-item[aria-current="page"] .more-item__icon-well {
+  background: color-mix(in srgb, var(--active-module-accent, var(--color-accent)) 20%, transparent);
+  color: var(--active-module-accent, var(--color-accent));
+}
+
 .more-item__icon {
-  width: var(--space-6);
-  height: var(--space-6);
+  width: 18px;
+  height: 18px;
   flex-shrink: 0;
 }
 
@@ -800,12 +818,15 @@ html.fab-anim-done .page-fab {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: var(--space-5);
+  margin-bottom: var(--space-6);
+  padding-bottom: var(--space-4);
   gap: var(--space-4);
+  border-bottom: 1px solid var(--color-border-subtle);
 }
 
 .page__title {
-  font-size: var(--text-xl);
+  /* Fluid: 20px (375px viewport) → 30px (1440px viewport) */
+  font-size: clamp(1.25rem, 0.94vw + 1.03rem, 1.875rem);
   font-weight: var(--font-weight-bold);
   letter-spacing: -0.5px;
   text-wrap: balance;
@@ -817,7 +838,6 @@ html.fab-anim-done .page-fab {
   }
 
   .page__title {
-    font-size: var(--text-2xl);
     letter-spacing: -0.8px;
   }
 }


### PR DESCRIPTION
## Summary

- **Fluid typography**: Page titles scale smoothly 20px→30px across viewports (375px–1440px) via `clamp()`
- **Module-tinted background**: App-shell ambient gradients now correctly track the active module color (`--active-module-accent`); adds a second gradient blob at bottom-right for more depth
- **Module-aware form focus**: Input focus rings adopt the active module accent instead of always being violet
- **Colored more-sheet icon wells**: Each item in the "more" navigation sheet gets a tinted rounded-square icon well using its module color

## Fixes

- Bug: `.app-shell` background gradient was using `--module-accent` (scoped to child page components, does not cascade upward) instead of `--active-module-accent` (set on `<html>` by router.js). The tint was never visible before this fix.

## Test plan

- [ ] Navigate between modules — verify app-shell background subtly shifts hue
- [ ] Open a form input — verify focus ring matches module color
- [ ] Open the "more" sheet — verify each item has a colored icon well
- [ ] Resize viewport — verify page titles scale fluidly without jumping

🤖 Generated with [Claude Code](https://claude.com/claude-code)