### PR TITLE
fix: calendar event assignment for non-admin users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.54.6] - 2026-05-29
+
+### Fixed
+- **Calendar – event assignment for non-admin users:** The `GET /auth/users` endpoint previously required admin privileges, causing the assignee dropdown to silently render empty for child and other non-admin family profiles. Removed the unnecessary `requireAdmin` guard so all authenticated family members can load the user list and assign calendar events.
+
 ## [0.54.5] - 2026-05-28
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oikos",
-  "version": "0.54.5",
+  "version": "0.54.6",
   "description": "Self-hosted family planner - calendar, tasks, shopping, meal planning, budget and more. Private, open-source, no subscription.",
   "main": "server/index.js",
   "type": "module",

--- a/server/auth.js
+++ b/server/auth.js
@@ -571,10 +571,10 @@ router.get('/me', requireAuth, (req, res) => {
 
 /**
  * GET /api/v1/auth/users
- * Admin only. Listet alle Familienmitglieder.
+ * Listet alle Familienmitglieder (für Zuweisung in Kalender, Tasks etc.).
  * Response: { data: User[] }
  */
-router.get('/users', requireAuth, requireAdmin, (req, res) => {
+router.get('/users', requireAuth, (req, res) => {
   try {
     const users = db.get()
       .prepare(`


### PR DESCRIPTION
## Summary

- Removes the `requireAdmin` guard from `GET /auth/users` so all authenticated family members can load the user list
- Child and other non-admin profiles can now assign calendar events — previously the assignee dropdown rendered empty silently
- Tasks already had its own `/tasks/meta/options` endpoint without an admin guard; this aligns the calendar to the same behavior

## Root cause

`loadUsers()` in `calendar.js` calls `GET /auth/users`, which had `requireAdmin` middleware. For non-admin sessions the request returned 403, the catch block set `state.users = []`, and the assignee multi-select rendered with no options — making assignment impossible for child/parent profiles.

## Test plan

- [ ] Log in as a non-admin family member (child or parent profile)
- [ ] Open the Calendar and create or edit an event
- [ ] Confirm the "Assigned to" dropdown lists all family members
- [ ] Assign a user and save — verify the assignment persists
- [ ] Log in as admin and confirm the user management page in Settings still works correctly

Closes #187

🤖 Generated with [Claude Code](https://claude.com/claude-code)