### PR TITLE
feat: Podman + SELinux support for RHEL-based systems

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,14 +6,19 @@ PORT=3000
 NODE_ENV=production
 # LOG_LEVEL=info   # debug, info, warn, error (default: info)
 
-# Docker host port mapping (docker-compose.yml maps OIKOS_HTTP_PORT:3000).
+# Container host port mapping (compose maps OIKOS_HTTP_PORT:3000).
 # The app inside the container always listens on 3000; change only the host port here.
 OIKOS_HTTP_PORT=3000
+# Host bind address for the published port (podman-compose.yml only; default 0.0.0.0).
+# Set to 127.0.0.1 for rootless Podman behind a reverse proxy on the same host.
+# OIKOS_HTTP_BIND=0.0.0.0
 # TZ=Europe/Berlin   # Container timezone (default: UTC)
 
-# Docker storage paths
+# Container storage paths (bind mounts)
 # DATA_DIR=./data              # Host folder for the database and stored app data
 # BACKUP_DIR=./backups         # Host folder for scheduled backups
+# On SELinux systems (RHEL/Fedora/CentOS Stream) use podman-compose.yml — it adds
+# the :Z relabel automatically so the container can access these folders.
 
 # Session
 SESSION_SECRET=REPLACE_WITH_A_LONG_RANDOM_STRING

--- a/MODULES.md
+++ b/MODULES.md
@@ -83,6 +83,8 @@ Oikos scans `modules/` and validates each `module.json`. Invalid modules are sho
 
 Admins can enable, disable, and order modules in Settings -> General -> Active modules. Copying a new folder into `modules/` makes it appear there automatically.
 
-## Docker
+## Docker / Podman
 
 The default `docker-compose.yml` mounts `${MODULES_DIR:-./modules}` to `/app/modules`. To keep modules outside the Oikos checkout, set `MODULES_DIR=/absolute/path/to/oikos-modules` in `.env` and restart the compose service. New or changed module folders are scanned at runtime; rebuilding the image is not required.
+
+On Podman (RHEL/Fedora/CentOS Stream) use `podman-compose.yml` instead — it mounts the same `/app/modules` path with the SELinux `:Z` relabel so the rootless container can read your modules.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 
 <br>
 
-Oikos is a self-hosted web app that keeps your household organized — tasks, groceries, meals, calendar, budget, and more — in one private place, without cloud accounts or subscriptions. Runs as a Docker container on any home server or NAS. Accessible on every device with a polished mobile-first PWA interface.
+Oikos is a self-hosted web app that keeps your household organized — tasks, groceries, meals, calendar, budget, and more — in one private place, without cloud accounts or subscriptions. Runs as a Docker or Podman container on any home server or NAS — including rootless Podman on SELinux-enabled RHEL/Fedora/CentOS Stream. Accessible on every device with a polished mobile-first PWA interface.
 
 Each module is independent. Use what fits, skip what doesn't.
 
@@ -78,7 +78,7 @@ git clone https://github.com/ulsklyc/oikos.git && cd oikos
 node tools/installer/install-server.js
 ```
 
-Open **http://localhost:8090** in your browser. The localized wizard (16 languages) checks your Docker setup, configures your `.env` — including optional reverse proxy/HTTPS, SSO (OIDC), and automatic backups — starts Docker, and creates your admin account. Requires Node.js 18+ on the host.
+Open **http://localhost:8090** in your browser. The localized wizard (16 languages) detects your container engine (Docker or Podman), configures your `.env` — including optional reverse proxy/HTTPS, SSO (OIDC), and automatic backups — starts the container, and creates your admin account. Requires Node.js 18+ on the host.
 
 **Option B — Pre-built image (no clone required)**
 
@@ -101,7 +101,13 @@ docker compose exec oikos node setup.js
 
 Open `http://localhost:3000` and sign in with the admin credentials you created above.
 
-> **New to Docker?** The **[Installation Guide](docs/installation.md)** covers Docker setup, HTTPS, backups, and troubleshooting step by step.
+> **Using Podman (RHEL / Fedora / CentOS Stream)?** Both installers above auto-detect
+> Podman and use `podman-compose.yml` (SELinux `:Z` labels, configurable host bind).
+> For a manual start, replace `docker compose` with `podman compose -f podman-compose.yml`
+> (or `podman-compose -f podman-compose.yml`). For rootless systemd autostart, see the
+> Quadlet unit at `tools/quadlet/oikos.container`.
+
+> **New to Docker or Podman?** The **[Installation Guide](docs/installation.md)** covers engine setup, HTTPS, backups, and troubleshooting step by step.
 
 ---
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1,6 +1,6 @@
 # Oikos - Product Specification
 
-Self-hosted family planner web app for a single household (2–6 people). No app store, no public access. Deployment via Docker on a private Linux server behind an Nginx reverse proxy with SSL.
+Self-hosted family planner web app for a single household (2–6 people). No app store, no public access. Deployment via Docker or Podman (rootless, SELinux-ready) on a private Linux server behind an Nginx reverse proxy with SSL.
 
 ---
 
@@ -928,7 +928,7 @@ modules/
 - Disabled modules are not served to the browser and do not appear in navigation.
 - Enabled module pages are registered automatically in the SPA router at startup.
 
-**Docker:** The default `docker-compose.yml` mounts `${MODULES_DIR:-./modules}` to `/app/modules`. To keep modules outside the Oikos checkout set `MODULES_DIR=/absolute/path` in `.env` and restart. No image rebuild is required.
+**Docker / Podman:** The default `docker-compose.yml` mounts `${MODULES_DIR:-./modules}` to `/app/modules`. To keep modules outside the Oikos checkout set `MODULES_DIR=/absolute/path` in `.env` and restart. No image rebuild is required. On Podman use `podman-compose.yml`, which adds the SELinux `:Z` relabel to the same mount.
 
 **Security rules for module authors:**
 - Use `replaceChildren()` and `insertAdjacentHTML()`. Never use `innerHTML`.

--- a/docs/index.html
+++ b/docs/index.html
@@ -437,6 +437,7 @@
       <div class="hero-tags">
         <span class="tag">MIT License</span>
         <span class="tag">Docker</span>
+        <span class="tag">Podman</span>
         <span class="tag">PWA</span>
         <span class="tag">16 languages</span>
         <span class="tag" data-t="tag_nocloud">No Cloud Required</span>
@@ -511,7 +512,7 @@
         <div class="phil-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="2" width="20" height="8" rx="2" ry="2"></rect><rect x="2" y="14" width="20" height="8" rx="2" ry="2"></rect><line x1="6" y1="6" x2="6.01" y2="6"></line><line x1="6" y1="18" x2="6.01" y2="18"></line></svg></div>
         <div>
           <h3 data-t="p_self_t">Fully Self-Hosted</h3>
-          <p data-t="p_self_d">Runs on a Raspberry Pi, a NAS, or any server. Docker makes setup a one-liner.</p>
+          <p data-t="p_self_d">Runs on a Raspberry Pi, a NAS, or any server. Docker or Podman makes setup a one-liner.</p>
         </div>
       </div>
       <div class="phil-card reveal reveal-d2">
@@ -691,7 +692,11 @@ curl -O https://raw.githubusercontent.com/ulsklyc/oikos/main/.env.example
 cp .env.example .env
 <span class="c"># Set SESSION_SECRET and DB_ENCRYPTION_KEY in .env</span>
 <span class="h">docker compose up -d</span>
-<span class="h">docker compose exec oikos node setup.js</span></div>
+<span class="h">docker compose exec oikos node setup.js</span>
+
+<span class="c"># Podman (RHEL/Fedora/CentOS Stream): use podman-compose.yml instead</span>
+<span class="c"># curl -O .../main/podman-compose.yml</span>
+<span class="c"># podman compose -f podman-compose.yml up -d</span></div>
         <p class="setup-note" data-t="setup_note">Then open <code>http://localhost:3000</code> and log in. Need a step-by-step guide, HTTPS setup, or troubleshooting? See the <a href="https://github.com/ulsklyc/oikos/blob/main/docs/installation.md" target="_blank" rel="noopener">Installation Guide</a>.</p>
       </div>
       <a href="install.html" class="setup-guide-link" data-t="setup_guide_link">→ Step-by-step installation guide</a>
@@ -777,7 +782,7 @@ cp .env.example .env
       phil_label:'Philosophy', phil_title:'Built different, on purpose',
       phil_desc:'No subscriptions, no vendor lock-in, no data leaving your home.',
       p_priv_t:'Privacy First', p_priv_d:'AES-256 encrypted database with SQLCipher. Zero telemetry. Your data never leaves your server.',
-      p_self_t:'Fully Self-Hosted', p_self_d:'Runs on a Raspberry Pi, a NAS, or any server. Docker makes setup a one-liner.',
+      p_self_t:'Fully Self-Hosted', p_self_d:'Runs on a Raspberry Pi, a NAS, or any server. Docker or Podman makes setup a one-liner.',
       p_build_t:'Zero Build Step', p_build_d:'Pure ES modules, vanilla JS, plain CSS. No bundler, no transpiler, no framework. Ships what you write.',
       p_open_t:'Open Source', p_open_d:'MIT licensed. Inspect, modify, extend, contribute. Built in the open for families who care about transparency.',
       setup_label:'Setup', setup_title:'Up and running in minutes',
@@ -827,7 +832,7 @@ cp .env.example .env
       phil_label:'Philosophie', phil_title:'Bewusst anders gebaut',
       phil_desc:'Keine Abos, kein Vendor-Lock-in, keine Daten, die euer Zuhause verlassen.',
       p_priv_t:'Datenschutz zuerst', p_priv_d:'AES-256-verschlüsselte Datenbank mit SQLCipher. Keine Telemetrie. Eure Daten verlassen nie euren Server.',
-      p_self_t:'Vollständig selbstgehostet', p_self_d:'Läuft auf einem Raspberry Pi, NAS oder jedem Server. Docker macht das Setup zum Einzeiler.',
+      p_self_t:'Vollständig selbstgehostet', p_self_d:'Läuft auf einem Raspberry Pi, NAS oder jedem Server. Docker oder Podman macht das Setup zum Einzeiler.',
       p_build_t:'Kein Build-Schritt', p_build_d:'Pure ES-Module, Vanilla JS, reines CSS. Kein Bundler, kein Transpiler, kein Framework.',
       p_open_t:'Open Source', p_open_d:'MIT-lizenziert. Einsehen, anpassen, erweitern, beitragen. Offen gebaut für Familien, die Transparenz schätzen.',
       setup_label:'Setup', setup_title:'In Minuten einsatzbereit',

--- a/docs/install.html
+++ b/docs/install.html
@@ -496,7 +496,7 @@
         <span data-t="hero_eyebrow">Installation</span>
       </p>
       <h1 class="reveal" data-t="hero_title">Install Oikos</h1>
-      <p class="hero-desc reveal" data-t="hero_desc">Get your self-hosted family planner running in a few minutes. No programming experience required — just Docker.</p>
+      <p class="hero-desc reveal" data-t="hero_desc">Get your self-hosted family planner running in a few minutes. No programming experience required — just Docker or Podman.</p>
       <div class="reveal">
         <span class="time-badge">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
@@ -511,16 +511,17 @@
     <div class="container">
       <p class="section-label reveal" data-t="prereq_label">Before you start</p>
       <h2 class="section-title reveal" data-t="prereq_title">What you need</h2>
-      <p class="section-desc reveal" data-t="prereq_desc">Oikos runs as a Docker container — you don't need to install Node.js or any other runtime. Just Docker, and you're good to go.</p>
+      <p class="section-desc reveal" data-t="prereq_desc">Oikos runs as a Docker or Podman container — you don't need to install Node.js or any other runtime. Just a container engine, and you're good to go.</p>
       <div class="prereq-grid">
         <div class="prereq-card reveal">
           <div class="prereq-icon" aria-hidden="true">🐳</div>
-          <h3>Docker</h3>
-          <p data-t="prereq_docker_desc">Packages the app so you don't need to install anything else. Free for personal use.</p>
+          <h3>Docker or Podman</h3>
+          <p data-t="prereq_docker_desc">Packages the app so you don't need to install anything else. Free for personal use. Podman (RHEL/Fedora/CentOS Stream) works too — rootless and SELinux-ready.</p>
           <div class="prereq-links">
             <a href="https://docs.docker.com/desktop/install/mac-install/" target="_blank" rel="noopener" class="prereq-link">macOS</a>
             <a href="https://docs.docker.com/desktop/install/windows-install/" target="_blank" rel="noopener" class="prereq-link">Windows</a>
             <a href="https://docs.docker.com/engine/install/" target="_blank" rel="noopener" class="prereq-link">Linux</a>
+            <a href="https://podman.io/docs/installation" target="_blank" rel="noopener" class="prereq-link">Podman</a>
           </div>
         </div>
         <div class="prereq-card reveal reveal-delay-1">
@@ -565,7 +566,7 @@
       <div class="tab-panel active" id="panel-installer" role="tabpanel" aria-labelledby="tab-installer">
         <div class="callout callout-success reveal">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>
-          <span data-t="option_installer_info">Recommended for most users. A localized browser wizard (16 languages) checks your Docker setup, then configures your .env — including optional reverse proxy/HTTPS, Single Sign-On (OIDC), and automatic backups — starts Docker, and creates your admin account. No manual steps. Requires Node.js 18+ on the host.</span>
+          <span data-t="option_installer_info">Recommended for most users. A localized browser wizard (16 languages) detects your container engine (Docker or Podman), then configures your .env — including optional reverse proxy/HTTPS, Single Sign-On (OIDC), and automatic backups — starts the container, and creates your admin account. No manual steps. Requires Node.js 18+ on the host.</span>
         </div>
 
         <div class="step reveal">
@@ -603,7 +604,7 @@ cd oikos</div>
           <div class="step-num" aria-hidden="true">3</div>
           <div class="step-content">
             <h3 class="step-title" data-t="step_inst3_title">Open the wizard in your browser</h3>
-            <p class="step-desc" data-t="step_inst3_desc">Navigate to the following address. The wizard will guide you through configuration, Docker startup, and admin account creation.</p>
+            <p class="step-desc" data-t="step_inst3_desc">Navigate to the following address. The wizard will guide you through configuration, container startup, and admin account creation.</p>
             <div class="code-wrap">
               <div class="code-block" role="region" aria-label="Installer URL"><span class="val">http://localhost:8090</span></div>
               <button class="copy-btn" data-copy="http://localhost:8090" aria-label="Copy URL">
@@ -613,7 +614,7 @@ cd oikos</div>
             </div>
             <div class="callout callout-info">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
-              <span data-t="step_inst3_info">The installer shuts down automatically after setup completes. Your Oikos instance keeps running via Docker.</span>
+              <span data-t="step_inst3_info">The installer shuts down automatically after setup completes. Your Oikos instance keeps running via Docker or Podman.</span>
             </div>
           </div>
         </div>
@@ -623,7 +624,7 @@ cd oikos</div>
       <div class="tab-panel" id="panel-a" role="tabpanel" aria-labelledby="tab-a">
         <div class="callout callout-info reveal">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
-          <span data-t="option_a_info">No Git, no build step — just two files and a single command. Requires only Docker.</span>
+          <span data-t="option_a_info">No Git, no build step — just two files and a single command. Requires only Docker or Podman (Podman: use podman-compose.yml).</span>
         </div>
 
         <div class="step reveal">
@@ -953,12 +954,12 @@ docker compose logs | grep "Server läuft"</div>
         en: {
           hero_eyebrow: 'Installation',
           hero_title: 'Install Oikos',
-          hero_desc: 'Get your self-hosted family planner running in a few minutes. No programming experience required \u2014 just Docker.',
+          hero_desc: 'Get your self-hosted family planner running in a few minutes. No programming experience required \u2014 just Docker or Podman.',
           hero_time: '~10 minutes',
           prereq_label: 'Before you start',
           prereq_title: 'What you need',
-          prereq_desc: 'Oikos runs as a Docker container \u2014 you don\u2019t need to install Node.js or any other runtime. Just Docker, and you\u2019re good to go.',
-          prereq_docker_desc: 'Packages the app so you don\u2019t need to install anything else. Free for personal use.',
+          prereq_desc: 'Oikos runs as a Docker or Podman container \u2014 you don\u2019t need to install Node.js or any other runtime. Just a container engine, and you\u2019re good to go.',
+          prereq_docker_desc: 'Packages the app so you don\u2019t need to install anything else. Free for personal use. Podman (RHEL/Fedora/CentOS Stream) works too \u2014 rootless and SELinux-ready.',
           prereq_terminal_title: 'Terminal',
           prereq_terminal_desc: 'A command-line interface to type a few commands. Built into every OS \u2014 no extra install needed.',
           prereq_terminal_hint: 'macOS: Terminal \u00b7 Windows: PowerShell \u00b7 Linux: bash',
@@ -970,16 +971,16 @@ docker compose logs | grep "Server läuft"</div>
           tab_installer: 'Option A \u2014 Web Installer',
           tab_a: 'Option B \u2014 Pre-built Image',
           tab_b: 'Option C \u2014 Build from Source',
-          option_installer_info: 'Recommended for most users. A localized browser wizard (16 languages) checks your Docker setup, then configures your .env \u2014 including optional reverse proxy/HTTPS, Single Sign-On (OIDC), and automatic backups \u2014 starts Docker, and creates your admin account. No manual steps. Requires Node.js 18+ on the host.',
-          option_a_info: 'No Git, no build step \u2014 just two files and a single command. Requires only Docker.',
+          option_installer_info: 'Recommended for most users. A localized browser wizard (16 languages) detects your container engine (Docker or Podman), then configures your .env \u2014 including optional reverse proxy/HTTPS, Single Sign-On (OIDC), and automatic backups \u2014 starts the container, and creates your admin account. No manual steps. Requires Node.js 18+ on the host.',
+          option_a_info: 'No Git, no build step \u2014 just two files and a single command. Requires only Docker or Podman (Podman: use podman-compose.yml).',
           option_b_info: 'For contributors or those who want to run a custom version. Requires Git. The first build takes a few minutes.',
           step_inst1_title: 'Clone the repository',
           step_inst1_desc: 'Open your terminal and clone Oikos to a folder of your choice.',
           step_inst2_title: 'Start the installer',
           step_inst2_desc: 'Run this command from the repository root. The installer server starts on port 8090.',
           step_inst3_title: 'Open the wizard in your browser',
-          step_inst3_desc: 'Navigate to the following address. The wizard will guide you through configuration, Docker startup, and admin account creation.',
-          step_inst3_info: 'The installer shuts down automatically after setup completes. Your Oikos instance keeps running via Docker.',
+          step_inst3_desc: 'Navigate to the following address. The wizard will guide you through configuration, container startup, and admin account creation.',
+          step_inst3_info: 'The installer shuts down automatically after setup completes. Your Oikos instance keeps running via Docker or Podman.',
           step_a1_title: 'Download the configuration files',
           step_a1_desc: 'Open your terminal and run these two commands. They download the Docker configuration and the template for your settings.',
           step_a2_title: 'Create your configuration',
@@ -1049,12 +1050,12 @@ docker compose logs | grep "Server läuft"</div>
         de: {
           hero_eyebrow: 'Installation',
           hero_title: 'Oikos installieren',
-          hero_desc: 'Euren selbstgehosteten Familienplaner in wenigen Minuten zum Laufen bringen. Keine Programmierkenntnisse n\u00f6tig \u2014 nur Docker.',
+          hero_desc: 'Euren selbstgehosteten Familienplaner in wenigen Minuten zum Laufen bringen. Keine Programmierkenntnisse n\u00f6tig \u2014 nur Docker oder Podman.',
           hero_time: '~10 Minuten',
           prereq_label: 'Voraussetzungen',
           prereq_title: 'Was ihr braucht',
-          prereq_desc: 'Oikos l\u00e4uft als Docker-Container \u2014 Node.js oder andere Laufzeitumgebungen m\u00fcsst ihr nicht installieren. Nur Docker, und ihr seid startklar.',
-          prereq_docker_desc: 'Verpackt die App, sodass ihr nichts weiter installieren m\u00fcsst. F\u00fcr den privaten Gebrauch kostenlos.',
+          prereq_desc: 'Oikos l\u00e4uft als Docker- oder Podman-Container \u2014 Node.js oder andere Laufzeitumgebungen m\u00fcsst ihr nicht installieren. Nur eine Container-Engine, und ihr seid startklar.',
+          prereq_docker_desc: 'Verpackt die App, sodass ihr nichts weiter installieren m\u00fcsst. F\u00fcr den privaten Gebrauch kostenlos. Podman (RHEL/Fedora/CentOS Stream) funktioniert ebenfalls \u2014 rootless und SELinux-f\u00e4hig.',
           prereq_terminal_title: 'Terminal',
           prereq_terminal_desc: 'Eine Befehlszeile, um ein paar Befehle einzugeben. In jedem Betriebssystem eingebaut \u2014 kein Extra-Install n\u00f6tig.',
           prereq_terminal_hint: 'macOS: Terminal \u00b7 Windows: PowerShell \u00b7 Linux: bash',
@@ -1066,16 +1067,16 @@ docker compose logs | grep "Server läuft"</div>
           tab_installer: 'Option A \u2014 Web-Installer',
           tab_a: 'Option B \u2014 Fertiges Image',
           tab_b: 'Option C \u2014 Aus Quellcode bauen',
-          option_installer_info: 'Empfohlen f\u00fcr die meisten Nutzer. Ein lokalisierter Browser-Assistent (16 Sprachen) pr\u00fcft eure Docker-Installation und konfiguriert dann eure .env \u2014 inklusive optionalem Reverse-Proxy/HTTPS, Single Sign-On (OIDC) und automatischen Backups \u2014 startet Docker und erstellt euer Admin-Konto. Ganz ohne manuelle Schritte. Erfordert Node.js 18+ auf dem Host.',
-          option_a_info: 'Kein Git, kein Build-Schritt \u2014 nur zwei Dateien und ein einziger Befehl. Nur Docker erforderlich.',
+          option_installer_info: 'Empfohlen f\u00fcr die meisten Nutzer. Ein lokalisierter Browser-Assistent (16 Sprachen) erkennt eure Container-Engine (Docker oder Podman) und konfiguriert dann eure .env \u2014 inklusive optionalem Reverse-Proxy/HTTPS, Single Sign-On (OIDC) und automatischen Backups \u2014 startet den Container und erstellt euer Admin-Konto. Ganz ohne manuelle Schritte. Erfordert Node.js 18+ auf dem Host.',
+          option_a_info: 'Kein Git, kein Build-Schritt \u2014 nur zwei Dateien und ein einziger Befehl. Nur Docker oder Podman erforderlich (Podman: podman-compose.yml verwenden).',
           option_b_info: 'F\u00fcr Mitwirkende oder wer eine eigene Version ausf\u00fchren m\u00f6chte. Erfordert Git. Der erste Build dauert einige Minuten.',
           step_inst1_title: 'Repository klonen',
           step_inst1_desc: '\u00d6ffnet euer Terminal und klont Oikos in einen Ordner eurer Wahl.',
           step_inst2_title: 'Installer starten',
           step_inst2_desc: 'F\u00fchrt diesen Befehl vom Projektordner aus. Der Installer-Server startet auf Port 8090.',
           step_inst3_title: 'Assistenten im Browser \u00f6ffnen',
-          step_inst3_desc: 'Navigiert zur folgenden Adresse. Der Assistent f\u00fchrt euch durch Konfiguration, Docker-Start und Admin-Konto-Erstellung.',
-          step_inst3_info: 'Der Installer beendet sich automatisch nach Abschluss der Einrichtung. Eure Oikos-Instanz l\u00e4uft weiter \u00fcber Docker.',
+          step_inst3_desc: 'Navigiert zur folgenden Adresse. Der Assistent f\u00fchrt euch durch Konfiguration, Container-Start und Admin-Konto-Erstellung.',
+          step_inst3_info: 'Der Installer beendet sich automatisch nach Abschluss der Einrichtung. Eure Oikos-Instanz l\u00e4uft weiter \u00fcber Docker oder Podman.',
           step_a1_title: 'Konfigurationsdateien herunterladen',
           step_a1_desc: '\u00d6ffnet euer Terminal und f\u00fchrt diese zwei Befehle aus. Sie laden die Docker-Konfiguration und die Vorlage f\u00fcr eure Einstellungen herunter.',
           step_a2_title: 'Konfiguration erstellen',

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -10,7 +10,7 @@ node tools/installer/install-server.js
 # Open http://localhost:8090
 ```
 
-Requires Node.js 18+ on the host. The browser-based wizard is fully localized (16 languages, auto-detected from your browser), checks Docker prerequisites first, then configures your `.env` — including optional reverse-proxy/HTTPS, Single Sign-On (OIDC), and automatic backups — starts Docker, and creates your admin account. Docker still runs the app itself.
+Requires Node.js 18+ on the host. The browser-based wizard is fully localized (16 languages, auto-detected from your browser), detects your container engine (Docker or Podman) first, then configures your `.env` — including optional reverse-proxy/HTTPS, Single Sign-On (OIDC), and automatic backups — starts the container, and creates your admin account. The engine still runs the app itself.
 
 ### Option B — CLI Installer (Linux / macOS)
 
@@ -19,7 +19,7 @@ git clone https://github.com/ulsklyc/oikos.git && cd oikos
 bash install.sh
 ```
 
-The script checks prerequisites, generates security keys, configures optional integrations, starts Docker, and creates your admin account.
+The script checks prerequisites, generates security keys, configures optional integrations, starts the container (Docker or Podman — auto-detected), and creates your admin account.
 
 Non-interactive mode (CI/provisioning — provide your own `.env`):
 
@@ -27,7 +27,7 @@ Non-interactive mode (CI/provisioning — provide your own `.env`):
 bash install.sh --env-file /path/to/.env
 ```
 
-### Option C — Manual (Docker only, no clone required)
+### Option C — Manual (Docker or Podman, no clone required)
 
 ```bash
 curl -O https://raw.githubusercontent.com/ulsklyc/oikos/main/docker-compose.yml
@@ -35,6 +35,17 @@ curl -O https://raw.githubusercontent.com/ulsklyc/oikos/main/.env.example
 cp .env.example .env  # set SESSION_SECRET and DB_ENCRYPTION_KEY
 docker compose up -d
 docker compose exec oikos node setup.js
+```
+
+**Podman (RHEL / Fedora / CentOS Stream):** grab `podman-compose.yml` instead — it
+adds the SELinux `:Z` relabel so the rootless container can write to its volumes:
+
+```bash
+curl -O https://raw.githubusercontent.com/ulsklyc/oikos/main/podman-compose.yml
+curl -O https://raw.githubusercontent.com/ulsklyc/oikos/main/.env.example
+cp .env.example .env  # set SESSION_SECRET and DB_ENCRYPTION_KEY
+podman compose -f podman-compose.yml up -d   # or: podman-compose -f podman-compose.yml up -d
+podman compose -f podman-compose.yml exec oikos node setup.js
 ```
 
 ---
@@ -91,6 +102,22 @@ docker --version           # Docker version 27.x.x or later
 docker compose version     # Docker Compose version v2.x.x
 ```
 
+### Podman (alternative to Docker, RHEL / Fedora / CentOS Stream)
+
+RHEL-based distributions ship **Podman** (often rootless) and **SELinux** instead of
+Docker. Oikos supports Podman out of the box: both installers auto-detect it, and a
+dedicated `podman-compose.yml` adds the SELinux `:Z` volume relabel. Install Podman and
+either the `podman compose` subcommand (Podman 4.1+) or the `podman-compose` package:
+
+```bash
+sudo dnf install -y podman podman-compose   # Fedora / RHEL 9+ / CentOS Stream
+podman --version              # podman version 4.x / 5.x
+podman compose version        # or: podman-compose --version
+```
+
+No extra SELinux configuration is required — the `:Z` labels in `podman-compose.yml`
+(and the Quadlet unit) relabel the bind mounts for the container automatically.
+
 ### Git
 
 You need Git to clone the repository and pull updates later.
@@ -133,14 +160,14 @@ node tools/installer/install-server.js
 
 #### 3. Open the Wizard
 
-Open your browser and navigate to **http://localhost:8090**. The wizard detects your browser language (16 languages supported), verifies that Docker and Docker Compose v2 are available, and reports any existing `.env` file or running container before you start. It then guides you through:
+Open your browser and navigate to **http://localhost:8090**. The wizard detects your browser language (16 languages supported), verifies that a container engine is available (Docker with Compose v2, or Podman with `podman compose` / `podman-compose`), and reports any existing `.env` file or running container before you start. It then guides you through:
 
 - Basics — timezone (`TZ`) and HTTP host port (`OIKOS_HTTP_PORT`)
 - Security key generation (`SESSION_SECRET`, `DB_ENCRYPTION_KEY`)
 - Optional integrations (weather, Google Calendar, Apple CalDAV)
 - Advanced settings — reverse-proxy/HTTPS (`SESSION_SECURE`, `TRUST_PROXY`), Single Sign-On (OIDC), and automatic backups
 - Writing your `.env` file (an existing `.env` is backed up to `.env.bak-<timestamp>` first)
-- Starting the Docker container
+- Starting the container (via Docker or Podman, whichever was detected)
 - Creating your admin account
 
 The installer server shuts down automatically after setup completes (or after 30 minutes of inactivity).
@@ -271,7 +298,8 @@ All configuration happens in the `.env` file. The container reads these values o
 | Variable | Description | Default | Required |
 |----------|-------------|---------|----------|
 | `PORT` | Port the Express server listens on **inside the container** (rarely changed) | `3000` | No |
-| `OIKOS_HTTP_PORT` | Host port that `docker-compose.yml` maps to the container's port 3000. Change this to expose Oikos on a different host port; the app inside the container always listens on 3000. | `3000` | No |
+| `OIKOS_HTTP_PORT` | Host port that the compose file maps to the container's port 3000. Change this to expose Oikos on a different host port; the app inside the container always listens on 3000. | `3000` | No |
+| `OIKOS_HTTP_BIND` | Host bind address for the published port (`podman-compose.yml` only). Set to `127.0.0.1` for rootless Podman behind a reverse proxy on the same host. | `0.0.0.0` | No |
 | `TZ` | Container timezone (e.g. `Europe/Berlin`). Affects timestamps and the automated-backup schedule. | `UTC` | No |
 | `NODE_ENV` | Runtime environment | `production` | No |
 | `TRUST_PROXY` | Number of reverse-proxy hops to trust, or a subnet string (e.g. `1`, `172.16.0.0/12`, `loopback`). Set to `1` when running behind a single Traefik/Nginx hop so `req.ip` returns the real client IP. Numeric values are treated as a hop count; subnet strings and named values (`loopback`, `linklocal`, `uniquelocal`) work as expected. | `false` | No |
@@ -440,6 +468,36 @@ docker compose up -d
 
 ---
 
+## Podman & systemd Autostart (rootless)
+
+On RHEL-based systems you can run Oikos as a rootless systemd service via Podman
+[Quadlet](https://docs.podman.io/en/latest/markdown/podman-systemd.unit.5.html). Oikos
+ships a ready-made unit at `tools/quadlet/oikos.container`.
+
+```bash
+# 1. Create the data folders and drop your generated .env in place
+mkdir -p ~/.local/share/oikos/{data,backups,modules} ~/.config/oikos
+cp /path/to/oikos/.env ~/.config/oikos/.env
+
+# 2. Install the Quadlet unit
+mkdir -p ~/.config/containers/systemd
+cp tools/quadlet/oikos.container ~/.config/containers/systemd/
+
+# 3. Generate and start the service
+systemctl --user daemon-reload
+systemctl --user start oikos
+
+# 4. Keep it running across reboots (even without an active login session)
+loginctl enable-linger "$USER"
+```
+
+The unit publishes port 3000, applies the SELinux `:Z` relabel to its volumes, runs the
+same healthcheck as Compose, and restarts automatically. Edit the `PublishPort` /
+`Volume` paths in the file to taste; for a system-wide (rootful) service, place the unit
+in `/etc/containers/systemd/` and use `systemctl` without `--user`.
+
+---
+
 ## Updates
 
 ### Option B — Pre-built Image
@@ -578,6 +636,25 @@ sudo usermod -aG docker $USER
 ```
 
 Log out and back in (or reboot) for the group change to take effect.
+
+</details>
+
+<details>
+<summary>Permission denied on volumes (Podman / SELinux)</summary>
+
+If the container logs show `EACCES` / permission errors writing to `/data` or `/backups`
+on an SELinux system, you started it without the `:Z` relabel. Use `podman-compose.yml`
+(which carries `:Z` on every bind mount) instead of `docker-compose.yml`:
+
+```bash
+podman compose -f podman-compose.yml up -d
+```
+
+To relabel existing host folders manually:
+
+```bash
+chcon -Rt container_file_t ./data ./backups ./modules
+```
 
 </details>
 

--- a/install.sh
+++ b/install.sh
@@ -27,16 +27,39 @@ generate_secret() {
 
 trap 'printf "\n%sInterrupted. Exiting.%s\n" "$YELLOW" "$RESET"; exit 1' INT TERM
 
+# ── Container engine detection (Docker preferred, Podman fallback) ──────────────
+# Sets the COMPOSE array used everywhere a compose command is run. Podman uses
+# the dedicated podman-compose.yml (SELinux :Z labels). Also sets ENGINE_BIN for
+# direct engine calls (e.g. inspect) and ENGINE_NAME for messages.
+COMPOSE=(); ENGINE_BIN=""; ENGINE_NAME=""
+detect_engine() {
+  if command -v docker &>/dev/null && docker compose version &>/dev/null 2>&1; then
+    COMPOSE=(docker compose); ENGINE_BIN=docker; ENGINE_NAME="Docker"; return 0
+  fi
+  if command -v podman &>/dev/null; then
+    if podman compose version &>/dev/null 2>&1; then
+      COMPOSE=(podman compose -f podman-compose.yml)
+    elif command -v podman-compose &>/dev/null; then
+      COMPOSE=(podman-compose -f podman-compose.yml)
+    else
+      return 1
+    fi
+    ENGINE_BIN=podman; ENGINE_NAME="Podman"; return 0
+  fi
+  return 1
+}
+
 # ── Prerequisites ──────────────────────────────────────────────────────────────
 check_prereqs() {
   step "Checking prerequisites"
   local ok=1
-  for cmd in docker curl; do
-    if command -v "$cmd" &>/dev/null; then success "$cmd found"
-    else warn "$cmd not found"; ok=0; fi
-  done
-  if docker compose version &>/dev/null 2>&1; then success "docker compose (v2) found"
-  else warn "docker compose v2 not found"; ok=0; fi
+  if ! command -v curl &>/dev/null; then warn "curl not found"; ok=0; else success "curl found"; fi
+  if detect_engine; then
+    success "$ENGINE_NAME with Compose found (${COMPOSE[*]})"
+  else
+    warn "No container engine found — need Docker (Compose v2) or Podman (podman compose / podman-compose)"
+    ok=0
+  fi
   [ $ok -eq 0 ] && err "Install missing prerequisites and re-run."
 }
 
@@ -143,9 +166,9 @@ review_and_confirm() {
   [ "${confirm,,}" = "n" ] && { info "Aborted."; exit 0; }
 }
 
-# ── Step 6: Docker ─────────────────────────────────────────────────────────────
+# ── Step 6: Container ───────────────────────────────────────────────────────────
 write_env_and_start() {
-  step "Step 6/7: Starting Docker Container"
+  step "Step 6/7: Starting Container ($ENGINE_NAME)"
 
   if [ -f .env ]; then
     backup=".env.bak-$(date +%Y-%m-%dT%H-%M-%S)"
@@ -176,9 +199,9 @@ ENVEOF
 
   success ".env written"
 
-  if ! docker compose up -d; then
-    warn "Docker failed to start. Recent logs:"
-    docker compose logs --tail 50
+  if ! "${COMPOSE[@]}" up -d; then
+    warn "$ENGINE_NAME failed to start. Recent logs:"
+    "${COMPOSE[@]}" logs --tail 50
     exit 1
   fi
 
@@ -196,7 +219,7 @@ ENVEOF
 
   printf "\n"
   warn "Timeout waiting for container. Logs:"
-  docker compose logs --tail 50
+  "${COMPOSE[@]}" logs --tail 50
   exit 1
 }
 
@@ -256,11 +279,14 @@ run_noninteractive() {
   info "Non-interactive mode: using $env_file"
   cp "$env_file" .env
 
+  detect_engine || err "No container engine found — need Docker (Compose v2) or Podman (podman compose / podman-compose)."
+  info "Using $ENGINE_NAME (${COMPOSE[*]})"
+
   OIKOS_PORT=$(grep -E '^PORT=' .env 2>/dev/null | cut -d= -f2- | head -n1)
   OIKOS_PORT="${OIKOS_PORT:-3000}"
   OIKOS_HOST="localhost"
 
-  if ! docker compose up -d; then docker compose logs --tail 50; exit 1; fi
+  if ! "${COMPOSE[@]}" up -d; then "${COMPOSE[@]}" logs --tail 50; exit 1; fi
 
   printf "  Waiting for container"
   local elapsed=0

--- a/podman-compose.yml
+++ b/podman-compose.yml
@@ -1,0 +1,45 @@
+# Podman-Compose-Manifest für Oikos (RHEL/Fedora/CentOS Stream, rootless + SELinux).
+# Nutzbar mit `podman compose -f podman-compose.yml up -d` (Podman 4.1+) oder
+# `podman-compose -f podman-compose.yml up -d`. Der Web-/CLI-Installer wählt das
+# Manifest automatisch, wenn nur Podman vorhanden ist.
+#
+# Unterschiede zu docker-compose.yml:
+#   - Bind-Mounts tragen `:Z` (privates SELinux-Relabel pro Container), sonst
+#     verweigert SELinux im Enforcing-Modus den Zugriff auf /data, /backups, …
+#   - Die Host-Bind-Adresse ist über OIKOS_HTTP_BIND konfigurierbar (Default
+#     0.0.0.0). Rootless hinter einem Reverse-Proxy: OIKOS_HTTP_BIND=127.0.0.1.
+services:
+  oikos:
+    image: ghcr.io/ulsklyc/oikos:latest
+    build: .                          # optional: use --build to build locally instead
+    container_name: oikos
+    restart: unless-stopped
+    ports:
+      # Host-Bind aus .env (OIKOS_HTTP_BIND, Default 0.0.0.0) + Host-Port
+      # (OIKOS_HTTP_PORT). App im Container bleibt auf 3000.
+      - "${OIKOS_HTTP_BIND:-0.0.0.0}:${OIKOS_HTTP_PORT:-3000}:3000"
+    volumes:
+      # `:Z` = privates SELinux-Relabel. Nur setzen, wenn die Verzeichnisse
+      # ausschließlich von diesem Container genutzt werden (hier der Fall).
+      - ${DATA_DIR:-./data}:/data:Z
+      - ${BACKUP_DIR:-./backups}:/backups:Z
+      # Drop Oikos modules into ./modules, or set MODULES_DIR=/path/to/modules.
+      - ${MODULES_DIR:-./modules}:/app/modules:Z
+    env_file:
+      - .env
+    environment:
+      - NODE_ENV=production
+      - DB_PATH=${DB_PATH:-/data/oikos.db}
+      - BACKUP_DIR=${BACKUP_DIR:-/backups}
+      # Secure cookies come from .env (the installer sets them):
+      #   - Reverse proxy + HTTPS → SESSION_SECURE=true, TRUST_PROXY=1
+      #   - Direct HTTP access     → SESSION_SECURE=false, TRUST_PROXY=loopback
+      # Default when unset (e.g. bare `podman compose up` without .env): false,
+      # so direct HTTP login keeps working out of the box.
+      - SESSION_SECURE=${SESSION_SECURE:-false}
+    healthcheck:
+      test: ["CMD", "node", "-e", "require('http').get('http://localhost:3000/health', r => process.exit(r.statusCode === 200 ? 0 : 1))"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s

--- a/test-installer-prereq.js
+++ b/test-installer-prereq.js
@@ -5,6 +5,7 @@ import { fileURLToPath } from 'node:url';
 
 import {
   commandAvailable, checkPrereqs, spawnStart, createInstallerServer,
+  detectEngine, composeCommand, inspectCommand,
 } from './tools/installer/install-server.js';
 
 const REPO_ROOT = fileURLToPath(new URL('.', import.meta.url));
@@ -45,6 +46,109 @@ test('spawnStart meldet ok:false bei Spawn-Fehler (unbekanntes Kommando)', async
 test('spawnStart meldet ok:true, wenn der Prozess erfolgreich startet', async () => {
   const r = await spawnStart('node', ['-e', '']);
   assert.equal(r.ok, true);
+});
+
+// ── detectEngine (Docker bevorzugt, Podman-Fallback) ───────────────────────────
+
+// Baut einen injizierbaren check(cmd, args), der nur für die in `present`
+// gelisteten "cmd args"-Kombinationen true liefert.
+function checkFor(present) {
+  const set = new Set(present);
+  return async (cmd, args = []) => set.has([cmd, ...args].join(' '));
+}
+
+test('detectEngine wählt docker, wenn docker + compose v2 vorhanden sind', async () => {
+  const e = await detectEngine(checkFor(['docker --version', 'docker compose version']));
+  assert.equal(e.engine, 'docker');
+  assert.equal(e.composeBin, 'docker');
+  assert.deepEqual(e.compose, ['compose']);
+  assert.deepEqual(e.missing, []);
+});
+
+test('detectEngine fällt auf "podman compose" zurück, wenn docker fehlt', async () => {
+  const e = await detectEngine(checkFor(['podman --version', 'podman compose version']));
+  assert.equal(e.engine, 'podman');
+  assert.equal(e.composeBin, 'podman');
+  assert.deepEqual(e.compose, ['compose', '-f', 'podman-compose.yml']);
+  assert.deepEqual(e.missing, []);
+});
+
+test('detectEngine nutzt podman-compose, wenn "podman compose" fehlt', async () => {
+  const e = await detectEngine(checkFor(['podman --version', 'podman-compose --version']));
+  assert.equal(e.engine, 'podman');
+  assert.equal(e.composeBin, 'podman-compose');
+  assert.deepEqual(e.compose, ['-f', 'podman-compose.yml']);
+  assert.deepEqual(e.missing, []);
+});
+
+test('detectEngine meldet engine:null, wenn weder docker noch podman da sind', async () => {
+  const e = await detectEngine(async () => false);
+  assert.equal(e.engine, null);
+  assert.ok(e.missing.includes('docker'));
+  assert.ok(e.missing.includes('podman'));
+});
+
+test('detectEngine meldet fehlendes compose, wenn nur podman (ohne compose) da ist', async () => {
+  const e = await detectEngine(checkFor(['podman --version']));
+  assert.equal(e.engine, null);
+  assert.ok(e.missing.some(m => /compose/.test(m)), 'missing nennt kein fehlendes compose');
+});
+
+// ── composeCommand / inspectCommand (Engine-aware Spawn-Argumente) ──────────────
+
+test('composeCommand baut den richtigen Befehl je Engine', async () => {
+  const docker = await detectEngine(checkFor(['docker --version', 'docker compose version']));
+  assert.deepEqual(composeCommand(docker, ['up', '-d']),
+    { cmd: 'docker', args: ['compose', 'up', '-d'] });
+
+  const podman = await detectEngine(checkFor(['podman --version', 'podman compose version']));
+  assert.deepEqual(composeCommand(podman, ['up', '-d']),
+    { cmd: 'podman', args: ['compose', '-f', 'podman-compose.yml', 'up', '-d'] });
+
+  const pc = await detectEngine(checkFor(['podman --version', 'podman-compose --version']));
+  assert.deepEqual(composeCommand(pc, ['logs', '--tail', '30']),
+    { cmd: 'podman-compose', args: ['-f', 'podman-compose.yml', 'logs', '--tail', '30'] });
+});
+
+test('inspectCommand nutzt das passende Binary (podman auch bei podman-compose)', async () => {
+  const pc = await detectEngine(checkFor(['podman --version', 'podman-compose --version']));
+  assert.deepEqual(inspectCommand(pc, ['inspect', 'oikos']),
+    { cmd: 'podman', args: ['inspect', 'oikos'] });
+
+  const docker = await detectEngine(checkFor(['docker --version', 'docker compose version']));
+  assert.deepEqual(inspectCommand(docker, ['inspect', 'oikos']),
+    { cmd: 'docker', args: ['inspect', 'oikos'] });
+});
+
+// ── checkPrereqs liefert den Engine-Deskriptor mit ─────────────────────────────
+
+test('checkPrereqs gibt engine-Deskriptor zurück (podman-Fallback)', async () => {
+  const r = await checkPrereqs(checkFor(['podman --version', 'podman compose version']));
+  assert.equal(r.ok, true);
+  assert.equal(r.engine.engine, 'podman');
+});
+
+// ── Statische Artefakte: podman-compose.yml, Quadlet, install.sh ────────────────
+
+test('podman-compose.yml trägt :Z-Labels, OIKOS_HTTP_BIND und SESSION_SECURE-Default', () => {
+  const src = readFileSync(new URL('./podman-compose.yml', import.meta.url), 'utf8');
+  assert.match(src, /\/data:Z/, 'kein :Z-Label auf dem /data-Mount');
+  assert.match(src, /\$\{OIKOS_HTTP_BIND:-0\.0\.0\.0\}/, 'kein konfigurierbares Host-Binding');
+  assert.match(src, /SESSION_SECURE=\$\{SESSION_SECURE:-false\}/, 'kein SESSION_SECURE-Default');
+});
+
+test('Quadlet-Unit existiert mit :Z-Volume und EnvironmentFile', () => {
+  const src = readFileSync(new URL('./tools/quadlet/oikos.container', import.meta.url), 'utf8');
+  assert.match(src, /\[Container\]/, 'keine [Container]-Sektion');
+  assert.match(src, /EnvironmentFile=/, 'kein EnvironmentFile');
+  assert.match(src, /:Z\b/, 'kein :Z-SELinux-Label');
+  assert.match(src, /WantedBy=default\.target/, 'kein [Install]-Autostart-Target');
+});
+
+test('install.sh enthält den Podman-Fallback', () => {
+  const src = readFileSync(new URL('./install.sh', import.meta.url), 'utf8');
+  assert.match(src, /podman compose/, 'install.sh kennt "podman compose" nicht');
+  assert.match(src, /podman-compose/, 'install.sh kennt "podman-compose" nicht');
 });
 
 // ── HTTP-Route /api/prereqs ────────────────────────────────────────────────────

--- a/tools/installer/README.md
+++ b/tools/installer/README.md
@@ -1,7 +1,8 @@
 # Oikos Web Installer
 
 A browser-based setup wizard for Oikos. Run it once to configure your `.env`,
-start Docker, and create your admin account — no hand-editing of config files.
+start your container engine, and create your admin account — no hand-editing of
+config files. Works with both Docker and Podman (auto-detected).
 
 ## Usage
 
@@ -18,16 +19,19 @@ The server shuts down automatically after setup completes (or after 30 minutes o
 ## Requirements
 
 - Node.js 18+ (the installer itself has zero npm dependencies — Node built-ins only)
-- Docker with Compose v2
+- A container engine — either **Docker** with Compose v2, or **Podman** with the
+  `podman compose` subcommand (4.1+) or the `podman-compose` package
 - The repository cloned locally
 
-The wizard verifies that `docker` and `docker compose` v2 are available before it
-starts, and surfaces container start/spawn errors in the UI instead of failing silently.
+The wizard auto-detects the engine (Docker preferred, Podman fallback) and verifies
+that it plus its compose command are available before it starts, surfacing container
+start/spawn errors in the UI instead of failing silently. With Podman it uses the
+dedicated `podman-compose.yml` (SELinux `:Z` labels).
 
 ## What it does
 
-1. Checks Docker prerequisites and reports any existing `.env` file or running
-   `oikos` container before you start
+1. Detects the container engine (Docker or Podman), checks its prerequisites, and
+   reports any existing `.env` file or running `oikos` container before you start
 2. Guides you through all configuration options, grouped into steps:
    - **Basics** — timezone (`TZ`) and HTTP host port (`OIKOS_HTTP_PORT`)
    - **Security keys** — generates `SESSION_SECRET` and `DB_ENCRYPTION_KEY`
@@ -37,7 +41,8 @@ starts, and surfaces container start/spawn errors in the UI instead of failing s
 3. Backs up any existing `.env` to `.env.bak-<ISO>` before writing
 4. Writes `.env` to the project root (keys are allowlisted against the shared
    env schema; values containing line breaks are rejected)
-5. Starts the Docker container (`docker compose up -d`)
+5. Starts the container (`docker compose up -d`, or `podman compose -f
+   podman-compose.yml up -d` / `podman-compose -f podman-compose.yml up -d`)
 6. Polls the health endpoint until the container is ready
 7. Creates your first admin account via `POST /api/v1/auth/setup`
 

--- a/tools/installer/install-server.js
+++ b/tools/installer/install-server.js
@@ -83,17 +83,68 @@ export function commandAvailable(cmd, args = ['--version']) {
 }
 
 /**
- * Verify the installer's prerequisites (docker + docker compose v2).
+ * Detect the available container engine, preferring Docker and falling back to
+ * Podman (RHEL/Fedora/CentOS Stream). `check` is injectable for deterministic
+ * tests. Returns a descriptor:
+ *   { engine: 'docker'|'podman'|null,
+ *     composeBin: 'docker'|'podman'|'podman-compose'|null,
+ *     compose: string[]|null,   // leading args before the compose subcommand
+ *     missing: string[] }       // human-readable list of absent prerequisites
+ *
+ * Podman uses the dedicated `podman-compose.yml` (SELinux `:Z` labels), so its
+ * compose args carry `-f podman-compose.yml`. Docker keeps the default file.
+ */
+export async function detectEngine(check = commandAvailable) {
+  if (await check('docker', ['--version']) && await check('docker', ['compose', 'version'])) {
+    return { engine: 'docker', composeBin: 'docker', compose: ['compose'], missing: [] };
+  }
+  if (await check('podman', ['--version'])) {
+    if (await check('podman', ['compose', 'version'])) {
+      return { engine: 'podman', composeBin: 'podman', compose: ['compose', '-f', 'podman-compose.yml'], missing: [] };
+    }
+    if (await check('podman-compose', ['--version'])) {
+      return { engine: 'podman', composeBin: 'podman-compose', compose: ['-f', 'podman-compose.yml'], missing: [] };
+    }
+    return { engine: null, composeBin: null, compose: null, missing: ['podman compose (oder podman-compose)'] };
+  }
+  return { engine: null, composeBin: null, compose: null, missing: ['docker', 'podman'] };
+}
+
+/**
+ * Build a compose invocation for the detected engine.
+ * docker: `docker compose <sub>`; podman: `podman compose -f podman-compose.yml
+ * <sub>`; podman-compose: `podman-compose -f podman-compose.yml <sub>`.
+ */
+export function composeCommand(engine, subArgs = []) {
+  return { cmd: engine.composeBin, args: [...(engine.compose || []), ...subArgs] };
+}
+
+/**
+ * Build an inspect invocation. Uses the engine binary directly (`podman` even
+ * when compose runs via `podman-compose`), since `docker`/`podman inspect`
+ * share the same flags and Go templates.
+ */
+export function inspectCommand(engine, args = []) {
+  return { cmd: engine.engine === 'docker' ? 'docker' : 'podman', args };
+}
+
+/**
+ * Verify the installer's prerequisites (a usable container engine + compose).
  * `check` is injectable so the result is deterministically testable.
- * Returns { ok, missing } where missing lists the absent prerequisites.
+ * Returns { ok, missing, engine } where engine is the detectEngine descriptor.
  */
 export async function checkPrereqs(check = commandAvailable) {
-  const docker = await check('docker', ['--version']);
-  const compose = docker ? await check('docker', ['compose', 'version']) : false;
-  const missing = [];
-  if (!docker) missing.push('docker');
-  if (!compose) missing.push('docker compose');
-  return { ok: missing.length === 0, missing };
+  const engine = await detectEngine(check);
+  return { ok: engine.engine !== null, missing: engine.missing, engine };
+}
+
+// Memoized real-engine detection for the HTTP handlers (probes the host once).
+// Tests call detectEngine/checkPrereqs directly with an injected check and never
+// touch this cache.
+let enginePromise = null;
+function getEngine() {
+  if (!enginePromise) enginePromise = detectEngine();
+  return enginePromise;
 }
 
 /**
@@ -225,8 +276,10 @@ async function route(req, res, server) {
   if (req.method === 'GET' && url.pathname === '/api/preflight') {
     try {
       const envExists = existsSync(resolve(projectRoot(), '.env'));
+      const engine = await getEngine();
+      const { cmd, args } = inspectCommand(engine, ['inspect', '--format', '{{.State.Status}}', 'oikos']);
       return await new Promise(resolvePromise => {
-        const inspect = spawn('docker', ['inspect', '--format', '{{.State.Status}}', 'oikos'], { stdio: 'pipe' });
+        const inspect = spawn(cmd, args, { stdio: 'pipe' });
         let out = '';
         let settled = false;
         const reply = containerRunning => {
@@ -267,8 +320,10 @@ async function route(req, res, server) {
 
   if (req.method === 'POST' && url.pathname === '/api/start') {
     try {
-      const result = await spawnStart('docker', ['compose', 'up', '-d'], { cwd: projectRoot() });
-      if (!result.ok) console.error('docker compose error:', result.error);
+      const engine = await getEngine();
+      const { cmd, args } = composeCommand(engine, ['up', '-d']);
+      const result = await spawnStart(cmd, args, { cwd: projectRoot() });
+      if (!result.ok) console.error(`${cmd} compose error:`, result.error);
       return json(res, result.ok ? 200 : 500, result);
     } catch (err) {
       return json(res, 500, { ok: false, error: err.message });
@@ -276,19 +331,23 @@ async function route(req, res, server) {
   }
 
   if (req.method === 'GET' && url.pathname === '/api/status') {
+    const engine = await getEngine();
+    const health = inspectCommand(engine, ['inspect', '--format', '{{.State.Health.Status}}', 'oikos']);
+    const stateCmd = inspectCommand(engine, ['inspect', '--format', '{{.State.Status}}', 'oikos']);
+    const logsCmd = composeCommand(engine, ['logs', '--tail', '30']);
     return new Promise(resolvePromise => {
-      const inspect = spawn('docker', ['inspect', '--format', '{{.State.Health.Status}}', 'oikos'], { stdio: 'pipe' });
+      const inspect = spawn(health.cmd, health.args, { stdio: 'pipe' });
       let out = '';
       inspect.stdout.on('data', d => { out += d.toString().trim(); });
       inspect.on('close', code => {
         if (code === 0 && out === 'healthy') return resolvePromise(json(res, 200, { status: 'running' }));
         if (code === 0 && (out === 'starting' || out === 'unhealthy')) return resolvePromise(json(res, 200, { status: 'starting' }));
-        const state = spawn('docker', ['inspect', '--format', '{{.State.Status}}', 'oikos'], { stdio: 'pipe' });
+        const state = spawn(stateCmd.cmd, stateCmd.args, { stdio: 'pipe' });
         let stateOut = '';
         state.stdout.on('data', d => { stateOut += d.toString().trim(); });
         state.on('close', () => {
           if (stateOut === 'running') return resolvePromise(json(res, 200, { status: 'starting' }));
-          const logs = spawn('docker', ['compose', 'logs', '--tail', '30'], { cwd: projectRoot(), stdio: 'pipe' });
+          const logs = spawn(logsCmd.cmd, logsCmd.args, { cwd: projectRoot(), stdio: 'pipe' });
           let logsOut = '';
           logs.stdout.on('data', d => { logsOut += d.toString(); });
           logs.stderr.on('data', d => { logsOut += d.toString(); });

--- a/tools/quadlet/oikos.container
+++ b/tools/quadlet/oikos.container
@@ -1,0 +1,61 @@
+# Oikos als systemd-Dienst über Podman Quadlet (rootless, Podman 5.x).
+#
+# ── Setup (rootless, empfohlen) ────────────────────────────────────────────────
+#   1. Datenverzeichnisse anlegen:
+#        mkdir -p ~/.local/share/oikos/{data,backups,modules} ~/.config/oikos
+#   2. Generierte .env ablegen (z. B. aus dem Web-/CLI-Installer):
+#        cp /pfad/zu/oikos/.env ~/.config/oikos/.env
+#   3. Diese Unit installieren:
+#        mkdir -p ~/.config/containers/systemd
+#        cp tools/quadlet/oikos.container ~/.config/containers/systemd/
+#   4. Generieren & starten:
+#        systemctl --user daemon-reload
+#        systemctl --user start oikos
+#   5. Autostart beim Boot (auch ohne aktive Sitzung):
+#        loginctl enable-linger "$USER"
+#
+# Quadlet macht KEINE ${VAR:-default}-Shell-Interpolation. Pfade hier sind fest
+# bzw. nutzen den systemd-Specifier %h (Home-Verzeichnis). Bei Bedarf anpassen.
+#
+# Rootful-Variante: Unit nach /etc/containers/systemd/ legen, %h durch feste
+# Pfade ersetzen und `systemctl` (ohne --user) verwenden.
+
+[Unit]
+Description=Oikos family planner
+After=network-online.target
+Wants=network-online.target
+
+[Container]
+Image=ghcr.io/ulsklyc/oikos:latest
+ContainerName=oikos
+
+# Lädt SESSION_SECRET, DB_ENCRYPTION_KEY, TZ, OPENWEATHER_*, OIDC_* … aus der .env.
+EnvironmentFile=%h/.config/oikos/.env
+
+# Laufzeit-Defaults (entsprechen docker-compose.yml).
+Environment=NODE_ENV=production
+Environment=DB_PATH=/data/oikos.db
+Environment=BACKUP_DIR=/backups
+
+# Veröffentlichter Port. Rootless hinter Reverse-Proxy stattdessen:
+#   PublishPort=127.0.0.1:3000:3000
+PublishPort=3000:3000
+
+# `:Z` = privates SELinux-Relabel pro Container (Enforcing-tauglich).
+Volume=%h/.local/share/oikos/data:/data:Z
+Volume=%h/.local/share/oikos/backups:/backups:Z
+Volume=%h/.local/share/oikos/modules:/app/modules:Z
+
+# Healthcheck identisch zum Compose-Manifest.
+HealthCmd=node -e "require('http').get('http://localhost:3000/health', r => process.exit(r.statusCode === 200 ? 0 : 1))"
+HealthInterval=30s
+HealthTimeout=10s
+HealthRetries=3
+HealthStartPeriod=10s
+
+[Service]
+Restart=always
+TimeoutStartSec=120
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
## Summary

Enables installing Oikos on RHEL-based distributions (RHEL, Fedora, CentOS Stream, Rocky, Alma) that ship **Podman** (often rootless) and **SELinux** enforcing instead of Docker.

### What changed
- **`podman-compose.yml`** *(new)* — mirrors `docker-compose.yml` with `:Z` SELinux relabel on bind mounts and a configurable `OIKOS_HTTP_BIND` host address (default `0.0.0.0`).
- **`tools/quadlet/oikos.container`** *(new)* — systemd Quadlet unit for rootless autostart (`EnvironmentFile`, `:Z` volumes, healthcheck, `WantedBy=default.target`).
- **Web installer** (`tools/installer/install-server.js`) — `detectEngine()` prefers Docker and falls back to `podman compose` then `podman-compose`; `composeCommand`/`inspectCommand` route every spawn through the detected engine.
- **CLI installer** (`install.sh`) — `detect_engine()` sets the `COMPOSE` array; prereqs accept Docker **or** Podman; both interactive and `--env-file` paths use the detected engine.
- **Tests** — `detectEngine` fallback, `composeCommand`/`inspectCommand`, and static checks for `podman-compose.yml` / Quadlet / `install.sh`.
- **Docs** — README, SPEC, installation guide, MODULES, `.env.example` (`OIKOS_HTTP_BIND`), installer README, and GitHub Pages landing/install pages (EN + DE in lockstep), plus a Quadlet autostart section and SELinux troubleshooting.

### Backward compatibility
The Docker path is unchanged (no `-f`, still uses `docker-compose.yml`, default bind `0.0.0.0`). All existing tests stay green.

### Verification
`npm test` exit 0; `bash -n install.sh` OK; installer suite 51/51 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)