### PR TITLE
docs: correct first-run admin instructions in Unraid template

### DIFF
--- a/templates/oikos.xml
+++ b/templates/oikos.xml
@@ -40,7 +40,7 @@ REQUIRED: Set a long random SESSION_SECRET.
 RECOMMENDED: Set a strong DB_ENCRYPTION_KEY to encrypt the database at rest — without it the database and any synced calendar/contact credentials are stored unencrypted.
 Generate either secret with: openssl rand -base64 48
 
-After the container starts, open the WebUI and create your admin account. That's it — pick the modules you want and invite your family.</Overview>
+After the container starts, create your admin account by opening the container Console and running: node setup.js (Oikos has no web-based first-run signup — the admin is created via this one-time command). Then open the WebUI and log in — pick the modules you want and invite your family.</Overview>
 
   <!-- Either Support or Project is required -->
   <Support>https://github.com/ulsklyc/oikos/issues</Support>


### PR DESCRIPTION
Fixes #207

## Problem

`templates/oikos.xml` (the Unraid Community Apps Overview) tells users:

> After the container starts, open the WebUI and create your admin account.

But Oikos has **no web-based first-run signup** — opening the WebUI just shows a login screen. The first admin is created with `node setup.js`, exactly as the README, `docs/installation.md`, and `docs/SPEC.md` (*"No public registration form"*) already state. New Unraid users land on a login page for an account that doesn't exist, with no on-screen hint.

## Change

One line in `templates/oikos.xml`: point first-run at the same `node setup.js` step the rest of the docs use (via the container **Console** on Unraid), then log in. No code change; this only aligns the template with the actual (CLI) bootstrap flow.

## Verified
- `templates/oikos.xml` still parses as valid XML.

See the linked issue for the root-cause trace (no `/setup` route, login-only frontend, backend `POST /api/v1/auth/setup` exists but is never called by the UI).