### PR TITLE
style(documents,split): Liquid Glass Migration — Phase 6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.54.5] - 2026-05-28
+
+### Changed
+- **Liquid Glass – Documents & Split Expenses modules:** Migrated `documents.css` and `split-expenses.css` to Glass design tokens. Document folder browser (`.documents-folder-browser`), document cards (`.document-card`), document rows (`.document-row`), the drop zone (`.document-dropzone`) and its icon, the member picker (`.document-member-picker`), and the view toggle (`.documents-view-toggle`) all use `--glass-bg-card`, `--glass-border-subtle`, `--radius-glass-card`/`--radius-glass-inner`, and `--glass-shadow-*` tokens. Split summary cards (`.split-summary-card`) receive a subtle module-accent tint via `::after`. Split cards (`.split-card`), the groups panel (`.split-groups-panel`), group headers (`.split-group-header`), groups (`.split-group`), and participants (`.split-participants`) are migrated to corresponding Glass tokens. All `--shadow-*` → `--glass-shadow-*`, `--radius-md/lg` → `--radius-glass-card/inner/chip`, and `--color-surface` → `--glass-bg-card` replacements applied.
+
 ## [0.54.4] - 2026-05-28
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oikos",
-  "version": "0.54.4",
+  "version": "0.54.5",
   "description": "Self-hosted family planner - calendar, tasks, shopping, meal planning, budget and more. Private, open-source, no subscription.",
   "main": "server/index.js",
   "type": "module",

--- a/public/styles/documents.css
+++ b/public/styles/documents.css
@@ -56,8 +56,8 @@
   display: inline-flex;
   padding: 2px;
   gap: 2px;
-  border-radius: var(--radius-md);
-  background: var(--color-surface-2);
+  border-radius: var(--radius-glass-chip);
+  background: var(--glass-bg-input);
 }
 
 .documents-view-toggle__btn {
@@ -66,7 +66,7 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  border-radius: calc(var(--radius-md) - 2px);
+  border-radius: calc(var(--radius-glass-chip) - 2px);
   color: var(--color-text-secondary);
 }
 
@@ -77,8 +77,8 @@
 
 .documents-view-toggle__btn--active {
   color: var(--module-accent);
-  background: var(--color-surface);
-  box-shadow: var(--shadow-sm);
+  background: var(--glass-bg-elevated);
+  box-shadow: var(--glass-shadow-sm);
 }
 
 .documents-filters {
@@ -102,10 +102,10 @@
 .documents-folder-browser {
   position: sticky;
   top: var(--space-4);
-  border: 1px solid var(--color-border-subtle);
-  border-radius: var(--radius-md);
-  background: var(--color-surface);
-  box-shadow: var(--shadow-sm);
+  border: 1px solid var(--glass-border-subtle);
+  border-radius: var(--radius-glass-card);
+  background-color: var(--glass-bg-card);
+  box-shadow: var(--glass-shadow-sm);
   overflow: hidden;
 }
 
@@ -208,10 +208,22 @@
 
 .document-card,
 .document-row {
-  border: 1px solid var(--color-border-subtle);
-  border-radius: var(--radius-md);
-  background: var(--color-surface);
-  box-shadow: var(--shadow-sm);
+  border: 1px solid var(--glass-border-subtle);
+  background-color: var(--glass-bg-card);
+  box-shadow: var(--glass-shadow-sm);
+}
+
+.document-card {
+  border-radius: var(--radius-glass-card);
+}
+
+.document-row {
+  border-radius: var(--radius-glass-inner);
+}
+
+.document-row:hover {
+  background-color: var(--glass-bg-card-hover);
+  box-shadow: var(--glass-shadow-md);
 }
 
 .document-card {
@@ -228,7 +240,7 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  border-radius: var(--radius-md);
+  border-radius: var(--radius-glass-inner);
   color: var(--module-accent);
   background: color-mix(in srgb, var(--module-accent) 12%, transparent);
 }
@@ -332,7 +344,7 @@
   min-height: 148px;
   padding: var(--space-5);
   border: 1.5px dashed color-mix(in srgb, var(--module-accent) 48%, var(--color-border));
-  border-radius: var(--radius-md);
+  border-radius: var(--radius-glass-card);
   background: color-mix(in srgb, var(--module-accent) 7%, var(--color-surface));
   color: var(--color-text-secondary);
   text-align: center;
@@ -356,10 +368,10 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  border-radius: var(--radius-md);
+  border-radius: var(--radius-glass-inner);
   color: var(--module-accent);
-  background: var(--color-surface);
-  box-shadow: var(--shadow-sm);
+  background-color: var(--glass-bg-elevated);
+  box-shadow: var(--glass-shadow-sm);
 }
 
 .document-dropzone__icon svg {
@@ -390,10 +402,10 @@
 
 .document-member-picker {
   margin-top: var(--space-2);
-  border: 1px solid var(--color-border-subtle);
-  border-radius: var(--radius-md);
+  border: 1px solid var(--glass-border-subtle);
+  border-radius: var(--radius-glass-inner);
   padding: var(--space-3);
-  background: var(--color-surface-2);
+  background-color: var(--glass-bg-card);
 }
 
 .document-member-picker__grid {

--- a/public/styles/split-expenses.css
+++ b/public/styles/split-expenses.css
@@ -55,17 +55,33 @@
 .split-summary-card,
 .split-card,
 .split-groups-panel {
-  background: var(--color-surface);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-lg);
-  box-shadow: var(--shadow-sm);
+  background-color: var(--glass-bg-card);
+  border: 1px solid var(--glass-border-subtle);
+  border-radius: var(--radius-glass-card);
+  box-shadow: var(--glass-shadow-sm);
 }
 
 .split-summary-card {
+  position: relative;
   padding: var(--space-4);
   display: flex;
   flex-direction: column;
   gap: var(--space-2);
+}
+
+.split-summary-card::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background-color: color-mix(in srgb, var(--module-accent) calc(var(--glass-tint-strength) / 2), transparent);
+  pointer-events: none;
+  z-index: 0;
+}
+
+.split-summary-card > * {
+  position: relative;
+  z-index: 1;
 }
 
 .split-summary-card span {
@@ -137,7 +153,7 @@
   align-items: center;
   gap: var(--space-3);
   border: 1px solid transparent;
-  border-radius: var(--radius-md);
+  border-radius: var(--radius-glass-inner);
   background: transparent;
   color: inherit;
   text-align: left;
@@ -157,7 +173,7 @@
   flex: 0 0 42px;
   display: grid;
   place-items: center;
-  border-radius: var(--radius-md);
+  border-radius: var(--radius-glass-inner);
   background: color-mix(in srgb, var(--module-split-expenses) 14%, var(--color-surface-2));
   color: var(--module-split-expenses);
 }
@@ -197,9 +213,9 @@
 .split-group-header {
   justify-content: space-between;
   padding: var(--space-4);
-  background: var(--color-surface);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-lg);
+  background-color: var(--glass-bg-card);
+  border: 1px solid var(--glass-border-subtle);
+  border-radius: var(--radius-glass-card);
 }
 
 .split-kicker {
@@ -294,8 +310,8 @@
 }
 
 .split-participants {
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-md);
+  border: 1px solid var(--glass-border-subtle);
+  border-radius: var(--radius-glass-inner);
   padding: var(--space-3);
 }
 


### PR DESCRIPTION
## Summary

- **documents.css**: `.documents-folder-browser`, `.document-card`, `.document-row`, `.document-dropzone`, `.document-dropzone__icon`, `.document-member-picker`, `.documents-view-toggle` auf Glass-Tokens migriert
- **split-expenses.css**: `.split-summary-card`, `.split-card`, `.split-groups-panel`, `.split-group-header`, `.split-group`, `.split-participants` auf Glass-Tokens migriert; optionaler Modul-Akzent-Tint auf `.split-summary-card` via `::after`
- Alle `--shadow-*` → `--glass-shadow-*`, `--radius-md/lg` → `--radius-glass-card/inner/chip`, `--color-surface` → `--glass-bg-card` an Karten-Containern ersetzt

## Test plan

- [ ] `npm run dev` starten, Dokumente- und Splitting-Seite im Browser öffnen
- [ ] Light- und Dark-Mode prüfen
- [ ] Desktop (≥1024px) und Mobile-Breite prüfen
- [ ] DevTools: `prefers-reduced-transparency: reduce` emulieren → Karten müssen opak/lesbar bleiben
- [ ] iOS-Simulator: Scrollen → kein Weißbild (Blank-Screen-Regression)
- [ ] Visueller Vergleich mit bereits migrierten Modulen (Tasks/Notes): konsistente Radien, Schatten, Tint-Intensität

🤖 Generated with [Claude Code](https://claude.com/claude-code)