### PR TITLE
feat: UX items 11–13 – icon-wells, login bg, metric colors

### DIFF
--- a/public/styles/dashboard.css
+++ b/public/styles/dashboard.css
@@ -1875,10 +1875,10 @@
   min-height: calc(var(--target-lg) + var(--space-12));
   height: 100%;
   padding: var(--space-3);
-  border: 1px solid var(--color-border);
+  border: 1px solid color-mix(in srgb, var(--today-card-accent) 22%, var(--color-border));
   border-inline-start: var(--space-1) solid var(--today-card-accent);
   border-radius: var(--radius-sm);
-  background: var(--color-surface);
+  background: color-mix(in srgb, var(--today-card-accent) 5%, var(--color-surface));
   color: var(--color-text-primary);
   text-align: left;
   cursor: pointer;
@@ -1888,8 +1888,8 @@
 
 .today-cockpit-card:hover,
 .today-cockpit-card:focus-visible {
-  border-color: color-mix(in srgb, var(--today-card-accent) 42%, var(--color-border));
-  background: color-mix(in srgb, var(--today-card-accent) 5%, var(--color-surface));
+  border-color: color-mix(in srgb, var(--today-card-accent) 50%, var(--color-border));
+  background: color-mix(in srgb, var(--today-card-accent) 9%, var(--color-surface));
   box-shadow: var(--shadow-xs);
 }
 
@@ -1900,8 +1900,9 @@
   width: var(--target-sm);
   height: var(--target-sm);
   border-radius: var(--radius-sm);
-  background: color-mix(in srgb, var(--today-card-accent) 12%, transparent);
+  background: color-mix(in srgb, var(--today-card-accent) 18%, var(--color-surface-elevated));
   color: var(--today-card-accent);
+  box-shadow: inset 0 1px 0 color-mix(in srgb, white 25%, transparent);
   grid-row: 1 / span 2;
 }
 
@@ -1921,7 +1922,7 @@
 
 .today-cockpit-card__value {
   align-self: start;
-  color: var(--color-text-primary);
+  color: var(--today-card-accent);
   font-size: var(--text-base);
   font-weight: var(--font-weight-bold);
   line-height: var(--line-height-snug);
@@ -2026,6 +2027,26 @@
 .dashboard-stat--weather .dashboard-stat__icon {
   background: color-mix(in srgb, var(--module-dashboard) 16%, transparent);
   color: var(--module-dashboard);
+}
+
+.dashboard-stat--tasks .dashboard-stat__icon {
+  background: color-mix(in srgb, var(--module-tasks) 16%, transparent);
+  color: var(--module-tasks);
+}
+
+.dashboard-stat--shopping .dashboard-stat__icon {
+  background: color-mix(in srgb, var(--module-shopping) 16%, transparent);
+  color: var(--module-shopping);
+}
+
+.dashboard-stat--notes .dashboard-stat__icon {
+  background: color-mix(in srgb, var(--module-notes) 16%, transparent);
+  color: var(--module-notes);
+}
+
+.dashboard-stat--budget .dashboard-stat__icon {
+  background: color-mix(in srgb, var(--module-budget) 16%, transparent);
+  color: var(--module-budget);
 }
 
 .dashboard-stat__text {

--- a/public/styles/layout.css
+++ b/public/styles/layout.css
@@ -352,17 +352,18 @@
   width: 36px;
   height: 36px;
   border-radius: var(--radius-sm);
-  background: color-mix(in srgb, var(--item-module-accent, var(--color-text-secondary)) 12%, transparent);
+  background: color-mix(in srgb, var(--item-module-accent, var(--color-text-secondary)) 20%, var(--color-surface-elevated));
   color: var(--item-module-accent, var(--color-text-secondary));
   display: flex;
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
+  box-shadow: inset 0 1px 0 color-mix(in srgb, white 28%, transparent);
   transition: background-color var(--transition-fast), color var(--transition-fast);
 }
 
 .more-item[aria-current="page"] .more-item__icon-well {
-  background: color-mix(in srgb, var(--active-module-accent, var(--color-accent)) 20%, transparent);
+  background: color-mix(in srgb, var(--active-module-accent, var(--color-accent)) 26%, var(--color-surface-elevated));
   color: var(--active-module-accent, var(--color-accent));
 }
 

--- a/public/styles/login.css
+++ b/public/styles/login.css
@@ -14,14 +14,19 @@
   padding: var(--space-4);
   background:
     radial-gradient(
-      ellipse 160% 60% at 50% -10%,
-      color-mix(in srgb, var(--color-accent) 8%, transparent),
-      transparent 65%
+      ellipse 200% 70% at 50% -20%,
+      color-mix(in srgb, var(--color-accent) 18%, transparent),
+      transparent 62%
     ),
     radial-gradient(
-      ellipse 100% 40% at 100% 100%,
-      color-mix(in srgb, var(--color-accent-active) 5%, transparent),
-      transparent 60%
+      ellipse 90% 50% at 105% 110%,
+      color-mix(in srgb, var(--color-accent-active) 12%, transparent),
+      transparent 55%
+    ),
+    radial-gradient(
+      ellipse 60% 40% at -10% 55%,
+      color-mix(in srgb, var(--color-accent) 8%, transparent),
+      transparent 58%
     ),
     var(--color-bg);
 }


### PR DESCRIPTION
## Summary

- **Item 11 – More-Sheet Icon-Wells**: Background opacity raised from 12 % → 20 %, mixed with `--color-surface-elevated` instead of `transparent` so colours render correctly in both light and dark mode. Active state 20 % → 26 %. Subtle inset top-highlight (`inset 0 1px 0 white/28 %`) gives each well an iOS-style gloss.
- **Item 12 – Login Branded Background**: Top radial gradient enlarged and strengthened (8 % → 18 %), bottom-right stop 5 % → 12 %, new left-centre radial (8 %) for a three-point colour wash that makes the login page feel distinctively branded.
- **Item 13 – Dashboard Metric modul-spezifisch**: `today-cockpit-card` now carries a permanent 5 % module-colour background tint (was plain surface), icon wells 12 % → 18 % with surface base + inset highlight, value text uses `--today-card-accent` instead of generic `--color-text-primary`. Added four missing `dashboard-stat` icon-colour variants: `--tasks`, `--shopping`, `--notes`, `--budget`.

## Test plan

- [ ] More-Sheet: open on mobile, each icon well should show a clearly tinted background matching its module colour
- [ ] Login page: background should show a soft but visible colour wash around edges and top
- [ ] Dashboard "Heute"-cockpit: each of the four cards (Aufgabe / Termin / Einkauf / Abendessen) should have a tinted background, coloured icon, and coloured value text
- [ ] Both light and dark mode: colours remain readable (no white-on-white or black-on-black)
- [ ] `prefers-reduced-transparency`: verify no visual regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)