### PR TITLE
feat(nav): Liquid Glass Navigation mit Custom Icons und morphenden Indikatoren

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -29,6 +29,7 @@
   <!-- Preload: kritische ES-Module (modulepreload ist korrekt für type="module") -->
   <link rel="modulepreload" href="/api.js" />
   <link rel="modulepreload" href="/router.js" />
+  <link rel="modulepreload" href="/nav-icons.js" />
   <link rel="modulepreload" href="/rrule-ui.js" />
 
   <!-- Theme: explizite Nutzer-Overrides vor CSS-Rendering anwenden (Flash-Prevention).

--- a/public/locales/ar.json
+++ b/public/locales/ar.json
@@ -57,7 +57,8 @@
     "search": "بحث",
     "housekeeping": "Housekeeping",
     "splitExpenses": "تقسيم",
-    "kitchenActiveLabel": "المطبخ، {{section}} نشط"
+    "kitchenActiveLabel": "المطبخ، {{section}} نشط",
+    "section.household": "المنزل"
   },
   "dashboard": {
     "title": "لوحة التحكم",

--- a/public/locales/de.json
+++ b/public/locales/de.json
@@ -57,7 +57,8 @@
     "search": "Suche",
     "housekeeping": "Hauspflege",
     "splitExpenses": "Aufteilen",
-    "kitchenActiveLabel": "Küche, {{section}} aktiv"
+    "kitchenActiveLabel": "Küche, {{section}} aktiv",
+    "section.household": "Haushalt"
   },
   "search": {
     "title": "Suche",

--- a/public/locales/el.json
+++ b/public/locales/el.json
@@ -57,7 +57,8 @@
     "search": "Αναζήτηση",
     "housekeeping": "Housekeeping",
     "splitExpenses": "Μοίρασμα",
-    "kitchenActiveLabel": "Κουζίνα, {{section}} ενεργό"
+    "kitchenActiveLabel": "Κουζίνα, {{section}} ενεργό",
+    "section.household": "Νοικοκυριό"
   },
   "dashboard": {
     "title": "Επισκόπηση",

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -57,7 +57,8 @@
     "search": "Search",
     "housekeeping": "Housekeeping",
     "splitExpenses": "Split",
-    "kitchenActiveLabel": "Kitchen, {{section}} active"
+    "kitchenActiveLabel": "Kitchen, {{section}} active",
+    "section.household": "Household"
   },
   "dashboard": {
     "title": "Overview",

--- a/public/locales/es.json
+++ b/public/locales/es.json
@@ -57,7 +57,8 @@
     "search": "Buscar",
     "housekeeping": "Limpieza",
     "splitExpenses": "Dividir",
-    "kitchenActiveLabel": "Cocina, {{section}} activo"
+    "kitchenActiveLabel": "Cocina, {{section}} activo",
+    "section.household": "Hogar"
   },
   "dashboard": {
     "title": "Inicio",

--- a/public/locales/fr.json
+++ b/public/locales/fr.json
@@ -57,7 +57,8 @@
     "search": "Recherche",
     "housekeeping": "Ménage",
     "splitExpenses": "Partager",
-    "kitchenActiveLabel": "Cuisine, {{section}} actif"
+    "kitchenActiveLabel": "Cuisine, {{section}} actif",
+    "section.household": "Maison"
   },
   "dashboard": {
     "title": "Accueil",

--- a/public/locales/hi.json
+++ b/public/locales/hi.json
@@ -57,7 +57,8 @@
     "search": "खोज",
     "housekeeping": "Housekeeping",
     "splitExpenses": "बांटें",
-    "kitchenActiveLabel": "रसोई, {{section}} सक्रिय"
+    "kitchenActiveLabel": "रसोई, {{section}} सक्रिय",
+    "section.household": "घरेलू"
   },
   "dashboard": {
     "title": "डैशबोर्ड",

--- a/public/locales/it.json
+++ b/public/locales/it.json
@@ -57,7 +57,8 @@
     "search": "Cerca",
     "housekeeping": "Pulizie",
     "splitExpenses": "Dividi",
-    "kitchenActiveLabel": "Cucina, {{section}} attiva"
+    "kitchenActiveLabel": "Cucina, {{section}} attiva",
+    "section.household": "Casa"
   },
   "dashboard": {
     "title": "Panoramica",

--- a/public/locales/ja.json
+++ b/public/locales/ja.json
@@ -57,7 +57,8 @@
     "search": "検索",
     "housekeeping": "Housekeeping",
     "splitExpenses": "分割",
-    "kitchenActiveLabel": "キッチン、{{section}} がアクティブ"
+    "kitchenActiveLabel": "キッチン、{{section}} がアクティブ",
+    "section.household": "家庭"
   },
   "dashboard": {
     "title": "ダッシュボード",

--- a/public/locales/pl.json
+++ b/public/locales/pl.json
@@ -57,7 +57,8 @@
     "search": "Szukaj",
     "housekeeping": "Sprzątanie",
     "splitExpenses": "Podział",
-    "kitchenActiveLabel": "Kuchnia, {{section}} aktywne"
+    "kitchenActiveLabel": "Kuchnia, {{section}} aktywne",
+    "section.household": "Gospodarstwo"
   },
   "search": {
     "title": "Szukaj",

--- a/public/locales/pt.json
+++ b/public/locales/pt.json
@@ -57,7 +57,8 @@
     "search": "Pesquisar",
     "housekeeping": "Faxina",
     "splitExpenses": "Dividir",
-    "kitchenActiveLabel": "Cozinha, {{section}} ativo"
+    "kitchenActiveLabel": "Cozinha, {{section}} ativo",
+    "section.household": "Casa"
   },
   "dashboard": {
     "title": "Painel",

--- a/public/locales/ru.json
+++ b/public/locales/ru.json
@@ -57,7 +57,8 @@
     "search": "Поиск",
     "housekeeping": "Housekeeping",
     "splitExpenses": "Разделить",
-    "kitchenActiveLabel": "Кухня, {{section}} активно"
+    "kitchenActiveLabel": "Кухня, {{section}} активно",
+    "section.household": "Хозяйство"
   },
   "dashboard": {
     "title": "Обзор",

--- a/public/locales/sv.json
+++ b/public/locales/sv.json
@@ -57,7 +57,8 @@
     "search": "Sök",
     "housekeeping": "Städning",
     "splitExpenses": "Dela",
-    "kitchenActiveLabel": "Kök, {{section}} aktivt"
+    "kitchenActiveLabel": "Kök, {{section}} aktivt",
+    "section.household": "Hushåll"
   },
   "dashboard": {
     "title": "Översikt",

--- a/public/locales/tr.json
+++ b/public/locales/tr.json
@@ -57,7 +57,8 @@
     "search": "Ara",
     "housekeeping": "Housekeeping",
     "splitExpenses": "Böl",
-    "kitchenActiveLabel": "Mutfak, {{section}} aktif"
+    "kitchenActiveLabel": "Mutfak, {{section}} aktif",
+    "section.household": "Ev"
   },
   "dashboard": {
     "title": "Genel Bakış",

--- a/public/locales/uk.json
+++ b/public/locales/uk.json
@@ -57,7 +57,8 @@
     "search": "Пошук",
     "housekeeping": "Прибирання",
     "splitExpenses": "Поділ",
-    "kitchenActiveLabel": "Кухня, {{section}} активно"
+    "kitchenActiveLabel": "Кухня, {{section}} активно",
+    "section.household": "Господарство"
   },
   "dashboard": {
     "title": "Огляд",

--- a/public/locales/zh.json
+++ b/public/locales/zh.json
@@ -57,7 +57,8 @@
     "search": "搜索",
     "housekeeping": "Housekeeping",
     "splitExpenses": "分摊",
-    "kitchenActiveLabel": "厨房，{{section}} 已激活"
+    "kitchenActiveLabel": "厨房，{{section}} 已激活",
+    "section.household": "家庭"
   },
   "dashboard": {
     "title": "概览",

--- a/public/nav-icons.js
+++ b/public/nav-icons.js
@@ -1,0 +1,148 @@
+/**
+ * Modul: Nav Icons
+ * Zweck: Eigener monoliniger Icon-Set für die Oikos-Navigation (1.6px Strich, 24×24).
+ * Jedes Icon ist eine Fabrikfunktion, die ein fertig konfiguriertes SVG-Element via
+ * createElementNS zurückgibt — kein innerHTML, kein insertAdjacentHTML.
+ *
+ * Schlüssel = Lucide-Icon-Name der navItems()-Definition.
+ * Aufruf: NAV_ICONS['calendar']?.()  → SVGElement
+ */
+
+const NS = 'http://www.w3.org/2000/svg';
+
+function makeSvg(...children) {
+  const s = document.createElementNS(NS, 'svg');
+  s.setAttribute('viewBox', '0 0 24 24');
+  s.setAttribute('fill', 'none');
+  s.setAttribute('stroke', 'currentColor');
+  s.setAttribute('stroke-width', '1.6');
+  s.setAttribute('stroke-linecap', 'round');
+  s.setAttribute('stroke-linejoin', 'round');
+  s.setAttribute('aria-hidden', 'true');
+  for (const child of children) s.appendChild(child);
+  return s;
+}
+
+function e(tag, attrs) {
+  const el = document.createElementNS(NS, tag);
+  for (const [k, v] of Object.entries(attrs)) el.setAttribute(k, v);
+  return el;
+}
+
+export const NAV_ICONS = {
+  'layout-dashboard': () => makeSvg(
+    e('rect', { x: '3.5', y: '3.5', width: '7.5', height: '7.5', rx: '2.2' }),
+    e('rect', { x: '13',  y: '3.5', width: '7.5', height: '5',   rx: '2'   }),
+    e('rect', { x: '13',  y: '10.5', width: '7.5', height: '10', rx: '2.2' }),
+    e('rect', { x: '3.5', y: '12.5', width: '7.5', height: '8',  rx: '2'   }),
+  ),
+
+  'calendar': () => {
+    const s = makeSvg(
+      e('rect', { x: '3.5', y: '5.5', width: '17', height: '15', rx: '3' }),
+      e('path', { d: 'M3.5 10h17' }),
+      e('path', { d: 'M8 3.2v4.6M16 3.2v4.6' }),
+    );
+    for (const [cx, cy] of [['8.5','14.5'],['12','14.5'],['15.5','14.5']]) {
+      const c = e('circle', { cx, cy, r: '.9' });
+      c.setAttribute('fill', 'currentColor');
+      c.setAttribute('stroke', 'none');
+      s.appendChild(c);
+    }
+    return s;
+  },
+
+  'check-square': () => makeSvg(
+    e('rect', { x: '3.5', y: '3.5', width: '17', height: '17', rx: '4.5' }),
+    e('path', { d: 'm8 12.3 2.8 2.8 5.6-5.6' }),
+  ),
+
+  'sticky-note': () => makeSvg(
+    e('path', { d: 'M5.5 4.5h9.5L18.5 8v11a1.5 1.5 0 0 1-1.5 1.5H5.5A1.5 1.5 0 0 1 4 19V6a1.5 1.5 0 0 1 1.5-1.5z' }),
+    e('path', { d: 'M15 4.5V7a1.5 1.5 0 0 0 1.5 1.5H19' }),
+    e('path', { d: 'M8 13h7M8 16.5h5' }),
+  ),
+
+  'cake': () => {
+    const s = makeSvg(
+      e('path', { d: 'M4 19.5h16' }),
+      e('path', { d: 'M5.5 19.5v-6.2a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v6.2' }),
+      e('path', { d: 'M5.5 15c1.2.8 1.8.8 3 0s1.8-.8 3 0 1.8.8 3 0 1.8-.8 3 0' }),
+      e('path', { d: 'M12 7.5v3.8' }),
+    );
+    const flame = e('path', { d: 'M12 4.5c.8.6.8 1.4 0 2-.8-.6-.8-1.4 0-2z' });
+    flame.setAttribute('fill', 'currentColor');
+    s.appendChild(flame);
+    return s;
+  },
+
+  'book-user': () => makeSvg(
+    e('rect', { x: '3.5', y: '4', width: '17', height: '16', rx: '3' }),
+    e('circle', { cx: '10', cy: '11', r: '2.4' }),
+    e('path', { d: 'M6.5 17.5c.6-2 2-3 3.5-3s2.9 1 3.5 3' }),
+    e('path', { d: 'M16 9h2.5M16 12h2M16 15h2.5' }),
+  ),
+
+  'wallet': () => makeSvg(
+    e('path', { d: 'M4 8.5a2.5 2.5 0 0 1 2.5-2.5H17l1 2.5' }),
+    e('rect', { x: '3.5', y: '7.5', width: '17', height: '12', rx: '2.5' }),
+    e('circle', { cx: '16.5', cy: '13.5', r: '1.3' }),
+  ),
+
+  'folder-lock': () => makeSvg(
+    e('path', { d: 'M3.5 7.5a2 2 0 0 1 2-2h3.4l2 2.2H18a2 2 0 0 1 2 2v8.8a2 2 0 0 1-2 2H5.5a2 2 0 0 1-2-2z' }),
+    e('path', { d: 'M8 13.5h8M8 16.5h5' }),
+  ),
+
+  'paintbrush': () => makeSvg(
+    e('path', { d: 'm4.5 19.5 7-7' }),
+    e('path', { d: 'm14 6 4 4-3.5 3.5L10.5 9.5z' }),
+    e('path', { d: 'M14 6 17 3l4 4-3 3' }),
+    e('path', { d: 'M5 17.5c-.5 1-.5 1.8 0 2.5 1 .6 1.9.5 2.5 0' }),
+  ),
+
+  'utensils': () => makeSvg(
+    e('path', { d: 'M7.5 3.5v8a2 2 0 0 1-2 2h-.5v7' }),
+    e('path', { d: 'M5.5 3.5v6M7.5 3.5v6M9.5 3.5v6' }),
+    e('path', { d: 'M17 3.5c-1.8 0-3 1.5-3 3.5v5h2.2v8.5h1.6V3.5z' }),
+  ),
+
+  'settings': () => makeSvg(
+    e('circle', { cx: '12', cy: '12', r: '3' }),
+    e('path', { d: 'M12 3v2.2M12 18.8V21M5.4 5.4l1.6 1.6M17 17l1.6 1.6M3 12h2.2M18.8 12H21M5.4 18.6 7 17M17 7l1.6-1.6' }),
+  ),
+
+  'grid-2x2': () => {
+    const s = makeSvg();
+    for (const [cx, cy] of [
+      ['6.5','6.5'],['12','6.5'],['17.5','6.5'],
+      ['6.5','12'], ['12','12'], ['17.5','12'],
+      ['6.5','17.5'],['12','17.5'],['17.5','17.5'],
+    ]) {
+      s.appendChild(e('circle', { cx, cy, r: '1.6' }));
+    }
+    return s;
+  },
+
+  'shopping-cart': () => makeSvg(
+    e('path', { d: 'M3 4.5h2.4L7.5 16h10.2l2-7H7' }),
+    e('circle', { cx: '9',  cy: '19.2', r: '1.4' }),
+    e('circle', { cx: '17', cy: '19.2', r: '1.4' }),
+  ),
+
+  'book-text': () => makeSvg(
+    e('path', { d: 'M4 4.5A1.5 1.5 0 0 1 5.5 3H18a1.5 1.5 0 0 1 1.5 1.5v15a1.5 1.5 0 0 1-1.5 1.5H5.5A1.5 1.5 0 0 1 4 19.5z' }),
+    e('path', { d: 'M8 8h8M8 12h8M8 16h5' }),
+  ),
+
+  'receipt-text': () => makeSvg(
+    e('path', { d: 'M4 3.5v17l2.5-2 2.5 2 2.5-2 2.5 2 2.5-2 2.5 2V3.5z' }),
+    e('path', { d: 'M8 9h8M8 13h8M8 17h4' }),
+  ),
+
+  'box': () => makeSvg(
+    e('path', { d: 'M21 8L12 13 3 8' }),
+    e('path', { d: 'M3 8l9-5 9 5v8l-9 5-9-5z' }),
+    e('path', { d: 'M12 13v9' }),
+  ),
+};

--- a/public/router.js
+++ b/public/router.js
@@ -9,6 +9,7 @@ import { initI18n, getLocale, t } from '/i18n.js';
 import { esc } from '/utils/html.js';
 import { init as initReminders, stop as stopReminders } from '/reminders.js';
 import { isKitchenRoute, getLastKitchenRoute } from '/utils/kitchen-tabs.js';
+import { NAV_ICONS } from '/nav-icons.js';
 
 // --------------------------------------------------------
 // Routen-Definitionen
@@ -634,10 +635,24 @@ function renderAppShell(container) {
   sidebarBrandText.append(sidebarLogoSpan, sidebarVersion);
   sidebarLogo.appendChild(sidebarBrandText);
   const sidebarItems = document.createElement('div');
-  sidebarItems.className = 'nav-sidebar__items';
+  sidebarItems.className = 'nav-sidebar__items nav-sidebar__items--liquid';
   sidebarItems.setAttribute('role', 'list');
   sidebarNavItems().forEach((item) => sidebarItems.appendChild(item));
   if (window.lucide) window.lucide.createIcons({ el: sidebarItems });
+
+  // Hover-Delegation: Indikator-Pille zeigt Vorschau wohin sie gleiten würde
+  sidebarItems.addEventListener('mouseover', (ev) => {
+    const item = ev.target.closest('.nav-item');
+    if (!item) return;
+    const ind = sidebarItems.querySelector('.nav-sidebar__indicator');
+    if (!ind) return;
+    const cr = sidebarItems.getBoundingClientRect();
+    const ir = item.getBoundingClientRect();
+    ind.style.transform = `translateY(${ir.top - cr.top + sidebarItems.scrollTop}px)`;
+    ind.style.opacity = '0.5';
+  });
+  sidebarItems.addEventListener('mouseleave', () => positionSidebarIndicator());
+
   sidebar.appendChild(sidebarLogo);
   sidebar.appendChild(sidebarItems);
 
@@ -667,11 +682,20 @@ function renderAppShell(container) {
     kitchenBtnWrap.className = 'nav-item__icon-wrap';
     const kitchenBtnWell = document.createElement('div');
     kitchenBtnWell.className = 'nav-item__icon-well';
-    const kitchenBtnIcon = document.createElement('i');
-    kitchenBtnIcon.dataset.lucide = 'utensils';
-    kitchenBtnIcon.className = 'nav-item__icon';
-    kitchenBtnIcon.setAttribute('aria-hidden', 'true');
-    kitchenBtnWell.appendChild(kitchenBtnIcon);
+    {
+      const iconFactory = NAV_ICONS['utensils'];
+      if (iconFactory) {
+        const svg = iconFactory();
+        svg.classList.add('nav-item__icon');
+        kitchenBtnWell.appendChild(svg);
+      } else {
+        const kitchenBtnIcon = document.createElement('i');
+        kitchenBtnIcon.dataset.lucide = 'utensils';
+        kitchenBtnIcon.className = 'nav-item__icon';
+        kitchenBtnIcon.setAttribute('aria-hidden', 'true');
+        kitchenBtnWell.appendChild(kitchenBtnIcon);
+      }
+    }
     kitchenBtnWrap.appendChild(kitchenBtnWell);
     const kitchenBtnLabel = document.createElement('span');
     kitchenBtnLabel.className = 'nav-item__label';
@@ -694,11 +718,20 @@ function renderAppShell(container) {
     moreBtnWrap.className = 'nav-item__icon-wrap';
     const moreBtnWell = document.createElement('div');
     moreBtnWell.className = 'nav-item__icon-well';
-    const moreBtnIcon = document.createElement('i');
-    moreBtnIcon.dataset.lucide = 'grid-2x2';
-    moreBtnIcon.className = 'nav-item__icon';
-    moreBtnIcon.setAttribute('aria-hidden', 'true');
-    moreBtnWell.appendChild(moreBtnIcon);
+    {
+      const iconFactory = NAV_ICONS['grid-2x2'];
+      if (iconFactory) {
+        const svg = iconFactory();
+        svg.classList.add('nav-item__icon');
+        moreBtnWell.appendChild(svg);
+      } else {
+        const moreBtnIcon = document.createElement('i');
+        moreBtnIcon.dataset.lucide = 'grid-2x2';
+        moreBtnIcon.className = 'nav-item__icon';
+        moreBtnIcon.setAttribute('aria-hidden', 'true');
+        moreBtnWell.appendChild(moreBtnIcon);
+      }
+    }
     moreBtnWrap.appendChild(moreBtnWell);
     const moreBtnLabel = document.createElement('span');
     moreBtnLabel.className = 'nav-item__label';
@@ -749,6 +782,14 @@ function renderAppShell(container) {
   }
 
   bottomNav.appendChild(bottomItems);
+
+  // Gleitender Tab-Indikator — Geschwister von bottomItems, überlebt replaceChildren auf items
+  if (!isGuest) {
+    const tabIndicator = document.createElement('div');
+    tabIndicator.className = 'nav-bottom__indicator';
+    tabIndicator.setAttribute('aria-hidden', 'true');
+    bottomNav.appendChild(tabIndicator);
+  }
 
   const searchOverlay = document.createElement('div');
   searchOverlay.className = 'search-overlay';
@@ -1259,7 +1300,17 @@ function navItems() {
 
 function sidebarNavItems() {
   const elements = [];
+  // Morphende Indikator-Pille — wird als erstes Kind eingefügt damit
+  // z-index: 0 es hinter den nav-items (z-index: 1) hält.
+  const indicator = document.createElement('div');
+  indicator.className = 'nav-sidebar__indicator';
+  indicator.setAttribute('aria-hidden', 'true');
+  elements.push(indicator);
+
   let kitchenAdded = false;
+  let nonKitchenCount = 0;
+  let sectionAdded = false;
+
   navItems().forEach((item) => {
     if (item.kitchenGroup) {
       if (!kitchenAdded) {
@@ -1268,6 +1319,15 @@ function sidebarNavItems() {
       }
       return;
     }
+    // Abschnittsbezeichnung vor dem (PRIMARY_NAV+1)ten Nicht-Küche-Eintrag
+    if (!sectionAdded && nonKitchenCount === PRIMARY_NAV) {
+      sectionAdded = true;
+      const label = document.createElement('div');
+      label.className = 'nav-section-label';
+      label.textContent = t('nav.section.household');
+      elements.push(label);
+    }
+    nonKitchenCount++;
     elements.push(navItemEl(item));
   });
   return elements;
@@ -1322,11 +1382,18 @@ function navItemEl({ path, label, icon, module: mod, accent }) {
   iconWrap.className = 'nav-item__icon-wrap';
   const well = document.createElement('div');
   well.className = 'nav-item__icon-well';
-  const i = document.createElement('i');
-  i.dataset.lucide = icon;
-  i.className = 'nav-item__icon';
-  i.setAttribute('aria-hidden', 'true');
-  well.appendChild(i);
+  const iconFactory = NAV_ICONS[icon];
+  if (iconFactory) {
+    const svg = iconFactory();
+    svg.classList.add('nav-item__icon');
+    well.appendChild(svg);
+  } else {
+    const i = document.createElement('i');
+    i.dataset.lucide = icon;
+    i.className = 'nav-item__icon';
+    i.setAttribute('aria-hidden', 'true');
+    well.appendChild(i);
+  }
   iconWrap.appendChild(well);
   const span = document.createElement('span');
   span.className = 'nav-item__label';
@@ -1348,6 +1415,65 @@ function replaceLucideIcon(container, selector, iconName) {
   next.setAttribute('aria-hidden', 'true');
   current.replaceWith(next);
   if (window.lucide) window.lucide.createIcons({ el: container });
+}
+
+/**
+ * Ersetzt ein Nav-Icon (Custom SVG bevorzugt, Lucide als Fallback).
+ * Funktioniert sowohl mit <svg>- als auch <i data-lucide>-Elementen.
+ */
+function replaceNavIcon(container, selector, lucideIconName) {
+  const current = container.querySelector(selector);
+  if (!current) return;
+  const iconFactory = NAV_ICONS[lucideIconName];
+  if (iconFactory) {
+    const classes = (current.getAttribute('class') || '')
+      .split(/\s+/)
+      .filter((cls) => cls && cls !== 'lucide' && !cls.startsWith('lucide-'));
+    const svg = iconFactory();
+    svg.className.baseVal = classes.join(' ') || 'nav-item__icon';
+    current.replaceWith(svg);
+  } else {
+    replaceLucideIcon(container, selector, lucideIconName);
+  }
+}
+
+/**
+ * Positioniert den morphenden Indikator in der Sidebar auf dem aktiven Nav-Item.
+ */
+function positionSidebarIndicator() {
+  const container = document.querySelector('.nav-sidebar__items');
+  const indicator = container?.querySelector('.nav-sidebar__indicator');
+  if (!indicator) return;
+  const active = container.querySelector('.nav-item[aria-current="page"]');
+  if (!active) {
+    indicator.style.opacity = '0';
+    return;
+  }
+  const cr = container.getBoundingClientRect();
+  const ar = active.getBoundingClientRect();
+  indicator.style.transform = `translateY(${ar.top - cr.top + container.scrollTop}px)`;
+  indicator.style.opacity = '';
+}
+
+/**
+ * Positioniert den gleitenden Indikator in der mobilen Tab-Bar.
+ */
+function positionTabIndicator() {
+  const nav = document.querySelector('.nav-bottom');
+  const indicator = nav?.querySelector('.nav-bottom__indicator');
+  if (!indicator || !nav) return;
+  const active = document.querySelector(
+    '.nav-bottom__items .nav-item[aria-current="page"], .nav-bottom__items .nav-item--active',
+  );
+  if (!active) {
+    indicator.style.opacity = '0';
+    return;
+  }
+  const nr = nav.getBoundingClientRect();
+  const ar = active.getBoundingClientRect();
+  indicator.style.width = `${ar.width}px`;
+  indicator.style.transform = `translateX(${ar.left - nr.left}px)`;
+  indicator.style.opacity = '';
 }
 
 function sidebarKitchenEl() {
@@ -1373,11 +1499,18 @@ function moreItemEl({ path, label, icon, module: mod, accent }) {
   else if (mod) a.style.setProperty('--item-module-accent', `var(--module-${mod})`);
   const well = document.createElement('div');
   well.className = 'more-item__icon-well';
-  const i = document.createElement('i');
-  i.dataset.lucide = icon;
-  i.className = 'more-item__icon';
-  i.setAttribute('aria-hidden', 'true');
-  well.appendChild(i);
+  const iconFactory = NAV_ICONS[icon];
+  if (iconFactory) {
+    const svg = iconFactory();
+    svg.classList.add('more-item__icon');
+    well.appendChild(svg);
+  } else {
+    const i = document.createElement('i');
+    i.dataset.lucide = icon;
+    i.className = 'more-item__icon';
+    i.setAttribute('aria-hidden', 'true');
+    well.appendChild(i);
+  }
   const span = document.createElement('span');
   span.className = 'more-item__label';
   span.textContent = label;
@@ -1422,7 +1555,7 @@ function setMoreButtonState(moreBtn, activeSecondary) {
 
   const moreBtnLabel = moreBtn.querySelector('.nav-item__label');
   if (moreBtnLabel) moreBtnLabel.textContent = moreLabel;
-  replaceLucideIcon(moreBtn, '.nav-item__icon', moreIcon);
+  replaceNavIcon(moreBtn, '.nav-item__icon', moreIcon);
 }
 
 function updateNav(path) {
@@ -1448,9 +1581,7 @@ function updateNav(path) {
     }
 
     const kitchenBtnLabel = kitchenNavBtn.querySelector('.nav-item__label');
-    const kitchenBtnIcon  = kitchenNavBtn.querySelector('.nav-item__icon');
     if (kitchenBtnLabel) kitchenBtnLabel.textContent = t('nav.kitchen');
-    if (kitchenBtnIcon) kitchenBtnIcon.dataset.lucide = 'utensils';
     kitchenNavBtn.setAttribute('aria-label', kitchenNavAriaLabel(path));
     kitchenNavBtn.setAttribute('title', t('nav.kitchen'));
   }
@@ -1479,6 +1610,11 @@ function updateNav(path) {
   if (window.lucide) {
     window.lucide.createIcons();
   }
+
+  requestAnimationFrame(() => {
+    positionSidebarIndicator();
+    positionTabIndicator();
+  });
 }
 
 function renderError(container, err) {
@@ -1701,6 +1837,7 @@ function rebuildNavigation({ updateLabels = true } = {}) {
     const sidebarEls = sidebarNavItems();
     navSidebarItems.replaceChildren(...sidebarEls);
     if (window.lucide) window.lucide.createIcons({ el: navSidebarItems });
+    requestAnimationFrame(() => positionSidebarIndicator());
   }
   if (bottomItems) {
     const kitchenBtnEl = bottomItems.querySelector('#kitchen-btn');
@@ -1713,6 +1850,7 @@ function rebuildNavigation({ updateLabels = true } = {}) {
     const newItems = navItems().filter((item) => !item.kitchenGroup).slice(0, PRIMARY_NAV).map(navItemEl);
     const tail = [kitchenBtnEl, moreBtn].filter(Boolean);
     bottomItems.replaceChildren(...newItems, ...tail);
+    requestAnimationFrame(() => positionTabIndicator());
   }
   if (moreSheet) {
     const handle = moreSheet.querySelector('.more-sheet__handle');
@@ -1754,6 +1892,11 @@ function refreshCurrentRoute() {
 
 window.addEventListener('date-format-changed', refreshCurrentRoute);
 window.addEventListener('time-format-changed', refreshCurrentRoute);
+
+window.addEventListener('resize', () => {
+  positionSidebarIndicator();
+  positionTabIndicator();
+}, { passive: true });
 
 // --------------------------------------------------------
 // Virtuelle Tastatur: FAB ausblenden wenn Keyboard offen

--- a/public/styles/glass.css
+++ b/public/styles/glass.css
@@ -832,3 +832,57 @@ html.navigating .app-content *::after {
     -webkit-backdrop-filter: none;
   }
 }
+
+/* ================================================================
+ * 38. Sidebar Liquid Indikator — Glass Pill
+ * ================================================================ */
+@media (min-width: 1024px) {
+  .nav-sidebar__indicator {
+    background: color-mix(in srgb, var(--active-module-accent, var(--color-accent)) 12%, var(--glass-bg-card));
+    border: 1px solid var(--glass-border-subtle);
+    box-shadow:
+      var(--glass-inset-soft),
+      var(--glass-shadow-sm);
+  }
+
+  @supports (backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px)) {
+    .nav-sidebar__indicator {
+      backdrop-filter: var(--blur-xs) saturate(150%);
+      -webkit-backdrop-filter: var(--blur-xs) saturate(150%);
+    }
+  }
+
+  @media (prefers-reduced-transparency: reduce) {
+    .nav-sidebar__indicator {
+      background: color-mix(in srgb, var(--active-module-accent, var(--color-accent)) 16%, var(--color-surface-elevated));
+      backdrop-filter: none;
+      -webkit-backdrop-filter: none;
+    }
+  }
+}
+
+/* ================================================================
+ * 39. Mobile Tab-Indikator — Glass Pill
+ * ================================================================ */
+.nav-bottom__indicator {
+  background: color-mix(in srgb, var(--active-module-accent, var(--color-accent)) 18%, transparent);
+  border: 1px solid var(--glass-border);
+  box-shadow:
+    var(--glass-inset-soft),
+    var(--glass-shadow-sm);
+}
+
+@supports (backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px)) {
+  .nav-bottom__indicator {
+    backdrop-filter: var(--blur-xs) saturate(150%);
+    -webkit-backdrop-filter: var(--blur-xs) saturate(150%);
+  }
+}
+
+@media (prefers-reduced-transparency: reduce) {
+  .nav-bottom__indicator {
+    background: color-mix(in srgb, var(--active-module-accent, var(--color-accent)) 22%, var(--color-surface-elevated));
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+  }
+}

--- a/public/styles/layout.css
+++ b/public/styles/layout.css
@@ -2442,3 +2442,95 @@ textarea.input { resize: vertical; }
   .modal-panel  { border: 2px solid CanvasText; }
   .nav-item[aria-current="page"] { border-bottom: 2px solid Highlight; }
 }
+
+/* ============================================================
+ * Liquid Nav — Custom Icons, Indikatoren, Abschnittsbezeichnung
+ * ============================================================ */
+
+/* SVG-Icons füllen ihren Eltern-Container */
+.nav-item__icon svg,
+.more-item__icon svg {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+/* ── Sidebar: Indikator-Container braucht position:relative ── */
+.nav-sidebar__items {
+  position: relative;
+}
+
+/* ── Sidebar: Morphende Indikator-Pille (Strukturell) ── */
+.nav-sidebar__indicator {
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  height: var(--target-base); /* 44px */
+  border-radius: var(--radius-sm);
+  pointer-events: none;
+  transition:
+    transform 0.45s cubic-bezier(0.28, 1.25, 0.36, 1),
+    opacity 0.25s ease;
+  will-change: transform;
+  z-index: 0;
+}
+
+/* Nav-Items über dem Sidebar-Indikator */
+.nav-sidebar__items--liquid .nav-item {
+  z-index: 1;
+}
+
+/* Kein linker Akzentbalken wenn Liquid-Indikator aktiv */
+.nav-sidebar__items--liquid .nav-item[aria-current="page"]::before {
+  display: none;
+}
+
+/* Kein statischer Hintergrund und kein Shadow-Highlight wenn Indikator aktiv */
+.nav-sidebar__items--liquid .nav-item[aria-current="page"] {
+  background: transparent !important;
+  box-shadow: none !important;
+}
+
+/* ── Sidebar: Abschnittsbezeichnung (z.B. "Haushalt") ── */
+.nav-section-label {
+  font-size: var(--text-2xs);
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--color-text-tertiary);
+  padding: var(--space-3) var(--space-3) var(--space-1);
+  user-select: none;
+  pointer-events: none;
+  position: relative;
+  z-index: 1;
+}
+
+/* ── Mobile: Tab-Indikator (Strukturell) ── */
+.nav-bottom__indicator {
+  position: absolute;
+  top: 4px;
+  bottom: 4px;
+  left: 0;
+  border-radius: var(--radius-full);
+  pointer-events: none;
+  transition:
+    transform 0.45s cubic-bezier(0.28, 1.25, 0.36, 1),
+    width 0.45s cubic-bezier(0.28, 1.25, 0.36, 1),
+    opacity 0.25s ease;
+  will-change: transform, width;
+  z-index: 0;
+}
+
+/* Nav-Items im Bottom-Bar über dem Indikator */
+.nav-bottom .nav-item {
+  position: relative;
+  z-index: 1;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .nav-sidebar__indicator,
+  .nav-bottom__indicator {
+    transition: opacity 0.01ms;
+  }
+}


### PR DESCRIPTION
## Summary

- **`public/nav-icons.js`** (neu): eigener monoliniger SVG-Icon-Set für alle Nav-Einträge, vollständig per `createElementNS` DOM-API erzeugt — kein `innerHTML`, kein `insertAdjacentHTML`
- **Sidebar Desktop**: morphende Glass-Pille gleitet animiert zum aktiven Eintrag; Hover-Preview zeigt das Ziel mit 50 % Opazität; linker Akzentbalken entfällt wenn Liquid-Modus aktiv
- **Sidebar**: „Haushalt"-Abschnittsbezeichnung nach den 4 Primär-Einträgen (Übersicht, Kalender, Aufgaben, Notizen)
- **Mobile Bottom-Bar**: gleitender Glass-Indikator-Pill folgt dem aktiven Tab
- **16 Locale-Dateien**: Schlüssel `nav.section.household` in allen Sprachen ergänzt
- Lucide-Fallback für Icons ohne Custom-SVG
- Respektiert `prefers-reduced-motion` und `prefers-reduced-transparency`

## Test plan

- [ ] Desktop: Sidebar-Indikator gleitet korrekt beim Seitenwechsel
- [ ] Desktop: Hover-Preview des Indikators auf inaktiven Einträgen
- [ ] Desktop: „Haushalt"-Label erscheint zwischen Notizen und Geburtstage
- [ ] Mobile: Tab-Indikator gleitet beim Tab-Wechsel
- [ ] Mobile: Mehr-Sheet öffnet sich, Tab-Indikator auf Mehr-Button
- [ ] Icons in Sidebar, Bottom-Nav und Mehr-Sheet sichtbar und korrekt
- [ ] `npm test` — alle Suites grün
- [ ] Dark Mode: Indikatoren sichtbar
- [ ] `prefers-reduced-motion`: keine Gleit-Animation, nur Fade

🤖 Generated with [Claude Code](https://claude.com/claude-code)