### PR TITLE
ux: größere, rundere Icon-Wells in der Bottom-Nav

### DIFF
--- a/public/styles/layout.css
+++ b/public/styles/layout.css
@@ -544,7 +544,7 @@
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
-  border-radius: var(--radius-xs);
+  border-radius: var(--radius-sm);
   background: color-mix(in srgb, var(--item-module-accent, var(--color-text-secondary)) 18%, var(--color-surface-elevated));
   color: var(--item-module-accent, var(--color-text-secondary));
   box-shadow: inset 0 1px 0 color-mix(in srgb, white 28%, transparent);
@@ -552,8 +552,8 @@
 }
 
 .nav-bottom .nav-item__icon-well {
-  width: 32px;
-  height: 32px;
+  width: 36px;
+  height: 36px;
 }
 
 .nav-sidebar .nav-item__icon-well {


### PR DESCRIPTION
## Summary

- Icon-Wells in der Bottom-Nav von 32×32 auf 36×36 px vergrößert
- Border-Radius aller Icon-Wells von `--radius-xs` (4 px) auf `--radius-sm` (8 px) erhöht
- Wells sind jetzt konsistent mit den Icon-Wells im More-Sheet

## Test plan

- [ ] Bottom-Nav auf mobiler Ansicht prüfen: Icons wirken größer und runder
- [ ] More-Sheet öffnen: Wells sollten optisch konsistent mit der Bottom-Nav sein
- [ ] Dark Mode prüfen
- [ ] Sidebar auf Desktop unverändert

🤖 Generated with [Claude Code](https://claude.com/claude-code)