### PR TITLE
docs: sync docs with installer changes in v0.55.18-v0.55.19

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ git clone https://github.com/ulsklyc/oikos.git && cd oikos
 node tools/installer/install-server.js
 ```
 
-Open **http://localhost:8090** in your browser. The wizard configures your `.env`, starts Docker, and creates your admin account. Requires Node.js 18+ on the host.
+Open **http://localhost:8090** in your browser. The localized wizard (16 languages) checks your Docker setup, configures your `.env` — including optional reverse proxy/HTTPS, SSO (OIDC), and automatic backups — starts Docker, and creates your admin account. Requires Node.js 18+ on the host.
 
 **Option B — Pre-built image (no clone required)**
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -462,7 +462,7 @@
     <span class="proof-sep proof-dt-only">·</span>
     <span class="proof-dt-only">MIT licensed</span>
     <span class="proof-sep">·</span>
-    <span>v0.55.16</span>
+    <span>v0.55.19</span>
   </div>
 </div>
 
@@ -725,7 +725,7 @@ cp .env.example .env
 
 <footer>
   <div class="wrap">
-    <p class="footer-meta"><span id="gh-stars-footer"></span><span id="footer-sep" style="display:none"> · </span>v0.55.16 · June 2026</p>
+    <p class="footer-meta"><span id="gh-stars-footer"></span><span id="footer-sep" style="display:none"> · </span>v0.55.19 · June 2026</p>
     <p data-t="footer_heart">Built with care for families who value privacy and simplicity.</p>
     <div class="footer-links">
       <a href="install.html" data-t="footer_install">Install</a>

--- a/docs/install.html
+++ b/docs/install.html
@@ -565,7 +565,7 @@
       <div class="tab-panel active" id="panel-installer" role="tabpanel" aria-labelledby="tab-installer">
         <div class="callout callout-success reveal">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>
-          <span data-t="option_installer_info">Recommended for most users. A browser-based wizard configures your .env, starts Docker, and creates your admin account — no manual steps. Requires Node.js 18+ on the host.</span>
+          <span data-t="option_installer_info">Recommended for most users. A localized browser wizard (16 languages) checks your Docker setup, then configures your .env — including optional reverse proxy/HTTPS, Single Sign-On (OIDC), and automatic backups — starts Docker, and creates your admin account. No manual steps. Requires Node.js 18+ on the host.</span>
         </div>
 
         <div class="step reveal">
@@ -970,7 +970,7 @@ docker compose logs | grep "Server läuft"</div>
           tab_installer: 'Option A \u2014 Web Installer',
           tab_a: 'Option B \u2014 Pre-built Image',
           tab_b: 'Option C \u2014 Build from Source',
-          option_installer_info: 'Recommended for most users. A browser-based wizard configures your .env, starts Docker, and creates your admin account \u2014 no manual steps. Requires Node.js 18+ on the host.',
+          option_installer_info: 'Recommended for most users. A localized browser wizard (16 languages) checks your Docker setup, then configures your .env \u2014 including optional reverse proxy/HTTPS, Single Sign-On (OIDC), and automatic backups \u2014 starts Docker, and creates your admin account. No manual steps. Requires Node.js 18+ on the host.',
           option_a_info: 'No Git, no build step \u2014 just two files and a single command. Requires only Docker.',
           option_b_info: 'For contributors or those who want to run a custom version. Requires Git. The first build takes a few minutes.',
           step_inst1_title: 'Clone the repository',
@@ -1066,7 +1066,7 @@ docker compose logs | grep "Server läuft"</div>
           tab_installer: 'Option A \u2014 Web-Installer',
           tab_a: 'Option B \u2014 Fertiges Image',
           tab_b: 'Option C \u2014 Aus Quellcode bauen',
-          option_installer_info: 'Empfohlen f\u00fcr die meisten Nutzer. Ein browserbasierter Assistent konfiguriert eure .env, startet Docker und erstellt euer Admin-Konto \u2014 ganz ohne manuelle Schritte. Erfordert Node.js 18+ auf dem Host.',
+          option_installer_info: 'Empfohlen f\u00fcr die meisten Nutzer. Ein lokalisierter Browser-Assistent (16 Sprachen) pr\u00fcft eure Docker-Installation und konfiguriert dann eure .env \u2014 inklusive optionalem Reverse-Proxy/HTTPS, Single Sign-On (OIDC) und automatischen Backups \u2014 startet Docker und erstellt euer Admin-Konto. Ganz ohne manuelle Schritte. Erfordert Node.js 18+ auf dem Host.',
           option_a_info: 'Kein Git, kein Build-Schritt \u2014 nur zwei Dateien und ein einziger Befehl. Nur Docker erforderlich.',
           option_b_info: 'F\u00fcr Mitwirkende oder wer eine eigene Version ausf\u00fchren m\u00f6chte. Erfordert Git. Der erste Build dauert einige Minuten.',
           step_inst1_title: 'Repository klonen',

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -10,7 +10,7 @@ node tools/installer/install-server.js
 # Open http://localhost:8090
 ```
 
-Requires Node.js 18+ on the host. The browser-based wizard configures your `.env`, starts Docker, and creates your admin account. Docker still runs the app itself.
+Requires Node.js 18+ on the host. The browser-based wizard is fully localized (16 languages, auto-detected from your browser), checks Docker prerequisites first, then configures your `.env` — including optional reverse-proxy/HTTPS, Single Sign-On (OIDC), and automatic backups — starts Docker, and creates your admin account. Docker still runs the app itself.
 
 ### Option B — CLI Installer (Linux / macOS)
 
@@ -133,12 +133,13 @@ node tools/installer/install-server.js
 
 #### 3. Open the Wizard
 
-Open your browser and navigate to **http://localhost:8090**. The wizard guides you through:
+Open your browser and navigate to **http://localhost:8090**. The wizard detects your browser language (16 languages supported), verifies that Docker and Docker Compose v2 are available, and reports any existing `.env` file or running container before you start. It then guides you through:
 
-- Basic configuration (host, port, timezone)
-- Security key generation
+- Basics — timezone (`TZ`) and HTTP host port (`OIKOS_HTTP_PORT`)
+- Security key generation (`SESSION_SECRET`, `DB_ENCRYPTION_KEY`)
 - Optional integrations (weather, Google Calendar, Apple CalDAV)
-- Writing your `.env` file
+- Advanced settings — reverse-proxy/HTTPS (`SESSION_SECURE`, `TRUST_PROXY`), Single Sign-On (OIDC), and automatic backups
+- Writing your `.env` file (an existing `.env` is backed up to `.env.bak-<timestamp>` first)
 - Starting the Docker container
 - Creating your admin account
 
@@ -269,7 +270,9 @@ All configuration happens in the `.env` file. The container reads these values o
 
 | Variable | Description | Default | Required |
 |----------|-------------|---------|----------|
-| `PORT` | Port the Express server listens on | `3000` | No |
+| `PORT` | Port the Express server listens on **inside the container** (rarely changed) | `3000` | No |
+| `OIKOS_HTTP_PORT` | Host port that `docker-compose.yml` maps to the container's port 3000. Change this to expose Oikos on a different host port; the app inside the container always listens on 3000. | `3000` | No |
+| `TZ` | Container timezone (e.g. `Europe/Berlin`). Affects timestamps and the automated-backup schedule. | `UTC` | No |
 | `NODE_ENV` | Runtime environment | `production` | No |
 | `TRUST_PROXY` | Number of reverse-proxy hops to trust, or a subnet string (e.g. `1`, `172.16.0.0/12`, `loopback`). Set to `1` when running behind a single Traefik/Nginx hop so `req.ip` returns the real client IP. Numeric values are treated as a hop count; subnet strings and named values (`loopback`, `linklocal`, `uniquelocal`) work as expected. | `false` | No |
 
@@ -420,16 +423,16 @@ sudo certbot renew --dry-run
 
 ### Update Oikos for HTTPS
 
-When using HTTPS through a reverse proxy, remove or comment out the `SESSION_SECURE=false` line in `docker-compose.yml`:
+`docker-compose.yml` reads `SESSION_SECURE` from your `.env` (`${SESSION_SECURE:-false}`), so you no longer need to edit the Compose file. When running behind an HTTPS reverse proxy, set these in `.env`:
 
-```yaml
-environment:
-  - NODE_ENV=production
-  - DB_PATH=/data/oikos.db
-  # - SESSION_SECURE=false   # Remove this for HTTPS
+```bash
+SESSION_SECURE=true
+TRUST_PROXY=1
 ```
 
-Then restart the container:
+> The web installer's **Advanced** step and `install.sh` set both values for you when you choose a reverse-proxy deployment.
+
+Then restart the container so the new values take effect:
 
 ```bash
 docker compose up -d
@@ -555,12 +558,13 @@ If port 3000 is already occupied by another application:
 lsof -i :3000
 ```
 
-Either stop the conflicting process, or change the port in your `.env` file and `docker-compose.yml`:
+Either stop the conflicting process, or change the host port in your `.env` file — `docker-compose.yml` maps `OIKOS_HTTP_PORT` to the container's port 3000 automatically:
 
-```yaml
-ports:
-  - "0.0.0.0:8080:3000"
+```bash
+OIKOS_HTTP_PORT=8080
 ```
+
+Then run `docker compose up -d` to apply it.
 
 </details>
 

--- a/tools/installer/README.md
+++ b/tools/installer/README.md
@@ -1,7 +1,7 @@
 # Oikos Web Installer
 
 A browser-based setup wizard for Oikos. Run it once to configure your `.env`,
-start Docker, and create your admin account.
+start Docker, and create your admin account — no hand-editing of config files.
 
 ## Usage
 
@@ -17,14 +17,54 @@ The server shuts down automatically after setup completes (or after 30 minutes o
 
 ## Requirements
 
-- Node.js 18+
+- Node.js 18+ (the installer itself has zero npm dependencies — Node built-ins only)
 - Docker with Compose v2
 - The repository cloned locally
 
+The wizard verifies that `docker` and `docker compose` v2 are available before it
+starts, and surfaces container start/spawn errors in the UI instead of failing silently.
+
 ## What it does
 
-1. Guides you through all configuration options
-2. Writes `.env` to the project root
-3. Starts the Docker container (`docker compose up -d`)
-4. Polls the health endpoint until the container is ready
-5. Creates your first admin account via `POST /api/v1/auth/setup`
+1. Checks Docker prerequisites and reports any existing `.env` file or running
+   `oikos` container before you start
+2. Guides you through all configuration options, grouped into steps:
+   - **Basics** — timezone (`TZ`) and HTTP host port (`OIKOS_HTTP_PORT`)
+   - **Security keys** — generates `SESSION_SECRET` and `DB_ENCRYPTION_KEY`
+   - **Optional integrations** — weather, Google Calendar, Apple CalDAV
+   - **Advanced** — reverse-proxy/HTTPS (`SESSION_SECURE`, `TRUST_PROXY`),
+     Single Sign-On (OIDC), and automatic backups
+3. Backs up any existing `.env` to `.env.bak-<ISO>` before writing
+4. Writes `.env` to the project root (keys are allowlisted against the shared
+   env schema; values containing line breaks are rejected)
+5. Starts the Docker container (`docker compose up -d`)
+6. Polls the health endpoint until the container is ready
+7. Creates your first admin account via `POST /api/v1/auth/setup`
+
+## Localization
+
+The wizard is fully localized into all 16 languages supported by the app and
+detects the browser language automatically (`de` is the reference locale, `en`
+the fallback). Translations live in `tools/installer/locales/*.json` and are
+loaded by `i18n-mini.js`, which mirrors the app's locale resolution.
+
+## Design
+
+The wizard reuses the app's design language: shared design tokens
+(`public/styles/tokens.css`) and the Plus Jakarta Sans variable font are served
+read-only from the repo, so the installer matches the app's violet accent,
+radii, shadows, and automatic dark mode. The wizard meets WCAG 2.1 AA
+(keyboard-operable accordions, ARIA live regions for Docker status, focus
+management, and labelled controls).
+
+## Architecture
+
+- `install-server.js` — the temporary HTTP server (port 8090). Endpoints:
+  `GET /api/defaults` (serves `ENV_SCHEMA`), `GET /api/prereqs`,
+  `GET /api/preflight` (existing `.env` / running container),
+  `POST /api/generate-secret`, `POST /api/save-env`, `POST /api/start`,
+  `GET /api/status`, `POST /api/create-admin`.
+- `env-schema.js` — the single source of truth (`ENV_SCHEMA`) for every
+  configurable variable, its group, default, and whether it is written to `.env`.
+- `i18n-mini.js` + `locales/*.json` — localization.
+- `install.html` — the wizard UI.


### PR DESCRIPTION
Synchronizes all documentation with the modernized web installer shipped in v0.55.18 and v0.55.19.

## Changes
- **tools/installer/README.md** — full rewrite: prerequisite checks, grouped wizard steps incl. **Advanced** (reverse proxy/HTTPS, OIDC, backups), `.env` backup, injection-safe writing, 16-language localization, app design language, endpoint/architecture overview.
- **docs/installation.md** — add `OIKOS_HTTP_PORT` and `TZ` to the Server env-var table; expand the Option A wizard description (2×); fix the HTTPS section to set `SESSION_SECURE`/`TRUST_PROXY` via `.env` (compose now derives them); switch port troubleshooting to `OIKOS_HTTP_PORT`.
- **docs/install.html** — extend the Option A callout (visible HTML + EN/DE i18n strings).
- **docs/index.html** — bump version badge v0.55.16 → v0.55.19 (hero + footer).
- **README.md** — note localization and Advanced settings in Quick Start.

Verified already-current (no change): `docker-compose.yml`, `install.sh`, `.env.example`, the OIDC/Backup/TRUST_PROXY env tables, and `docs/SPEC.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)