### PR TITLE
docs: document frontend audit rollout

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 
 <br>
 
-Oikos is a self-hosted web app that keeps your household organized — tasks, groceries, meals, calendar, budget, and more — in one private place, without cloud accounts or subscriptions. Runs as a Docker container on any home server or NAS. Accessible on every device. Installable as a PWA.
+Oikos is a self-hosted web app that keeps your household organized — tasks, groceries, meals, calendar, budget, and more — in one private place, without cloud accounts or subscriptions. Runs as a Docker container on any home server or NAS. Accessible on every device with a polished mobile-first PWA interface.
 
 Each module is independent. Use what fits, skip what doesn't.
 
@@ -41,11 +41,11 @@ Each module is independent. Use what fits, skip what doesn't.
 
 | | |
 |---|---|
-| **Tasks** | Shared tasks with deadlines, priorities, subtasks, recurring schedules, and multi-member assignment. |
-| **Shopping** | Collaborative lists organized by aisle. Import from meal plans in one click. |
+| **Tasks** | Shared tasks with deadlines, priorities, subtasks, recurring schedules, multi-member assignment, Kanban, and mobile-friendly bulk controls. |
+| **Shopping** | Collaborative lists organized by aisle. Touch-safe quick add, swipe gestures, and meal-plan import in one click. |
 | **Meals** | Weekly drag-and-drop planner with direct export to your shopping list. |
 | **Recipes** | Create, duplicate, and scale recipes. Pre-fill meal slots or save any meal as a recipe. |
-| **Calendar** | Google Calendar (OAuth) and CalDAV sync (iCloud, Nextcloud, Radicale). ICS subscriptions, recurring events, file attachments. |
+| **Calendar** | Google Calendar (OAuth) and CalDAV sync (iCloud, Nextcloud, Radicale). ICS subscriptions, recurring events, file attachments, and readable month/agenda views. |
 | **Documents** | Upload and organize family files. Folders, tags, per-document visibility, drag-and-drop. |
 | **Budget** | Income, expenses, recurring entries, trends, CSV export. Split Expenses for shared costs with automatic debt simplification. |
 | **Housekeeping** | Manage household staff — schedules, check-in/out, payments, chores, supply requests. |
@@ -60,8 +60,8 @@ Each module is independent. Use what fits, skip what doesn't.
 
 ## Design & Technology
 
-- **Liquid Glass UI** — translucent surfaces, backdrop blur, spring animations, and module-tinted overlays — built in pure CSS
-- **PWA** — installable on any device, works offline, responsive from phone to desktop, dark mode
+- **Disciplined Liquid Glass UI** — readable work surfaces, subtle translucent navigation, spring animations, and module-tinted overlays — built in pure CSS
+- **PWA** — installable on any device, works offline, responsive from phone to desktop, with tuned mobile navigation, touch targets, and dark mode
 - **Privacy First** — fully self-hosted, SQLCipher AES-256 encrypted database, zero telemetry
 - **Zero Build Step** — pure ES modules, no bundler, no transpiler, no framework
 - **Multilingual** — 16 languages with automatic locale detection (de, en, es, fr, it, sv, el, ru, tr, zh, ja, ar, hi, pt, uk, pl)

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -676,6 +676,8 @@ Responsive grid: 1 column on mobile, 2 on tablet, 3 on desktop.
 
 **Today Cockpit (v0.52.40):** a compact summary strip renders above the widget grid that highlights at a glance: the next urgent/high-priority task, the next upcoming calendar event, the open shopping item count, and the planned dinner for today. Tapping any cockpit item navigates directly to the relevant module.
 
+**Mobile readability (v0.55.7):** on narrow phones, important cockpit cards span the full grid width so long German task/event titles do not split mid-word. Quick actions keep tokenized icon-button dimensions, and the dashboard reserves scroll room for the fixed FAB so it does not cover the first widget.
+
 **Widgets:**
 - Greeting: "Good [morning/afternoon/evening], [Name]" + date; auto-refreshes on `visibilitychange` so the greeting stays current during long sessions
 - Weather: OpenWeatherMap proxy, 3-day preview, refresh every 30 min, hide widget on API error
@@ -705,6 +707,7 @@ Skeleton loading instead of spinners (skeleton renders all 9 widgets at their co
 - Inline reminder presets: offset from due date/time — 15 min, 1 h, 1 d, 2 d, 1 w, 2 w, or fully custom offset
 - **Bulk actions (list view only):** select multiple tasks via checkboxes and apply batch operations (mark done, mark open, archive, delete); bulk select toggle in toolbar
 - **Start date:** tasks can have an optional start date; tasks with a future start date are hidden from the default list view to reduce cognitive load. A "Show scheduled" toggle chip in the filter bar reveals all upcoming planned tasks. Task cards display a "Starts on …" badge when a start date is set.
+- **Mobile toolbar (v0.55.8):** secondary controls collapse into a single overflow trigger on small screens; bulk actions remain hidden until at least one task is selected. Checkbox and row actions use the shared 44px target tokens.
 - Mobile swipe: left = done, right = edit
 - Badge for overdue tasks
 
@@ -717,6 +720,7 @@ Skeleton loading instead of spinners (skeleton renders all 9 widgets at their co
 - Checked items shown with strikethrough + moved to bottom
 - "Clear list" = remove checked items only
 - Autocomplete from previous entries (local)
+- Mobile quick-add form uses a resilient grid: item name spans the row, quantity/category/add controls remain touch-safe at 390px width, and autocomplete stays anchored to the input.
 - Mobile swipe: left = check/uncheck, right = delete; × delete button hidden on mobile (swipe takes over)
 
 ### Meal Plan (`/meals`)
@@ -757,6 +761,7 @@ Reusable recipe cards linked to meal slots.
 - **File attachments:** Events support a single file attachment (images, PDFs, Office documents, ≤ 5 MB). Images are displayed inline in the event popup; other files show a download link. Drag-and-drop upload supported in the event modal. Stored as Base64 in `attachment_data`.
 - **Overlapping events:** In week and day views, timed events that overlap in time are rendered side-by-side using a column-layout algorithm instead of stacking.
 - **Task chips:** Open and in-progress tasks with a `due_date` appear as read-only priority-coloured chips in all four calendar views (month, week/day all-day row, agenda). Clicking a chip navigates to `/tasks?open=<id>` and opens the task edit modal. Tasks with `due_time` show the time in the chip label. Done/archived tasks are not shown. No server changes required — tasks are fetched in parallel with events on each range load (`GET /api/v1/tasks?include_future=1`), filtered client-side, and rendered via `renderTaskChip()`.
+- **Readability polish (v0.55.10):** month cells use stronger work surfaces, explicit grid/chip boundaries, and clearer today emphasis. Agenda rows and task chips use solid surfaces plus borders for contrast in both themes. Calendar metadata uses Lucide icon placeholders and shared icon classes instead of visible emoji markers.
 - Configurable sync interval (default 15 min)
 - External events visually distinguishable
 - Conflicts: external event wins, local additions are preserved
@@ -834,7 +839,8 @@ User management and app configuration. Logged-in users only.
 - **Language:** System (follows `navigator.language`), German, English, Spanish, French, Italian, Swedish, Greek, Russian, Turkish, Chinese, Japanese, Arabic, Hindi, Portuguese, Ukrainian, Polish - via `oikos-locale-picker` web component; switch without page reload
 - **API Tokens (admin):** create named Bearer / X-API-Key tokens for external integrations; the full token value is shown only once immediately after creation; tokens can be revoked at any time; support optional expiry and track last-used timestamp
 - **Backup Management (admin):** download the current database as a file (`GET /api/v1/backup/database`) or restore from a backup file (`POST /api/v1/backup/restore`, drag-and-drop supported). Validates that the uploaded file is a valid Oikos database. A rollback copy is created automatically before restore. **Automatic scheduled backups:** configurable via `.env` (`BACKUP_ENABLED`, `BACKUP_SCHEDULE`, `BACKUP_DIR`, `BACKUP_KEEP`); default 2 AM daily, keeps last 7 copies; Settings → Backup shows scheduler status, schedule, retention policy, last backup timestamp, and a manual trigger button.
-- **Tab navigation:** Settings is organized in nine tabs (General, Meals, Budget, Shopping, Synchronization, Family, API Tokens, Backup, Account). Admin-only tabs: Family, API Tokens, Backup. Sticky tab bar, active tab persists in sessionStorage, Synchronization tab auto-activates after OAuth callbacks.
+- **Tab navigation:** Settings is organized in nine tabs (General, Meals, Budget, Shopping, Synchronization, Family, API Tokens, Backup, Account). Admin-only tabs: Family, API Tokens, Backup. Active tab persists in sessionStorage, Synchronization tab auto-activates after OAuth callbacks. On desktop the shared sub-tab bar becomes a sticky local navigation column; on mobile it remains horizontally scrollable with gradient scroll affordances and keyboard-accessible tab behavior.
+- **Information architecture (v0.55.10):** major settings areas use distinct card modifiers for theme, app info, localization/date-time, modules, account, family, API tokens, sync, and backup sections while preserving existing form IDs and API behavior.
 - **Family management (admin):** assign a `family_role` (Dad, Mom, Parent, Child, Grandparent, Relative, Other) to each user, and set per-member phone, email, and birthday — automatically synced to Contacts and Birthdays. Displayed in the family member list and profile views.
 - **Profile picture:** users can upload a personal avatar (PNG/JPEG/WebP/GIF, ≤ 5 MB), stored as a Base64 data URL in `avatar_data`. Displayed alongside display name across the app.
 - **App info:** version, license
@@ -942,7 +948,7 @@ Authentication options for external integrations:
 
 ### Colors (CSS Custom Properties)
 
-Source of truth: `public/styles/tokens.css`. Key values (as of v0.55.2):
+Source of truth: `public/styles/tokens.css`. Key values (as of v0.55.10):
 
 **Palette rationale:** Warm-tinted neutral scale (`#F5F4F1 → #1C1C1A`) anchored by a **Violet primary** (`#6c3aed`) that unifies the brand identity and the Calendar module color. Module colors are semantically separated from severity colors — no hue is shared without explicit documentation in `tokens.css`.
 
@@ -951,6 +957,9 @@ Source of truth: `public/styles/tokens.css`. Key values (as of v0.55.2):
   /* Neutral canvas — warm linen/unbleached-paper atmosphere */
   --color-bg:              #F5F4F1;   /* neutral-100 */
   --color-surface:         #FFFFFF;
+  --color-surface-work:    #FFFFFF;   /* readable productive surfaces */
+  --color-surface-raised:  #FAFAF8;   /* subtle elevated surfaces */
+  --color-surface-glass:   rgba(255,255,255,0.70); /* decorative/light glass */
   --color-border:          #E8E7E2;   /* neutral-200 */
   --color-text-primary:    #1C1C1A;   /* neutral-900, 14.7:1 on bg */
   --color-text-secondary:  #6C6B67;   /* neutral-600, 5.0:1 on white */
@@ -998,6 +1007,7 @@ Source of truth: `public/styles/tokens.css`. Key values (as of v0.55.2):
   /* Glass layer tokens */
   --glass-bg: rgba(255,255,255,0.72);
   --glass-border: rgba(255,255,255,0.55);
+  --glass-bg-card: var(--color-surface-glass);
   --blur-2xs: blur(2px);
   --blur-md: 16px;
   --radius-glass-button: 9999px;       /* capsule */
@@ -1041,7 +1051,10 @@ Source of truth: `public/styles/tokens.css`. Key values (as of v0.55.2):
     --module-reminders: #22D3EE;  /* Cyan-400 */
     --glass-bg: rgba(28,28,26,0.75);
     --glass-border: rgba(255,255,255,0.12);
-    --glass-bg-card: rgba(38,38,36,0.50);
+    --color-surface-work: #242422;
+    --color-surface-raised: #2E2E2B;
+    --color-surface-glass: rgba(34,34,32,0.78);
+    --glass-bg-card: var(--color-surface-glass);
     --glass-tint-strength: 8%;
   }
 }
@@ -1090,6 +1103,12 @@ Additive CSS file loaded globally after `layout.css`. Implements a Liquid Glass 
 - **`--lg-*` design tokens** (`tokens.css`): `--lg-blob-opacity` (0.4 light / 0.55 dark, collapses to 0 under `prefers-reduced-transparency` / `prefers-contrast: more`), `--lg-glass-saturate`, `--lg-card-radius`, `--lg-density`, `--lg-specular`.
 - The drift animation is frozen under `prefers-reduced-motion`; the backdrop is hidden entirely under `prefers-reduced-transparency` / `prefers-contrast: more`.
 
+**Phase 8 — Frontend UI/UX Audit Rollout (v0.55.7–v0.55.10):**
+- **Glass discipline:** `tokens.css` now separates `--color-surface-work`, `--color-surface-raised`, and `--color-surface-glass` so productive pages can use stronger, more readable surfaces while nav, modals, dashboard hero, and lightweight widgets keep decorative glass.
+- **Mobile ergonomics:** dashboard cockpit cards, Tasks secondary controls, Shopping quick-add controls, and Budget row actions use tokenized touch targets and responsive constraints tested at 390px width.
+- **Navigation identity:** Kitchen and More keep stable labels/icons in the mobile bar; the active subsection is exposed through localized accessible labels instead of replacing the visible nav identity.
+- **Calendar and Settings polish:** calendar month/agenda views use explicit readable surfaces and boundaries; Settings uses the shared sub-tab component as desktop sticky local navigation and mobile scrollable tabs.
+
 **Accessibility:** `prefers-reduced-transparency`, `prefers-reduced-motion`, and `prefers-contrast: more` blocks deactivate blur/animation and restore solid fallbacks across all phases.
 
 ### Components
@@ -1098,7 +1117,8 @@ Additive CSS file loaded globally after `layout.css`. Implements a Liquid Glass 
 - **Inputs:** `var(--radius-sm)`, 1.5px border, padding 12px 16px. Search inputs use `--radius-glass-button` and `--glass-border-subtle`. `[required]` fields receive validation status on blur (`.form-field--error` / `.form-field--valid`). Enter in a **single-line field** submits the modal form (standard web convention, v0.55.0); in a multi-line textarea Enter inserts a newline.
 - **FAB (Floating Action Button):** Color follows the module accent token (`--module-accent`) - each module defines its own accent color. Specular inner highlight + attention ring pulse. Hidden when the virtual keyboard is open (`visualViewport.resize`, threshold 75% of window height).
 - **Module accent colors:** `--module-accent` is applied on three visual layers - (1) active nav tab (bottom bar + sidebar stripe), (2) toolbar `border-top: 3px`, (3) cards/rows `border-left: 3px`. The active accent is written to `--active-module-accent` on `:root` on every navigation change. Falls back to `--color-accent` for pages without a module context.
-- **Navigation:** Bottom tab bar on mobile (Dashboard, Calendar, Tasks, Notes + Kitchen button + More button), auto-hides on scroll-down. Sidebar on desktop. Both use glass blur surfaces with a **sliding glass pill indicator** that animates to the active entry using spring easing. Hovering an inactive sidebar entry shows the indicator at 50 % opacity as a destination preview. Custom monoline SVG icons are served from `public/nav-icons.js` (DOM API, no `innerHTML`); Lucide is used as fallback. The sidebar displays a **"Haushalt" section heading** between the four primary entries (Dashboard, Calendar, Tasks, Notes) and the module entries. The Kitchen button dynamically shows the icon and label of the last visited kitchen section (Meals / Recipes / Shopping).
+- **Navigation:** Bottom tab bar on mobile (Dashboard, Calendar, Tasks, Notes + Kitchen button + More button), auto-hides on scroll-down. Sidebar on desktop. Both use glass blur surfaces with a **sliding glass pill indicator** that animates to the active entry using spring easing. Hovering an inactive sidebar entry shows the indicator at 50 % opacity as a destination preview. Custom monoline SVG icons are served from `public/nav-icons.js` (DOM API, no `innerHTML`); Lucide is used as fallback. The sidebar displays a **"Haushalt" section heading** between the four primary entries (Dashboard, Calendar, Tasks, Notes) and the module entries. Kitchen and More keep stable visible labels/icons; active subsections are communicated via localized `aria-label`/`aria-current` state and shared sub-tabs inside the module.
+- **Sub-tabs:** `public/utils/sub-tabs.js` renders sticky pill-style tab bars for Kitchen and Settings. It wires `role="tablist"`, `aria-selected`, `aria-controls`, `aria-labelledby`, keyboard arrow navigation, and panel focus coordination from one shared helper.
 - **Transitions:** Directional slide-X animation on page change (forward = from right, back = from left, 200ms) with spring easing. Respects `prefers-reduced-motion`.
 - **Empty states:** Consistent `.empty-state` class across all modules (icon + title + description, centered). Compact variant `.empty-state--compact` for meal slots.
 - **Modals:** Centered panel on desktop with glass overlay. On mobile (< 768px) bottom sheet - spring slide-in from below, sheet handle visible, swipe-to-close (> 80px downward). `focusin` scrolls inputs into view when the virtual keyboard is open. The modal lifecycle is managed as an explicit state machine (`idle → open → confirming → closing`) with encapsulated suspend/restore helpers, hardening the unsaved-changes confirmation against double-close and back-navigation races (v0.55.0). Modal titles and `selectModal` option labels are HTML-escaped centrally to prevent XSS from raw user data reused as modal headings.

--- a/docs/UI-UX-AUDIT-2026-05.md
+++ b/docs/UI-UX-AUDIT-2026-05.md
@@ -8,6 +8,14 @@ Typografie → Animation → Forms → Navigation → Datenvisualisierung) sowie
 `dashboard.css`, `components/modal.js`, `index.html`, `theme-init.js`, `router.js` (Toast/Route),
 `budget.js` (Datenvis), stichprobenhaft alle `pages/*` und `styles/*`.
 
+**Umsetzungsstatus (2026-06-01):** Die Audit-Ergebnisse wurden in mehreren Releases umgesetzt.
+Die ursprünglichen P1/P2-Sicherheits- und Accessibility-Punkte sind in `v0.54.12` und
+`v0.55.0` geschlossen. Der breitere Frontend-UI/UX-Rollout aus
+`docs/superpowers/plans/2026-05-31-frontend-ui-ux-audit-improvements.md` ist in
+`v0.55.7` bis `v0.55.10` gelandet: stärkere Arbeitsflächen, bessere mobile Dashboard-,
+Tasks- und Shopping-Ergonomie, stabile Kitchen/More-Navigation, lesbarere Kalenderansichten,
+strukturiertere Settings und zusätzliche Regressionstests.
+
 ---
 
 ## 0. Gesamteinschätzung

--- a/docs/design/2026-05-30-landing-page-plan.md
+++ b/docs/design/2026-05-30-landing-page-plan.md
@@ -302,14 +302,14 @@ Directly after the closing `</header>` tag of the hero section, insert:
     <span class="proof-sep proof-dt-only">·</span>
     <span class="proof-dt-only">MIT licensed</span>
     <span class="proof-sep">·</span>
-    <span>v0.55.3</span>
+    <span>v0.55.10</span>
   </div>
 </div>
 ```
 
 - [ ] **Step 2: Verify proof bar**
 
-Open in browser. A thin bar appears below the hero mockup. On desktop: "★ 2.4k · 14 modules · 16 languages · MIT licensed · v0.55.3" (stars load async). Resize to 375px: only "16 languages · v0.55.3" visible.
+Open in browser. A thin bar appears below the hero mockup. On desktop: "★ 2.4k · 14 modules · 16 languages · MIT licensed · v0.55.10" (stars load async). Resize to 375px: only "16 languages · v0.55.10" visible.
 
 - [ ] **Step 3: Commit**
 
@@ -799,7 +799,7 @@ Find `<footer>` and replace the entire block with:
 ```html
 <footer>
   <div class="wrap">
-    <p class="footer-meta"><span id="gh-stars-footer"></span><span id="footer-sep" style="display:none"> · </span>v0.55.3 · May 2026</p>
+    <p class="footer-meta"><span id="gh-stars-footer"></span><span id="footer-sep" style="display:none"> · </span>v0.55.10 · June 2026</p>
     <p data-t="footer_heart">Built with care for families who value privacy and simplicity.</p>
     <div class="footer-links">
       <a href="install.html" data-t="footer_install">Install</a>
@@ -844,7 +844,7 @@ footer_install: 'Installieren',
 
 - [ ] **Step 4: Verify footer**
 
-Open in browser, scroll to footer. First line shows "★ 2.4k · v0.55.3 · May 2026" (stars async). "Install" link appears as first footer link. Toggle DE: "Install" → "Installieren", "Contributing" → "Mitmachen".
+Open in browser, scroll to footer. First line shows "★ 2.4k · v0.55.10 · June 2026" (stars async). "Install" link appears as first footer link. Toggle DE: "Install" → "Installieren", "Contributing" → "Mitmachen".
 
 - [ ] **Step 5: Commit**
 

--- a/docs/design/2026-05-30-landing-page-redesign.md
+++ b/docs/design/2026-05-30-landing-page-redesign.md
@@ -85,7 +85,7 @@ Inhalt (zentriert, `--text-3`, `font-size: 0.8125rem`, `font-weight: 500`):
 ```
 
 - `{stars}`: live von GitHub API (selber Fetch wie Nav-Button, gemeinsam gecacht)
-- `{version}`: statisch hardcodiert, bei jedem Release aktualisiert (aktuell: `v0.55.3`)
+- `{version}`: statisch hardcodiert, bei jedem Release aktualisiert (aktuell: `v0.55.10`)
 - Kein Bild, keine Icons außer `★` (Unicode)
 - Auf Mobile: nur `★ {stars}  ·  16 languages  ·  MIT` (3 Elemente, Rest ausgeblendet via `@media (max-width: 600px)`)
 
@@ -212,7 +212,7 @@ Link zur `install.html` unter den 3 Schritten:
 ## 13. Footer
 
 **Neue Zeile über den Links:**  
-`v0.55.3  ·  ★ {stars}  ·  Last release: May 2026` — selbes Sterne-Objekt aus sessionStorage.
+`v0.55.10  ·  ★ {stars}  ·  Last release: June 2026` — selbes Sterne-Objekt aus sessionStorage.
 
 **Neue vierte Link-Option:**  
 `install.html` → `"Install"` / `"Installieren"` — neben GitHub, MIT, Contributing.

--- a/docs/index.html
+++ b/docs/index.html
@@ -462,7 +462,7 @@
     <span class="proof-sep proof-dt-only">·</span>
     <span class="proof-dt-only">MIT licensed</span>
     <span class="proof-sep">·</span>
-    <span>v0.55.3</span>
+    <span>v0.55.10</span>
   </div>
 </div>
 
@@ -563,7 +563,7 @@
       <div class="feat-card reveal">
         <div class="feat-card-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"></rect><line x1="8" y1="21" x2="16" y2="21"></line><line x1="12" y1="17" x2="12" y2="21"></line></svg></div>
         <h3 data-t="f_pwa_t">Works Everywhere</h3>
-        <p data-t="f_pwa_d">Installable PWA on any device. Offline support, dark mode, fully responsive from phone to desktop.</p>
+        <p data-t="f_pwa_d">Installable PWA on any device. Offline support, polished mobile navigation, touch-safe controls, dark mode, and responsive layouts from phone to desktop.</p>
       </div>
     </div>
   </div>
@@ -641,7 +641,7 @@
     <div class="showcase-header reveal vis">
       <p class="section-label" data-t="screens_label">Preview</p>
       <h2 class="section-title" data-t="screens_title">Every screen, beautifully crafted</h2>
-      <p class="section-desc" data-t="screens_desc">A clean, intuitive interface that adapts to your device and preferred theme.</p>
+      <p class="section-desc" data-t="screens_desc">A clean, intuitive interface with readable work surfaces, tuned touch targets, and layouts that adapt to your device and preferred theme.</p>
     </div>
   </div>
   <div class="carousel-track">
@@ -725,7 +725,7 @@ cp .env.example .env
 
 <footer>
   <div class="wrap">
-    <p class="footer-meta"><span id="gh-stars-footer"></span><span id="footer-sep" style="display:none"> · </span>v0.55.3 · May 2026</p>
+    <p class="footer-meta"><span id="gh-stars-footer"></span><span id="footer-sep" style="display:none"> · </span>v0.55.10 · June 2026</p>
     <p data-t="footer_heart">Built with care for families who value privacy and simplicity.</p>
     <div class="footer-links">
       <a href="install.html" data-t="footer_install">Install</a>
@@ -766,13 +766,13 @@ cp .env.example .env
       f_budget_t:'Budget & Split Expenses', f_budget_d:'Track income and expenses with 15 currency options, recurring entries, and loan tracking. Split shared costs in groups with equal, percentage, or exact-amount splits, multi-currency support, and automatic debt simplification.',
       f_notes_t:'Notes', f_notes_d:'Colored sticky notes with Markdown support. Perfect for recipes, family memos, and quick reminders.',
       f_contacts_t:'Contacts', f_contacts_d:'Shared family contact directory with CardDAV sync, vCard import/export, and multi-account support.',
-      f_pwa_t:'Works Everywhere', f_pwa_d:'Installable PWA on any device. Offline support, dark mode, fully responsive from phone to desktop.',
+      f_pwa_t:'Works Everywhere', f_pwa_d:'Installable PWA on any device. Offline support, polished mobile navigation, touch-safe controls, dark mode, and responsive layouts from phone to desktop.',
       f_housekeeping_t:'Housekeeping', f_housekeeping_d:'Manage household staff with check-in/check-out sessions, recurring chore tracking, supply requests, and monthly payment summaries.',
       f_tasks_t2:'Tasks', f_cal_t2:'Calendar', f_shop_t2:'Shopping', f_meals_t2:'Meals',
       f_recipes_t2:'Recipes', f_birthdays_t2:'Birthdays', f_housekeeping_t2:'Housekeeping',
       f_budget_t2:'Budget', f_notes_t2:'Notes', f_contacts_t2:'Contacts', f_settings_t:'Settings',
       screens_label:'Preview', screens_title:'Every screen, beautifully crafted',
-      screens_desc:'A clean, intuitive interface that adapts to your device and preferred theme.',
+      screens_desc:'A clean, intuitive interface with readable work surfaces, tuned touch targets, and layouts that adapt to your device and preferred theme.',
       why_label:'Why Oikos', why_title:'Built for families, not for profit.',
       phil_label:'Philosophy', phil_title:'Built different, on purpose',
       phil_desc:'No subscriptions, no vendor lock-in, no data leaving your home.',
@@ -816,13 +816,13 @@ cp .env.example .env
       f_budget_t:'Budget & Ausgaben teilen', f_budget_d:'Einnahmen und Ausgaben verfolgen mit 15 Währungen, wiederkehrenden Einträgen und Kreditverwaltung. Gemeinsame Ausgaben in Gruppen aufteilen — gleich, prozentual oder exakt, mit Multi-Währungs-Support und automatischer Schulden-Vereinfachung.',
       f_notes_t:'Notizen', f_notes_d:'Farbige Haftnotizen mit Markdown-Support. Perfekt für Rezepte, Familien-Memos und schnelle Erinnerungen.',
       f_contacts_t:'Kontakte', f_contacts_d:'Gemeinsames Familien-Kontaktverzeichnis mit CardDAV-Sync, vCard-Import/-Export und Multi-Account-Support.',
-      f_pwa_t:'Überall nutzbar', f_pwa_d:'Installierbare PWA auf jedem Gerät. Offline-Support, Dark Mode, voll responsive vom Handy bis Desktop.',
+      f_pwa_t:'Überall nutzbar', f_pwa_d:'Installierbare PWA auf jedem Gerät. Offline-Support, optimierte mobile Navigation, touch-sichere Controls, Dark Mode und responsive Layouts vom Handy bis Desktop.',
       f_housekeeping_t:'Haushaltshilfe', f_housekeeping_d:'Haushaltspersonal verwalten mit Ein-/Ausstempeln, wiederkehrender Chore-Verfolgung, Bedarfsanfragen und monatlichen Abrechnungsübersichten.',
       f_tasks_t2:'Aufgaben', f_cal_t2:'Kalender', f_shop_t2:'Einkauf', f_meals_t2:'Mahlzeiten',
       f_recipes_t2:'Rezepte', f_birthdays_t2:'Geburtstage', f_housekeeping_t2:'Haushaltshilfe',
       f_budget_t2:'Budget', f_notes_t2:'Notizen', f_contacts_t2:'Kontakte', f_settings_t:'Einstellungen',
       screens_label:'Vorschau', screens_title:'Jeder Screen, schön gestaltet',
-      screens_desc:'Eine klare, intuitive Oberfläche, die sich an euer Gerät und bevorzugtes Theme anpasst.',
+      screens_desc:'Eine klare, intuitive Oberfläche mit lesbaren Arbeitsflächen, optimierten Touch-Zielen und Layouts, die sich an euer Gerät und bevorzugtes Theme anpassen.',
       why_label:'Warum Oikos', why_title:'Für Familien gebaut, nicht für Profit.',
       phil_label:'Philosophie', phil_title:'Bewusst anders gebaut',
       phil_desc:'Keine Abos, kein Vendor-Lock-in, keine Daten, die euer Zuhause verlassen.',


### PR DESCRIPTION
## Summary
- update README and GitHub Pages copy for the completed frontend UI/UX audit rollout
- document mobile dashboard, Tasks/Shopping, Calendar, Settings, navigation, and glass-surface changes in docs/SPEC.md
- mark the audit/implementation plan docs with completed rollout status and refresh stale landing-page version references

## Validation
- npm run test:frontend-audit
- git diff --check