### PR TITLE
refactor(ui): debounce document and split-expense search inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Debounce the documents and split-expenses search inputs.
+
 ## [0.57.4] - 2026-06-02
 
 ### Changed

--- a/public/pages/documents.js
+++ b/public/pages/documents.js
@@ -156,9 +156,14 @@ function bindPageEvents() {
   _container.querySelector('#documents-add-btn')?.addEventListener('click', () => openDocumentModal());
   _container.querySelector('#documents-folder-btn')?.addEventListener('click', () => openFolderModal());
   _container.querySelector('#fab-new-document')?.addEventListener('click', () => openDocumentModal());
+  let documentsSearchTimer;
   _container.querySelector('#documents-search')?.addEventListener('input', (e) => {
-    state.query = e.target.value.trim().toLowerCase();
-    renderDocuments();
+    const value = e.target.value.trim().toLowerCase();
+    clearTimeout(documentsSearchTimer);
+    documentsSearchTimer = setTimeout(() => {
+      state.query = value;
+      renderDocuments();
+    }, 200);
   });
   _container.querySelector('#documents-status')?.addEventListener('change', async (e) => {
     state.status = e.target.value;

--- a/public/pages/split-expenses.js
+++ b/public/pages/split-expenses.js
@@ -154,11 +154,16 @@ function bindShell() {
   _container.querySelector('#split-add-group')?.addEventListener('click', () => openGroupModal());
   _container.querySelector('#split-add-expense')?.addEventListener('click', () => openExpenseModal());
   _container.querySelector('#split-fab')?.addEventListener('click', () => openExpenseModal());
-  _container.querySelector('#split-group-search')?.addEventListener('input', async (e) => {
-    state.query = e.target.value.trim();
-    await loadGroups();
-    await loadGroupData();
-    renderAll();
+  let groupSearchTimer;
+  _container.querySelector('#split-group-search')?.addEventListener('input', (e) => {
+    const value = e.target.value.trim();
+    clearTimeout(groupSearchTimer);
+    groupSearchTimer = setTimeout(async () => {
+      state.query = value;
+      await loadGroups();
+      await loadGroupData();
+      renderAll();
+    }, 250);
   });
   _container.querySelector('#split-groups')?.addEventListener('click', async (e) => {
     const btn = e.target.closest('[data-group-id]');


### PR DESCRIPTION
## What

Two search inputs ran their full handler on **every keystroke**:

- **Documents** (`documents.js`): each character set `state.query` and called `renderDocuments()`, rebuilding the entire document list synchronously.
- **Split-expenses** (`split-expenses.js`): each character fired **two sequential API calls** (`loadGroups()` then `loadGroupData()`) plus a full `renderAll()`. Typing "groceries" = ~9 keystrokes × multiple requests.

## Fix

Wrap both in the same `setTimeout`/`clearTimeout` debounce that the **Contacts** search already uses (`contacts.js:107`) — 200 ms for documents, 250 ms for split-expenses (it hits the network). The input value is captured at event time so the deferred handler reads the right string. Behaviour is identical, just coalesced.

## Testing

- `node --check` on both files.
- `npm run test:frontend-audit` and `npm run test:split-expenses` pass.

Small, self-contained; part of a series of render-perf fixes. The larger one (scoping the ~51 unscoped `lucide.createIcons()` calls) will be a separate PR.