### PR TITLE
refactor: compress text assets with gzip and defer the Lucide script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Compress CSS/JS/JSON responses with gzip and defer the icon library so it no longer blocks first paint.
+
 ## [0.57.4] - 2026-06-02
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "bcrypt": "^6.0.0",
         "better-sqlite3": "^12.10.0",
+        "compression": "^1.8.1",
         "dotenv": "^17.4.2",
         "express": "^5.2.1",
         "express-rate-limit": "^8.5.2",
@@ -851,6 +852,45 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/compressible": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
+      "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": ">= 1.43.0 < 2"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/compression": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.8.1.tgz",
+      "integrity": "sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "compressible": "~2.0.18",
+        "debug": "2.6.9",
+        "negotiator": "~0.6.4",
+        "on-headers": "~1.1.0",
+        "safe-buffer": "5.2.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/compression/node_modules/negotiator": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+      "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/content-disposition": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   "dependencies": {
     "bcrypt": "^6.0.0",
     "better-sqlite3": "^12.10.0",
+    "compression": "^1.8.1",
     "dotenv": "^17.4.2",
     "express": "^5.2.1",
     "express-rate-limit": "^8.5.2",

--- a/public/index.html
+++ b/public/index.html
@@ -49,7 +49,9 @@
   <link rel="stylesheet" href="/styles/login.css" />
 
   <!-- Lucide Icons (lokal, v0.469.0) -->
-  <script src="/lucide.min.js"></script>
+  <!-- defer: nicht render-blockierend. Laeuft vor den (ebenfalls deferred)
+       Modul-Skripten api.js/router.js, daher ist `lucide` zur Render-Zeit da. -->
+  <script src="/lucide.min.js" defer></script>
 </head>
 <body>
   <!-- Offline-Banner: sichtbar wenn navigator.onLine === false -->

--- a/server/index.js
+++ b/server/index.js
@@ -6,6 +6,7 @@
 
 import express from 'express';
 import helmet from 'helmet';
+import compression from 'compression';
 import rateLimit from 'express-rate-limit';
 import path from 'path';
 import { readFileSync } from 'node:fs';
@@ -91,6 +92,16 @@ const _trustProxy = _rawTrustProxy === undefined
   ? 1
   : /^\d+$/.test(_rawTrustProxy) ? parseInt(_rawTrustProxy, 10) : _rawTrustProxy;
 app.set('trust proxy', _trustProxy);
+
+// --------------------------------------------------------
+// Kompression (gzip/deflate)
+//
+// Komprimiert HTML, JS, CSS und JSON-Antworten on-the-fly. Die ungebauten
+// Frontend-Quelldateien (router.js, calendar.js, lucide.min.js, *.css) werden
+// unminifiziert ausgeliefert und sind hochgradig komprimierbar (~70-80%).
+// Bilder/Fonts (woff2, png) werden vom Default-Filter ausgelassen.
+// --------------------------------------------------------
+app.use(compression());
 
 // --------------------------------------------------------
 // Request-Parsing


### PR DESCRIPTION
## What

Two small load-performance fixes for cold page loads:

1. **Add `compression()` (gzip) middleware.** The frontend source is served unminified and was going out **uncompressed** — roughly 1.6 MB of highly compressible text (`router.js` 76.5 KB, `calendar.js` 83 KB, `settings.js` 133 KB, `lucide.min.js` 358 KB, `dashboard.css` 70 KB, …), plus JSON API responses. With gzip, `router.js` drops **76.5 KB → 19.5 KB (~75%)**; CSS/JSON see similar wins.
2. **`defer` the Lucide `<script>`.** It's a 358 KB library loaded synchronously in `<head>`, fully render-blocking on every page. `defer` makes it non-blocking. It still executes **before** the deferred `api.js`/`router.js` ES modules (they appear later in document order and modules are deferred too), so the global `lucide` is defined before any `lucide.createIcons()` call at render time.

## Why a dependency

`compression` is a **backend-only** dependency (the standard Express middleware). My reading is that the CONTRIBUTING "no external dependencies" rule targets the **frontend** (it carves out Lucide specifically). Happy to swap for a small built-in `zlib` middleware instead if you'd prefer zero new deps — just say the word.

## Testing

- Smoke: started the server, confirmed `Content-Encoding: gzip` + `Vary: Accept-Encoding` on `/router.js` (76574 → 19479 bytes), HTML still 200, server boots clean.
- `npm run test:api` (5/5) and `npm run test:dashboard` (11/11) pass.

## Notes

For deployments behind a reverse proxy that already gzips, this is harmless (the proxy won't double-compress an already-encoded response). It guarantees compression for users who run Oikos without a compressing proxy.