### PR TITLE
refactor(db): add indexes for assignment and recurring-event lookups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Add database indexes for event/task assignment, loan-payment, and recurring-event lookups.
+
 ## [0.57.4] - 2026-06-02
 
 ### Changed

--- a/server/db.js
+++ b/server/db.js
@@ -1572,6 +1572,28 @@ const MIGRATIONS = [
         ON users(oidc_sub) WHERE oidc_sub IS NOT NULL;
     `,
   },
+  {
+    version: 43,
+    description: 'Performance indexes: assignment lookups by user, loan-payment entries, recurring events',
+    up: `
+      -- "assigned to me" lookups: the PKs are (event_id|task_id, user_id),
+      -- so a user_id-leading index is missing for filtering by assignee.
+      CREATE INDEX IF NOT EXISTS idx_event_assignments_user
+        ON event_assignments(user_id);
+      CREATE INDEX IF NOT EXISTS idx_task_assignments_user
+        ON task_assignments(user_id);
+
+      -- budget month list LEFT JOINs loan payments on budget_entry_id (only
+      -- loan_id and paid_date were indexed) -> probed with a scan per row.
+      CREATE INDEX IF NOT EXISTS idx_budget_loan_payments_entry
+        ON budget_loan_payments(budget_entry_id);
+
+      -- calendar GET expands all recurring events; partial index keeps that
+      -- scan to just the recurring rows instead of the full events table.
+      CREATE INDEX IF NOT EXISTS idx_calendar_recurring
+        ON calendar_events(start_datetime) WHERE recurrence_rule IS NOT NULL;
+    `,
+  },
 ];
 
 /**


### PR DESCRIPTION
## What

Adds **migration 43** with four indexes on hot query paths. On a SQLCipher-encrypted DB every page read costs decryption, so unindexed scans hurt more than on plain SQLite.

| Index | Why |
|-------|-----|
| `idx_event_assignments_user` | PK is `(event_id, user_id)`; filtering events **by assignee** had no `user_id`-leading index. |
| `idx_task_assignments_user` | Same for `task_assignments` (PK `(task_id, user_id)`). |
| `idx_budget_loan_payments_entry` | Budget month list `LEFT JOIN budget_loan_payments ON budget_entry_id`, which was unindexed (only `loan_id`/`paid_date` were) -> a scan per budget row. |
| `idx_calendar_recurring` | Partial index `(start_datetime) WHERE recurrence_rule IS NOT NULL` for the calendar GET that selects all recurring events to expand. |

I deliberately **did not** add a `family_document_access(document_id)` index — its PK `(document_id, user_id)` already leads with `document_id`.

## Testing
- Fresh DB reaches **schema v43**, `Migration 43 applied` logged; all four indexes confirmed in `sqlite_master`.
- `test:db` (36), `test:dashboard` (11), `test:calendar` (29), `test:split-expenses` pass.

Additive, idempotent (`IF NOT EXISTS`), follows the "append new migrations at the end" rule.