### PR TITLE
fix: recurring event end time shifted by UTC offset

### DIFF
--- a/server/routes/calendar.js
+++ b/server/routes/calendar.js
@@ -212,9 +212,13 @@ function expandRecurringEvents(events, from, to) {
             d.setDate(d.getDate() + durationDays);
             newEnd = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
           } else {
-            newEnd = new Date(new Date(newStart).getTime() + durationMs)
-              .toISOString()
-              .replace('.000Z', 'Z');
+            const endDate = new Date(new Date(newStart).getTime() + durationMs);
+            if (timeSuffix.includes('Z')) {
+              newEnd = endDate.toISOString().replace('.000Z', 'Z');
+            } else {
+              const p = n => String(n).padStart(2, '0');
+              newEnd = `${endDate.getFullYear()}-${p(endDate.getMonth() + 1)}-${p(endDate.getDate())}T${p(endDate.getHours())}:${p(endDate.getMinutes())}`;
+            }
           }
         }
 


### PR DESCRIPTION
## Summary

- Recurring event instances had their `end_datetime` formatted with `.toISOString()`, which always appends a `Z` (UTC) suffix
- The original events are stored as naive local-time strings (no timezone marker, e.g. `2026-05-28T11:30`)
- Browsers interpret `Z`-suffixed strings as UTC, so UTC+2 users saw end times shifted +2 hours on all recurring instances
- Fix: when the event's time suffix contains no `Z`, format `newEnd` as a naive `YYYY-MM-DDTHH:MM` string to match the stored format; `Z`-suffixed events (e.g. CalDAV imports) retain the existing `toISOString()` path

Closes #184

## Test plan

- [ ] Create a repeating event (e.g. 08:00–11:30) in a UTC+2 browser
- [ ] Verify all recurring instances show 08:00–11:30, not 08:00–13:30
- [ ] Verify all-day recurring events are unaffected
- [ ] Verify CalDAV-imported recurring events (UTC `Z` format) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)