### PR TITLE
fix(ui): remove backdrop-filter that made modal scrolling janky

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Fix janky, laggy scrolling in tall modals (e.g. the event editor) caused by a backdrop-filter on the scroll container.
+
 ## [0.57.4] - 2026-06-02
 
 ### Changed

--- a/public/styles/glass.css
+++ b/public/styles/glass.css
@@ -95,11 +95,15 @@
     -webkit-backdrop-filter: var(--blur-xs) saturate(120%);
   }
 
-  .modal-panel {
-    background: var(--glass-bg-elevated);
-    backdrop-filter: var(--blur-sm);
-    -webkit-backdrop-filter: var(--blur-sm);
-  }
+  /* NOTE: deliberately NO backdrop-filter on .modal-panel.
+   * The panel contains the .modal-panel__body scroll container
+   * (overflow-y:auto); a backdrop-filter on that scroll ancestor forces the
+   * browser off the fast async-scroll path and re-rasterizes the blur every
+   * frame, making tall modals (e.g. the event editor) hang while scrolling.
+   * The panel keeps its opaque --color-surface background from layout.css;
+   * the blur lives on the non-scrolling .modal-overlay instead. Same
+   * opaque-background fix already used for the sticky toolbars in
+   * housekeeping.css / shopping.css. */
 
   .modal-panel__header {
     background: var(--glass-bg-elevated);


### PR DESCRIPTION
## Problem

The event editor modal scrolls with severe lag and visible hangs (reported on a real install; worst on the tallest modal because it's the one that actually scrolls).

## Root cause

`.modal-panel` has `backdrop-filter: var(--blur-sm)` (glass.css `@supports` block) **and** contains the `.modal-panel__body` scroll container (`overflow-y: auto`). A `backdrop-filter` on an ancestor of a scrolling element forces the browser off the fast async-scroll/composited path and re-rasterizes the blurred region every frame — the classic "laggy/hanging modal scroll," brutal on mobile GPUs.

This codebase already documents the same class of bug for sticky toolbars (see the "backdrop-filter on position:sticky inside overflow:auto" comments in `housekeeping.css` and `shopping.css`) and fixes it the same way: go opaque.

## Fix

Remove the `backdrop-filter` override on `.modal-panel`. It falls back to the opaque `background-color: var(--color-surface)` already defined in `layout.css`, so no new tokens. The page-dimming blur stays on the **non-scrolling** `.modal-overlay`, so the glass aesthetic is preserved — the panel just sits opaque on top of the still-blurred backdrop. One rule removed.

## Notes
- Visual: the modal panel itself no longer blurs what's directly behind it; in practice it sits on the blurred dark overlay so the difference is barely perceptible, and scroll becomes smooth.
- No JS change; `test:frontend-audit` and `test:calendar` still pass.