### PR TITLE
fix(weather): honor app language and city IDs, key cache per query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Make the weather widget follow the app language, support city IDs, and key its cache per city/units/language.
+
 ## [0.57.4] - 2026-06-02
 
 ### Changed

--- a/public/pages/dashboard.js
+++ b/public/pages/dashboard.js
@@ -1274,7 +1274,7 @@ export async function render(container, { user }) {
   try {
     const [dashRes, weatherRes, prefsRes] = await Promise.all([
       api.get('/dashboard'),
-      api.get('/weather').catch(() => ({ data: null })),
+      api.get(`/weather?lang=${encodeURIComponent(getLocale())}`).catch(() => ({ data: null })),
       api.get('/preferences').catch(() => ({ data: {} })),
     ]);
     data         = dashRes;
@@ -1445,7 +1445,7 @@ export async function render(container, { user }) {
   if (refreshBtn) {
     const doAutoRefresh = async () => {
       try {
-        const res = await api.get('/weather').catch(() => ({ data: null }));
+        const res = await api.get(`/weather?lang=${encodeURIComponent(getLocale())}`).catch(() => ({ data: null }));
         weather = res.data ?? null;
         rebuildDashboard(widgetConfig);
       } catch { /* silently ignore */ }
@@ -1468,7 +1468,7 @@ function wireWeatherRefresh(container, onUpdated = null) {
     refreshBtn.disabled = true;
     refreshBtn.classList.add('weather-widget__refresh--spinning');
     try {
-      const res = await api.get('/weather').catch(() => ({ data: null }));
+      const res = await api.get(`/weather?lang=${encodeURIComponent(getLocale())}`).catch(() => ({ data: null }));
       const wWidget = container.querySelector('#weather-widget');
       if (wWidget) {
         const wrapper = wWidget.closest('.widget-wrapper');

--- a/server/routes/weather.js
+++ b/server/routes/weather.js
@@ -11,9 +11,20 @@ const log = createLogger('Weather');
 
 const router  = express.Router();
 
-// Cache: Daten für 30 Minuten halten
-let cache = { data: null, ts: 0 };
+// Cache: Daten für 30 Minuten halten - pro Stadt/Einheit/Sprache, damit ein
+// Wechsel von Stadt/Sprache/Einheit nicht 30 Minuten lang veraltete (oder
+// falschsprachige) Daten ausliefert.
+const cache = new Map(); // key `${city}|${units}|${lang}` → { data, ts }
 const CACHE_TTL_MS = 30 * 60 * 1000;
+const CACHE_MAX_ENTRIES = 50; // Schutz gegen unbegrenztes Wachstum bei variablen Query-Params
+
+// OpenWeatherMap erwartet bei einem Ortsnamen `q=`, bei einer numerischen
+// City-ID aber `id=`. Ortsnamen lassen sich mit Ländercode disambiguieren,
+// z.B. "Wellington,NZ" (sonst kann OWM die falsche Stadt zurückgeben).
+function cityParam(city) {
+  const c = String(city).trim();
+  return /^\d+$/.test(c) ? `id=${encodeURIComponent(c)}` : `q=${encodeURIComponent(c)}`;
+}
 
 // --------------------------------------------------------
 // GET /api/v1/weather
@@ -24,25 +35,29 @@ const CACHE_TTL_MS = 30 * 60 * 1000;
 router.get('/', async (req, res) => {
   try {
     const apiKey = process.env.OPENWEATHER_API_KEY;
-    const city   = process.env.OPENWEATHER_CITY || 'Berlin';
-    const units  = process.env.OPENWEATHER_UNITS || 'metric';
-    const lang   = process.env.OPENWEATHER_LANG  || 'de';
+    const city   = String(req.query.city  || process.env.OPENWEATHER_CITY  || 'Berlin');
+    const units  = String(req.query.units || process.env.OPENWEATHER_UNITS || 'metric');
+    // Sprache folgt der App-Locale (vom Frontend via ?lang= übergeben),
+    // dann OPENWEATHER_LANG, dann Englisch als neutraler Default.
+    const lang   = String(req.query.lang  || process.env.OPENWEATHER_LANG  || 'en');
 
     // Kein API-Key → leere Antwort (Widget wird ausgeblendet)
     if (!apiKey) {
       return res.json({ data: null });
     }
 
-    // Cache prüfen
-    if (cache.data && Date.now() - cache.ts < CACHE_TTL_MS) {
-      return res.json({ data: cache.data });
+    // Cache prüfen (pro Stadt/Einheit/Sprache)
+    const cacheKey = `${city}|${units}|${lang}`;
+    const cached = cache.get(cacheKey);
+    if (cached && Date.now() - cached.ts < CACHE_TTL_MS) {
+      return res.json({ data: cached.data });
     }
 
     // Dynamischer Import für node-fetch (ESM)
     const { default: fetch } = await import('node-fetch');
 
     // Aktuelles Wetter
-    const currentUrl = `https://api.openweathermap.org/data/2.5/weather?q=${encodeURIComponent(city)}&appid=${apiKey}&units=${units}&lang=${lang}`;
+    const currentUrl = `https://api.openweathermap.org/data/2.5/weather?${cityParam(city)}&appid=${apiKey}&units=${units}&lang=${lang}`;
     const currentRes = await fetch(currentUrl, { signal: AbortSignal.timeout(8000) });
     if (!currentRes.ok) {
       log.warn(`API error: ${currentRes.status}`);
@@ -51,7 +66,7 @@ router.get('/', async (req, res) => {
     const currentJson = await currentRes.json();
 
     // 5-Tage-Forecast (3h-Intervalle → aggregiert zu Tageswerten)
-    const forecastUrl = `https://api.openweathermap.org/data/2.5/forecast?q=${encodeURIComponent(city)}&appid=${apiKey}&units=${units}&lang=${lang}&cnt=40`;
+    const forecastUrl = `https://api.openweathermap.org/data/2.5/forecast?${cityParam(city)}&appid=${apiKey}&units=${units}&lang=${lang}&cnt=40`;
     const forecastRes = await fetch(forecastUrl, { signal: AbortSignal.timeout(8000) });
     let forecastDays = [];
 
@@ -113,7 +128,14 @@ router.get('/', async (req, res) => {
       forecast: forecastDays,
     };
 
-    cache = { data, ts: Date.now() };
+    // Älteste Einträge entfernen, falls der Cache zu groß wird (Map bewahrt Insertionsreihenfolge)
+    if (cache.size >= CACHE_MAX_ENTRIES) {
+      for (const k of cache.keys()) {
+        if (cache.size < CACHE_MAX_ENTRIES) break;
+        cache.delete(k);
+      }
+    }
+    cache.set(cacheKey, { data, ts: Date.now() });
     res.json({ data });
   } catch (err) {
     log.warn('Error:', err.message);


### PR DESCRIPTION
## Problems

Running Oikos with the UI in English, the weather widget still showed German descriptions (e.g. *"Bedeckt"*). Digging in surfaced three related issues in `server/routes/weather.js`:

1. **Language was hardcoded to German.** `const lang = process.env.OPENWEATHER_LANG || 'de'` — the OpenWeatherMap `lang` never followed the app locale, so non-German users got German descriptions unless they knew to set an env var.
2. **The in-memory cache was keyed only by timestamp** (`{ data, ts }`), ignoring city/units/lang. If those ever vary (they now can, see below), the 30-minute cache serves the wrong city/language/units to everyone.
3. **Numeric `OPENWEATHER_CITY` values 404.** The URL always used `q=`, but OWM treats a numeric value as a name and returns `404 city not found`. Users who pasted a **city ID** to disambiguate (e.g. Wellington NZ vs Wellington UK) ended up with an empty widget.

## Changes

- **Locale-aware language.** The dashboard now sends `?lang=<active locale>` (via the existing `getLocale()`), and the route resolves `lang` as `req.query.lang || OPENWEATHER_LANG || 'en'`. Same pattern allows optional `?city=`/`?units=` overrides. (The ultimate fallback is `'en'` to match the app's own English i18n fallback — easy to change back to `'de'` if you'd prefer.)
- **Per-parameter cache.** Cache is now a `Map` keyed by `city|units|lang`, bounded to 50 entries (oldest evicted).
- **City IDs supported.** A numeric `OPENWEATHER_CITY` is sent as `id=`; otherwise `q=`. Names can still be disambiguated with a country code, e.g. `Wellington,NZ`.

## Testing

- Boot smoke: server starts clean; `GET /api/v1/weather?lang=en` returns 401 (auth-gated) rather than 500 — route logic intact.
- `npm run test:dashboard` (11/11) and `npm run test:frontend-audit` (57/57) pass.
- Verified live against OpenWeatherMap: `q=2179537` → `404 city not found`; `q=Wellington,NZ` → Wellington, **NZ**; `?lang=en` returns English descriptions.

## Note on locale codes

`getLocale()` returns the app's locale code (e.g. `en`, `de`, `fr`). Most line up with OWM's `lang` codes; a few differ (OWM uses `pt_br`, `zh_cn`, etc.) and OWM falls back to English for unknown values. A small locale→OWM map could be added later if you want exact coverage.