### PR TITLE
fix(meals): kitchen pages drift under tab bar on scroll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.55.1] - 2026-05-30
+
+### Fixed
+- **Kitchen pages no longer drift under the tab bar while scrolling:** The meal planner and recipes pages did not subtract the kitchen tab bar height from their viewport height, so the outer scroll container overflowed by exactly the tab bar height. On desktop this made the whole page (week navigation and the day header row, e.g. "MO") drift upward while scrolling instead of only the inner content. Both pages now reduce their height by the tab bar height, matching the shopping page, so only the inner grid scrolls and the day headers stick correctly.
+
 ## [0.55.0] - 2026-05-29
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oikos",
-  "version": "0.55.0",
+  "version": "0.55.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oikos",
-      "version": "0.55.0",
+      "version": "0.55.1",
       "license": "MIT",
       "dependencies": {
         "bcrypt": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oikos",
-  "version": "0.55.0",
+  "version": "0.55.1",
   "description": "Self-hosted family planner - calendar, tasks, shopping, meal planning, budget and more. Private, open-source, no subscription.",
   "main": "server/index.js",
   "type": "module",

--- a/public/styles/kitchen-tabs.css
+++ b/public/styles/kitchen-tabs.css
@@ -8,9 +8,20 @@
   --sub-tabs-height: var(--kitchen-tabs-height);
 }
 
-/* Mahlzeiten: sticky day-header unterhalb der Tab-Leiste */
-.has-kitchen-tabs .day-header {
-  top: var(--kitchen-tabs-height);
+/* Mahlzeiten + Rezepte: Viewport-Höhe um Tab-Leiste reduzieren (Mobile).
+ * Ohne diese Reduktion ist die Seite um --kitchen-tabs-height zu hoch und
+ * der äußere .app-content-Scrollcontainer läuft über → beim Scrollen wandert
+ * die gesamte Seite (z.B. week-nav + Tages-Header) statt nur des inneren
+ * Scrollbereichs. .meals-page und .recipes-page teilen dieselbe Basisformel. */
+.has-kitchen-tabs .meals-page,
+.has-kitchen-tabs .recipes-page {
+  height: calc(
+    100dvh
+    - var(--safe-area-inset-top)
+    - var(--nav-bottom-height)
+    - var(--safe-area-inset-bottom)
+    - var(--kitchen-tabs-height)
+  );
 }
 
 /* Einkauf: Viewport-Höhe um Tab-Leiste reduzieren (Mobile) */
@@ -23,8 +34,10 @@
   );
 }
 
-/* Einkauf: Viewport-Höhe (Desktop) */
+/* Mahlzeiten + Rezepte + Einkauf: Viewport-Höhe (Desktop) */
 @media (min-width: 1024px) {
+  .has-kitchen-tabs .meals-page,
+  .has-kitchen-tabs .recipes-page,
   .has-kitchen-tabs .shopping-page {
     height: calc(100dvh - var(--kitchen-tabs-height));
   }


### PR DESCRIPTION
## Problem

In the kitchen module (meals/recipes) on desktop, the row with the day header (e.g. "MO") drifted up while scrolling instead of staying fixed — only the inner content should scroll.

## Root cause

The sticky `kitchen-tabs-bar` (56px) sits **above** `.meals-page`/`.recipes-page` inside the scrollable `.app-content`. Those pages used `height: 100dvh` (desktop) without subtracting the tab bar height, so `.app-content` overflowed by exactly the tab bar height and became scrollable itself — dragging the whole page (week nav + day headers) along. `.shopping-page` already had this compensation; meals/recipes were missing it.

## Fix

- Add the kitchen-tab-bar height compensation for `.meals-page` and `.recipes-page` in `kitchen-tabs.css` (mobile + desktop), matching `.shopping-page`.
- Remove the now-obsolete `.has-kitchen-tabs .day-header { top: var(--kitchen-tabs-height) }` rule — with no outer scroll, the day headers stick correctly at the inner `week-grid` edge (`top: 0`).

## Verification

Measured via Puppeteer over a real HTTP server (correct `dvh`):
- Before: outer `.app-content` overflow = **56px** (= tab bar height)
- After: outer overflow = **0**, `.day-header` still `position: sticky` at `top: 0`

Tests: kitchen-tabs 7/7, meals 25/25 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)