### PR TITLE
refactor(ui): scope icon rendering and index calendar day lookups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Scope icon re-rendering to changed subtrees and index calendar day lookups for smoother large lists and month views.
+
 ## [0.57.4] - 2026-06-02
 
 ### Changed

--- a/public/components/modal.js
+++ b/public/components/modal.js
@@ -290,7 +290,7 @@ export function openModal({ title, content, onSave, onDelete, onClose, size = 'm
   activeOverlay._onCloseCallback = onClose;
 
   // Lucide-Icons rendern
-  if (window.lucide) window.lucide.createIcons();
+  if (window.lucide) window.lucide.createIcons({ el: activeOverlay });
 
   // Focus-Trap
   const panel = activeOverlay.querySelector('.modal-panel');

--- a/public/pages/birthdays.js
+++ b/public/pages/birthdays.js
@@ -216,7 +216,7 @@ function renderList() {
     </article>
   `).join(''));
 
-  if (window.lucide) window.lucide.createIcons();
+  if (window.lucide) window.lucide.createIcons({ el: host });
   stagger(host.querySelectorAll('.birthday-item'));
 }
 
@@ -272,7 +272,7 @@ function renderPage() {
   renderUpcoming();
   renderList();
   renderSuggestions();
-  if (window.lucide) window.lucide.createIcons();
+  if (window.lucide) window.lucide.createIcons({ el: _container });
 }
 
 function bindEvents() {

--- a/public/pages/budget.js
+++ b/public/pages/budget.js
@@ -245,7 +245,7 @@ export async function render(container, { user }) {
     </div>
   `);
 
-  if (window.lucide) lucide.createIcons();
+  if (window.lucide) lucide.createIcons({ el: container });
 
   if (user?.access_scope !== 'split_guest') {
     await loadMonth(state.month);
@@ -319,7 +319,7 @@ function renderBody() {
   if (state.activeTab === 'loans') {
     setHtml(body, renderLoansPage());
     wireLoansPage();
-    if (window.lucide) lucide.createIcons();
+    if (window.lucide) lucide.createIcons({ el: body });
     return;
   }
   if (state.activeTab === 'split-expenses') {
@@ -387,7 +387,7 @@ function renderBody() {
     </div>
   `);
 
-  if (window.lucide) lucide.createIcons();
+  if (window.lucide) lucide.createIcons({ el: body });
   _container.querySelector('#empty-cta-budget')?.addEventListener('click', () => {
     document.querySelector('.page-fab')?.click();
   });
@@ -1141,7 +1141,7 @@ function requestNameInPanel(panel, { title, label, placeholder }) {
       </div>
     `);
     panel.append(overlay);
-    if (window.lucide) lucide.createIcons();
+    if (window.lucide) lucide.createIcons({ el: overlay });
 
     const input = overlay.querySelector('#budget-inline-name');
     const cleanup = (value = '') => {

--- a/public/pages/calendar.js
+++ b/public/pages/calendar.js
@@ -576,7 +576,58 @@ function getAgendaRange(dateStr) {
   return { from: dateStr, to: addDays(dateStr, 30) };
 }
 
+// Per-Render-Pass Day-Buckets. Vermeidet, dass jede der 42 Monats-Zellen die
+// komplette state.events/state.tasks-Liste neu filtert und pro Event ein neues
+// Date parst (O(Zellen × Events) → O(Events + Zellen)).
+// _dayIndex.active signalisiert, dass die Maps für die aktuelle Render-Phase
+// gültig sind; ansonsten fallen die Helfer auf direktes Filtern zurück.
+const _dayIndex = {
+  active:  false,
+  events:  new Map(), // isoDate -> Event[]
+  tasks:   new Map(), // isoDate -> Task[]
+};
+
+/**
+ * Baut die Tages-Buckets für Events und Tasks einmal pro Render-Durchlauf.
+ * Jedes Datum wird genau einmal geparst; mehrtägige Events werden in jeden
+ * Tag ihres Bereichs (geklammert auf das geladene Fenster) einsortiert.
+ */
+function buildDayIndex() {
+  const evMap = new Map();
+  // Events in Originalreihenfolge durchlaufen, damit pro Tag die Reihenfolge
+  // identisch zum bisherigen .filter()-Verhalten bleibt.
+  const lo = state.rangeFrom || '';
+  const hi = state.rangeTo   || '';
+  for (const e of state.events) {
+    const start = localDate(e.start_datetime);
+    const end   = e.end_datetime ? localDate(e.end_datetime) : start;
+    // Auf das geladene Fenster klammern, damit mehrtägige/fehlerhafte Events
+    // keinen unbegrenzten Bereich erzeugen.
+    let from = lo && start < lo ? lo : start;
+    const to = hi && end > hi ? hi : end;
+    if (from > to) continue;
+    for (let day = from; day <= to; day = addDays(day, 1)) {
+      const bucket = evMap.get(day);
+      if (bucket) bucket.push(e);
+      else evMap.set(day, [e]);
+    }
+  }
+
+  const taskMap = new Map();
+  for (const t of state.tasks) {
+    if (!t.due_date) continue;
+    const bucket = taskMap.get(t.due_date);
+    if (bucket) bucket.push(t);
+    else taskMap.set(t.due_date, [t]);
+  }
+
+  _dayIndex.events = evMap;
+  _dayIndex.tasks  = taskMap;
+  _dayIndex.active = true;
+}
+
 function eventsOnDay(dateStr) {
+  if (_dayIndex.active) return _dayIndex.events.get(dateStr) ?? [];
   return state.events.filter((e) => {
     const start = localDate(e.start_datetime);
     const end   = e.end_datetime ? localDate(e.end_datetime) : start;
@@ -593,6 +644,7 @@ function filterTasksForCalendar(tasks) {
 
 /** Tasks, die an einem bestimmten Tag fällig sind. */
 function tasksOnDay(dateStr) {
+  if (_dayIndex.active) return _dayIndex.tasks.get(dateStr) ?? [];
   return state.tasks.filter((t) => t.due_date === dateStr);
 }
 
@@ -723,7 +775,7 @@ function renderToolbar() {
     </div>
   `);
 
-  if (window.lucide) lucide.createIcons();
+  if (window.lucide) lucide.createIcons({ el: bar });
 
   updateLabel();
 
@@ -817,11 +869,18 @@ function renderView() {
   if (!body) return;
   body.replaceChildren();
 
-  if (state.view === 'month')  renderMonthView(body);
-  if (state.view === 'week')   renderWeekView(body);
-  if (state.view === 'day')    renderDayView(body);
-  if (state.view === 'agenda') renderAgendaView(body);
-  if (window.lucide) lucide.createIcons();
+  // Tages-Buckets einmal pro Render-Pass aufbauen; danach wieder deaktivieren,
+  // damit spätere State-Mutationen (Modals etc.) keinen veralteten Index lesen.
+  buildDayIndex();
+  try {
+    if (state.view === 'month')  renderMonthView(body);
+    if (state.view === 'week')   renderWeekView(body);
+    if (state.view === 'day')    renderDayView(body);
+    if (state.view === 'agenda') renderAgendaView(body);
+  } finally {
+    _dayIndex.active = false;
+  }
+  if (window.lucide) lucide.createIcons({ el: body });
 }
 
 // --------------------------------------------------------
@@ -1315,7 +1374,7 @@ function showEventPopup(ev, anchor) {
   `);
 
   document.body.appendChild(popup);
-  if (window.lucide) lucide.createIcons();
+  if (window.lucide) lucide.createIcons({ el: popup });
 
   if (ev.external_source === 'ics' && ev.user_modified === 1) {
     const resetLink = document.createElement('a');
@@ -1607,7 +1666,7 @@ function openEventModal({ mode, event = null, date = null, reminder = null }) {
           iconTrigger.dataset.icon = nextIcon;
           iconTrigger.replaceChildren(eventIconElement(nextIcon, 'event-icon-picker__trigger-icon'));
         }
-        if (window.lucide) lucide.createIcons();
+        if (window.lucide) lucide.createIcons({ el: iconTrigger });
       };
 
       iconTrigger?.addEventListener('click', () => {
@@ -1700,7 +1759,7 @@ function openEventModal({ mode, event = null, date = null, reminder = null }) {
       });
 
       panel.querySelector('#modal-save').addEventListener('click', () => saveEvent(panel, mode, event?.id, reminder, attachmentState));
-      if (window.lucide) lucide.createIcons();
+      if (window.lucide) lucide.createIcons({ el: panel });
     },
   });
 }

--- a/public/pages/contacts.js
+++ b/public/pages/contacts.js
@@ -90,7 +90,7 @@ export async function render(container, { user }) {
     </div>
   `);
 
-  if (window.lucide) lucide.createIcons();
+  if (window.lucide) lucide.createIcons({ el: container });
 
   const res        = await api.get('/contacts');
   state.contacts   = res.data;
@@ -196,7 +196,7 @@ function renderList() {
         </button>
       </div>
     `);
-    if (window.lucide) lucide.createIcons();
+    if (window.lucide) lucide.createIcons({ el: container });
     container.querySelector('#empty-cta-contacts')?.addEventListener('click', () => {
       document.querySelector('.page-fab')?.click();
     });
@@ -220,7 +220,7 @@ function renderList() {
       </div>
     `).join(''));
 
-  if (window.lucide) lucide.createIcons();
+  if (window.lucide) lucide.createIcons({ el: container });
   stagger(container.querySelectorAll('.contact-item'));
 
   // Event-Delegation

--- a/public/pages/dashboard.js
+++ b/public/pages/dashboard.js
@@ -945,7 +945,7 @@ function initFab(container, signal) {
     fabActions.querySelectorAll('[role="button"]').forEach((el) => {
       el.tabIndex = open ? 0 : -1;
     });
-    if (window.lucide) window.lucide.createIcons();
+    if (window.lucide) window.lucide.createIcons({ el: container });
   }
 
   fabMain.addEventListener('click', (e) => { e.stopPropagation(); toggleFab(); });
@@ -1398,7 +1398,7 @@ export async function render(container, { user }) {
       ${renderDashboardLayout(cfg, data, weather, currency, { editing: isCustomizing })}
     `);
     wireLinks(container, rerender, { editing: isCustomizing });
-    if (window.lucide) window.lucide.createIcons();
+    if (window.lucide) window.lucide.createIcons({ el: shell });
     wireWeatherRefresh(container, (updatedWeather) => {
       weather = updatedWeather;
       rebuildDashboard(cfg);

--- a/public/pages/documents.js
+++ b/public/pages/documents.js
@@ -102,7 +102,7 @@ export async function render(container) {
     </div>
   `);
 
-  if (window.lucide) lucide.createIcons();
+  if (window.lucide) lucide.createIcons({ el: _container });
 
   await Promise.all([loadMembers(), loadFolders()]);
   await loadDocuments();
@@ -233,14 +233,14 @@ function renderDocuments() {
         </div>
       </div>
     `);
-    if (window.lucide) lucide.createIcons();
+    if (window.lucide) lucide.createIcons({ el: list });
     list.querySelector('#documents-empty-upload')?.addEventListener('click', () => openDocumentModal());
     list.querySelector('#documents-empty-folder')?.addEventListener('click', () => openFolderModal());
     return;
   }
   list.replaceChildren();
   list.insertAdjacentHTML('beforeend', docs.map((doc) => state.view === 'list' ? renderListItem(doc) : renderGridCard(doc)).join(''));
-  if (window.lucide) lucide.createIcons();
+  if (window.lucide) lucide.createIcons({ el: list });
   stagger(list.querySelectorAll('.document-card, .document-row'));
 }
 
@@ -274,7 +274,7 @@ function renderFolderBrowser() {
       <span class="documents-folder-item__count">${counts.get(item.id) || 0}</span>
     </button>
   `).join(''));
-  if (window.lucide) lucide.createIcons();
+  if (window.lucide) lucide.createIcons({ el: browser });
 }
 
 function renderMeta(doc) {

--- a/public/pages/meals.js
+++ b/public/pages/meals.js
@@ -185,7 +185,7 @@ export async function render(container, { user }) {
     </div>
   `);
 
-  if (window.lucide) lucide.createIcons();
+  if (window.lucide) lucide.createIcons({ el: container });
   renderKitchenTabsBar(container, '/meals');
 
   const today  = toLocalDateKey(new Date());
@@ -260,7 +260,7 @@ function renderWeekGrid() {
     `;
   }).join(''));
 
-  if (window.lucide) lucide.createIcons();
+  if (window.lucide) lucide.createIcons({ el: grid });
   stagger(grid.querySelectorAll('.meal-card'));
   wireGrid(grid);
 }
@@ -660,7 +660,7 @@ function openMealModal(opts) {
           })
           .join(''));
 
-        if (window.lucide) lucide.createIcons();
+        if (window.lucide) lucide.createIcons({ el: ingList });
       };
 
       recipeSelect?.addEventListener('change', () => {
@@ -685,7 +685,7 @@ function openMealModal(opts) {
           ))
           .join(''));
 
-        if (window.lucide) lucide.createIcons();
+        if (window.lucide) lucide.createIcons({ el: ingList });
       });
 
       saveAsRecipeBtn?.addEventListener('click', async () => {
@@ -740,7 +740,7 @@ function openMealModal(opts) {
         tmp.insertAdjacentHTML('beforeend', ingredientRowHTML('', '', null));
         const row = tmp.firstElementChild;
         ingList.appendChild(row);
-        if (window.lucide) lucide.createIcons();
+        if (window.lucide) lucide.createIcons({ el: ingList });
         row.querySelector('input').focus();
       });
 

--- a/public/pages/notes.js
+++ b/public/pages/notes.js
@@ -81,7 +81,7 @@ export async function render(container, { user }) {
     </div>
   `);
 
-  if (window.lucide) lucide.createIcons();
+  if (window.lucide) lucide.createIcons({ el: container });
 
   try {
     const res  = await api.get('/notes');
@@ -155,7 +155,7 @@ function renderGrid() {
         </button>` : ''}
       </div>
     `);
-    if (window.lucide) lucide.createIcons();
+    if (window.lucide) lucide.createIcons({ el: grid });
     grid.querySelector('#empty-cta-notes')?.addEventListener('click', () => {
       document.querySelector('.page-fab')?.click();
     });
@@ -164,7 +164,7 @@ function renderGrid() {
 
   grid.replaceChildren();
   grid.insertAdjacentHTML('beforeend', visible.map((n) => renderNoteCard(n)).join(''));
-  if (window.lucide) lucide.createIcons();
+  if (window.lucide) lucide.createIcons({ el: grid });
   stagger(grid.querySelectorAll('.note-card'));
 }
 

--- a/public/pages/recipes.js
+++ b/public/pages/recipes.js
@@ -73,7 +73,7 @@ export async function render(container) {
   container.replaceChildren(page);
   renderKitchenTabsBar(container, '/recipes');
 
-  if (window.lucide) window.lucide.createIcons();
+  if (window.lucide) window.lucide.createIcons({ el: container });
 
   await Promise.all([loadRecipes(), loadCategories()]);
   renderRecipeList();
@@ -322,7 +322,7 @@ function openRecipeModal(mode, recipe = null) {
 
       panel.querySelector('#recipe-add-ingredient')?.addEventListener('click', () => {
         ingList.appendChild(buildIngredientRow('', '', null));
-        if (window.lucide) window.lucide.createIcons();
+        if (window.lucide) window.lucide.createIcons({ el: ingList });
       });
 
       ingList.addEventListener('click', (e) => {
@@ -334,7 +334,7 @@ function openRecipeModal(mode, recipe = null) {
       panel.querySelector('#recipe-cancel')?.addEventListener('click', closeModal);
       panel.querySelector('#recipe-save')?.addEventListener('click', () => saveRecipe(panel, mode, recipe));
 
-      if (window.lucide) window.lucide.createIcons();
+      if (window.lucide) window.lucide.createIcons({ el: panel });
     },
   });
 }

--- a/public/pages/settings.js
+++ b/public/pages/settings.js
@@ -904,7 +904,7 @@ docker cp oikos:/data/oikos-backup.db ./oikos-backup.db</code></pre>
 
   renderSettingsSubTabs(container, user, activeTab);
   bindEvents(container, user, users, categories, icsSubscriptions, apiTokens, thirdPartyModules);
-  if (window.lucide) window.lucide.createIcons();
+  if (window.lucide) window.lucide.createIcons({ el: container });
 }
 // CalDAV-Konten laden
 async function loadCalDAVAccounts(container, user) {
@@ -2260,7 +2260,7 @@ function renderApiTokenList(container, tokens) {
     tmp.insertAdjacentHTML('beforeend', apiTokenHtml(token));
     list.appendChild(tmp.firstElementChild);
   });
-  if (window.lucide) window.lucide.createIcons();
+  if (window.lucide) window.lucide.createIcons({ el: list });
 }
 
 function datetimeLocalToIso(value) {
@@ -2376,7 +2376,7 @@ async function loadBackupSchedulerStatus(container) {
     infoContainer.replaceChildren();
     infoContainer.insertAdjacentHTML('beforeend', html);
 
-    if (window.lucide) window.lucide.createIcons();
+    if (window.lucide) window.lucide.createIcons({ el: infoContainer });
 
     // Event-Handler für manuellen Trigger
     const triggerBtn = infoContainer.querySelector('#backup-trigger-btn');
@@ -2512,7 +2512,7 @@ function renderCatList(container, cats) {
     tmp.insertAdjacentHTML('beforeend', categoryRowHtml(c, i === 0, i === cats.length - 1));
     list.appendChild(tmp.firstElementChild);
   });
-  if (window.lucide) window.lucide.createIcons();
+  if (window.lucide) window.lucide.createIcons({ el: list });
 }
 
 function bindCategoryEvents(container) {
@@ -2747,7 +2747,7 @@ function renderIcsList(container, subs, user) {
     ul.appendChild(li);
   });
   listEl.appendChild(ul);
-  if (window.lucide) window.lucide.createIcons();
+  if (window.lucide) window.lucide.createIcons({ el: listEl });
 }
 
 function bindIcsEvents(container, user, initialSubs) {
@@ -2823,7 +2823,7 @@ function bindIcsEvents(container, user, initialSubs) {
         target.disabled = true;
         target.title = t('settings.ics.status.syncing');
         if (origIcon) origIcon.setAttribute('data-lucide', 'loader');
-        if (window.lucide) window.lucide.createIcons();
+        if (window.lucide) window.lucide.createIcons({ el: target });
         try {
           const res = await api.post(`/calendar/subscriptions/${id}/sync`, {});
           const idx = subs.findIndex((s) => s.id === id);
@@ -2835,7 +2835,7 @@ function bindIcsEvents(container, user, initialSubs) {
           target.disabled = false;
           target.title = origTitle;
           if (origIcon) origIcon.setAttribute('data-lucide', 'refresh-cw');
-          if (window.lucide) window.lucide.createIcons();
+          if (window.lucide) window.lucide.createIcons({ el: target });
         }
       }
 

--- a/public/pages/shopping.js
+++ b/public/pages/shopping.js
@@ -110,7 +110,7 @@ function renderTabs(container) {
       <i data-lucide="plus" class="icon-md" aria-hidden="true"></i>
     </button>
   `);
-  if (window.lucide) window.lucide.createIcons();
+  if (window.lucide) window.lucide.createIcons({ el: bar });
 }
 
 function renderListContent(container) {
@@ -127,7 +127,7 @@ function renderListContent(container) {
           ${t('shopping.noListsDescription')}
         </div>
       </div>`);
-    if (window.lucide) window.lucide.createIcons();
+    if (window.lucide) window.lucide.createIcons({ el: content });
     return;
   }
 
@@ -182,7 +182,7 @@ function renderListContent(container) {
     </div>
   `);
 
-  if (window.lucide) window.lucide.createIcons();
+  if (window.lucide) window.lucide.createIcons({ el: content });
   stagger(content.querySelectorAll('.shopping-item'));
   wireAutocomplete(container);
   wireQuickAdd(container);
@@ -288,7 +288,7 @@ function wireAutocomplete(container) {
           });
         });
 
-        if (window.lucide) window.lucide.createIcons();
+        if (window.lucide) window.lucide.createIcons({ el: dropdown });
       } catch { dropdown.hidden = true; }
     }, 200);
   });
@@ -349,7 +349,7 @@ function _flashAddBtn(btn) {
   setTimeout(() => {
     btn.classList.remove('btn--success');
     btn.replaceChildren(...saved);
-    if (window.lucide) window.lucide.createIcons();
+    if (window.lucide) window.lucide.createIcons({ el: btn });
   }, 700);
 }
 
@@ -559,7 +559,7 @@ function updateItemsList(container) {
   if (listEl) {
     listEl.replaceChildren();
     listEl.insertAdjacentHTML('beforeend', renderItems());
-    if (window.lucide) window.lucide.createIcons();
+    if (window.lucide) window.lucide.createIcons({ el: listEl });
     stagger(listEl.querySelectorAll('.shopping-item'));
     wireSwipeGestures(container);
     maybeShowSwipeHint(container);
@@ -579,7 +579,7 @@ function updateItemsList(container) {
           <i data-lucide="trash-2" class="icon-md" aria-hidden="true"></i>
           ${t('shopping.clearChecked', { count: checkedCount })}
         </button>`);
-      if (window.lucide) window.lucide.createIcons();
+      if (window.lucide) window.lucide.createIcons({ el: header });
     } else if (clearBtn) {
       if (checkedCount === 0) {
         clearBtn.remove();
@@ -588,7 +588,7 @@ function updateItemsList(container) {
         clearBtn.insertAdjacentHTML('beforeend', `
           <i data-lucide="trash-2" class="icon-md" aria-hidden="true"></i>
           ${t('shopping.clearChecked', { count: checkedCount })}`);
-        if (window.lucide) window.lucide.createIcons();
+        if (window.lucide) window.lucide.createIcons({ el: clearBtn });
       }
     }
   }

--- a/public/pages/split-expenses.js
+++ b/public/pages/split-expenses.js
@@ -85,7 +85,7 @@ export async function render(container, { user } = {}) {
       </button>
     </div>
   `);
-  if (window.lucide) lucide.createIcons();
+  if (window.lucide) lucide.createIcons({ el: _container });
   await loadInitial();
   bindShell();
   renderAll();
@@ -173,7 +173,7 @@ function renderAll() {
   renderSummary();
   renderGroups();
   renderMain();
-  if (window.lucide) lucide.createIcons();
+  if (window.lucide) lucide.createIcons({ el: _container });
 }
 
 function renderSummary() {

--- a/public/pages/tasks.js
+++ b/public/pages/tasks.js
@@ -834,7 +834,7 @@ function renderKanban(container) {
   listEl.replaceChildren();
   listEl.insertAdjacentHTML('beforeend', kanbanHtml);
 
-  if (window.lucide) window.lucide.createIcons();
+  if (window.lucide) window.lucide.createIcons({ el: listEl });
   wireKanbanDrag(container);
   wireKanbanTouch(container);
   updateOverdueBadge();
@@ -1066,7 +1066,7 @@ function renderTaskList(container) {
   if (!listEl) return;
   listEl.replaceChildren();
   listEl.insertAdjacentHTML('beforeend', renderTaskGroups(state.tasks, state.groupMode));
-  if (window.lucide) window.lucide.createIcons();
+  if (window.lucide) window.lucide.createIcons({ el: listEl });
   stagger(listEl.querySelectorAll('.swipe-row, .kanban-card'));
   updateOverdueBadge();
   updateBulkActionsBar(container);
@@ -1849,7 +1849,7 @@ export async function render(container, { user }) {
     </div>
   `);
 
-  if (window.lucide) window.lucide.createIcons();
+  if (window.lucide) window.lucide.createIcons({ el: container });
 
   // Daten laden (Filter-State aus vorheriger Session berücksichtigen)
   try {

--- a/public/router.js
+++ b/public/router.js
@@ -1098,7 +1098,7 @@ function initMoreSheet(container, openSearch) {
     backdrop.classList.add('more-backdrop--visible');
     currentMoreBtn().setAttribute('aria-expanded', 'true');
     sheet.querySelector('#more-sheet-search, [data-route]')?.focus();
-    if (window.lucide) window.lucide.createIcons();
+    if (window.lucide) window.lucide.createIcons({ el: sheet });
   }
 
   function closeSheet({ restoreFocus = true } = {}) {
@@ -1175,7 +1175,7 @@ function initSearch(container) {
     setOverlayInteractive(overlay, true);
     overlay.classList.add('search-overlay--visible');
     setTimeout(() => input.focus(), 50);
-    if (window.lucide) window.lucide.createIcons();
+    if (window.lucide) window.lucide.createIcons({ el: overlay });
 
     _searchTrapHandler = createFocusTrap(overlay);
     overlay.addEventListener('keydown', _searchTrapHandler);
@@ -1629,7 +1629,8 @@ function updateNav(path) {
   }
 
   if (window.lucide) {
-    window.lucide.createIcons();
+    const navRoot = document.getElementById('app');
+    window.lucide.createIcons(navRoot ? { el: navRoot } : undefined);
   }
 
   requestAnimationFrame(() => {


### PR DESCRIPTION
Two frontend render-performance fixes.

## Fix 1 — scope `lucide.createIcons()` calls
Unscoped `lucide.createIcons()` (no args) re-scans the whole document and rebuilds every `[data-lucide]` SVG. Called after rendering a list or per keystroke (autocomplete, ingredient rows, icon picker), it reprocessed all page icons and caused jank.

All ~38 remaining unscoped sites across 15 files now pass `{ el: <container> }` so only the just-rendered subtree is processed — matching the scoped pattern already used elsewhere in the codebase. Each call is scoped to the nearest element confirmed to wrap the rendered icons (rebuilt list/panel/grid/modal/page root). The shell-wide `router.js` `updateNav()` is scoped to `#app` (the app-shell root that holds both nav regions).

## Fix 2 — calendar day-bucketing (`public/pages/calendar.js`)
The month grid renders 42 cells; each called `eventsOnDay()`/`tasksOnDay()`, which each `.filter()` the entire `state.events`/`state.tasks` and built a `new Date` per event per cell — O(cells x events) with repeated date parsing every render.

Now `buildDayIndex()` (called once at the top of `renderView`) builds a `Map<isoDate, [...]>` for events and one for tasks, parsing each item's date once and bucketing multi-day events across their range (clamped to the loaded `[rangeFrom, rangeTo]` window). Per-cell lookups read O(1) from the Map. The helpers fall back to the original filter when no index is active, so behavior is preserved exactly (item ordering, all-day vs timed, and week/day/agenda views which share the same helpers).

## Tests
All pass, none modified:
- `test:calendar` — 29 passed
- `test:frontend-audit` — 57 passed
- `test:dashboard` — 11 passed
- `test:tasks` — 18 passed