### PR TITLE
fix(tasks): allow date separator input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Allow task date fields to accept slash and hyphen separators when creating or editing tasks.
+
 ## [0.52.53] - 2026-05-25
 
 ### Fixed

--- a/public/i18n.js
+++ b/public/i18n.js
@@ -169,14 +169,14 @@ export function parseDateInput(value) {
   const isoMatch = raw.match(/^(\d{4})-(\d{2})-(\d{2})$/);
   if (isoMatch) return isValidDateParts(isoMatch[1], isoMatch[2], isoMatch[3]) ? raw : '';
 
-  const ymdSeparatorMatch = raw.match(/^(\d{4})[\/.](\d{1,2})[\/.](\d{1,2})$/);
+  const ymdSeparatorMatch = raw.match(/^(\d{4})[\/.-](\d{1,2})[\/.-](\d{1,2})$/);
   if (ymdSeparatorMatch && getDateFormatPreference().startsWith('ymd')) {
     const [, year, month, day] = ymdSeparatorMatch;
     if (!isValidDateParts(year, month, day)) return '';
     return `${year}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
   }
 
-  const slashMatch = raw.match(/^(\d{1,2})[\/.](\d{1,2})[\/.](\d{4})$/);
+  const slashMatch = raw.match(/^(\d{1,2})[\/.-](\d{1,2})[\/.-](\d{4})$/);
   if (!slashMatch) return '';
 
   const [, first, second, year] = slashMatch;

--- a/public/pages/tasks.js
+++ b/public/pages/tasks.js
@@ -370,14 +370,14 @@ function renderModalContent({ task = null, users = [], reminder = null } = {}) {
       <div class="form-group" style="margin-top:var(--space-4)">
         <label class="label" for="task-start-date">${t('tasks.startDateLabel')}</label>
         <input class="input js-date-input" type="text" id="task-start-date" name="start_date"
-               value="${formatDateInput(task?.start_date)}" placeholder="${dateInputPlaceholder()}" inputmode="numeric">
+               value="${formatDateInput(task?.start_date)}" placeholder="${dateInputPlaceholder()}" inputmode="text">
       </div>
 
       <div class="modal-grid modal-grid--2" style="margin-top:var(--space-4)">
         <div class="form-group">
           <label class="label" for="task-due-date">${t('tasks.dueDateLabel')}</label>
           <input class="input js-date-input" type="text" id="task-due-date" name="due_date"
-                 value="${formatDateInput(task?.due_date)}" placeholder="${dateInputPlaceholder()}" inputmode="numeric">
+                 value="${formatDateInput(task?.due_date)}" placeholder="${dateInputPlaceholder()}" inputmode="text">
         </div>
         <div class="form-group">
           <label class="label" for="task-due-time">${t('tasks.dueTimeLabel')}</label>

--- a/public/rrule-ui.js
+++ b/public/rrule-ui.js
@@ -110,7 +110,7 @@ export function renderRRuleFields(prefix, existingRule) {
           <div class="form-group rrule-until-field" style="margin-bottom:0">
             <label class="label form-label" for="${prefix}-rrule-until">${t('rrule.labelUntil')}</label>
             <input class="input form-input js-date-input" type="text" id="${prefix}-rrule-until"
-                   value="${formatDateInput(parsed.until)}" placeholder="${dateInputPlaceholder()}" inputmode="numeric">
+                   value="${formatDateInput(parsed.until)}" placeholder="${dateInputPlaceholder()}" inputmode="text">
           </div>
         </div>
 

--- a/test-ux-utils.js
+++ b/test-ux-utils.js
@@ -4,6 +4,7 @@
  */
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
 
 // Minimales Window/Navigator-Mock für Node
 const { stagger, vibrate, deleteWithUndo } = await (async () => {
@@ -20,12 +21,44 @@ const { stagger, vibrate, deleteWithUndo } = await (async () => {
   return import('./public/utils/ux.js');
 })();
 
+const dateStore = new Map();
+global.localStorage = {
+  getItem: (key) => dateStore.get(key) ?? null,
+  setItem: (key, value) => dateStore.set(key, String(value)),
+  removeItem: (key) => dateStore.delete(key),
+};
+
+const { parseDateInput, isDateInputValid } = await import('./public/i18n.js');
+
 test('stagger: setzt opacity:0 auf alle Elemente', () => {
   const els = [{ style: {} }, { style: {} }, { style: {} }];
   stagger(els, { delay: 0, duration: 0 });
   assert.equal(els[0].style.opacity, '0');
   assert.equal(els[1].style.opacity, '0');
   assert.equal(els[2].style.opacity, '0');
+});
+
+test('date inputs: accept slash, dot, and hyphen separators for DMY dates', () => {
+  localStorage.setItem('oikos-date-format', 'dmy');
+  assert.equal(parseDateInput('26/05/2026'), '2026-05-26');
+  assert.equal(parseDateInput('26.05.2026'), '2026-05-26');
+  assert.equal(parseDateInput('26-05-2026'), '2026-05-26');
+  assert.equal(isDateInputValid('26-05-2026'), true);
+});
+
+test('date inputs: accept hyphen separators for YMD dates', () => {
+  localStorage.setItem('oikos-date-format', 'ymd');
+  assert.equal(parseDateInput('2026-5-6'), '2026-05-06');
+  assert.equal(parseDateInput('2026/05/06'), '2026-05-06');
+  assert.equal(parseDateInput('2026.05.06'), '2026-05-06');
+});
+
+test('task create date fields use a keyboard that allows separators', () => {
+  const tasksSource = readFileSync(new URL('./public/pages/tasks.js', import.meta.url), 'utf8');
+  const rruleSource = readFileSync(new URL('./public/rrule-ui.js', import.meta.url), 'utf8');
+  assert.match(tasksSource, /name="start_date"[\s\S]*?inputmode="text"/);
+  assert.match(tasksSource, /name="due_date"[\s\S]*?inputmode="text"/);
+  assert.match(rruleSource, /id="\$\{prefix\}-rrule-until"[\s\S]*?inputmode="text"/);
 });
 
 test('stagger: tut nichts bei prefers-reduced-motion', () => {


### PR DESCRIPTION
## Summary

Closes #177

Fixes task date inputs so mobile users can type common date separators such as `/` and `-`.

## Changes

- Change task start date and due date fields to use `inputmode="text"`
- Change recurrence until date field to use `inputmode="text"`
- Allow hyphen separators in shared date parsing
- Add regression coverage for date separators and task date input mode
- Add changelog entry

## Checklist

- [x] `npm test` passes
- [x] Follows CONTRIBUTING.md conventions
- [x] No new frontend dependencies (vanilla JS, no frameworks)
- [x] UI strings use `t('key')` (no hardcoded text)
- [x] CHANGELOG.md updated