### PR TITLE
fix(calendar): correct multi-day end date and recurrence in Google sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Google Calendar sync no longer adds a phantom extra day to all-day multi-day events, and multi-day repeating events now sync without the `Invalid recurrence rule` error. Outbound all-day events now use Google's exclusive end date, and recurrence rules are sent with the required `RRULE:` prefix and a value type that matches the event (date vs. date-time).
+
 ## [0.57.4] - 2026-06-02
 
 ### Changed

--- a/server/services/google-calendar.js
+++ b/server/services/google-calendar.js
@@ -316,6 +316,49 @@ function upsertGoogleEvents(items, calRefId = null, calColor = GOOGLE_COLOR) {
 // Helfer: lokales Event → Google Calendar Event Format
 // --------------------------------------------------------
 
+/**
+ * Adds one day to a YYYY-MM-DD date string.
+ * Google all-day events use an EXCLUSIVE end date (end.date is the day AFTER
+ * the last day), while Oikos stores the inclusive last day. So a 28th–4th
+ * vacation is stored end=...-04 but must be sent to Google as end=...-05.
+ * @param {string} dateStr - YYYY-MM-DD
+ * @returns {string} YYYY-MM-DD, one day later
+ */
+function nextDay(dateStr) {
+  const d = new Date(dateStr + 'T00:00:00Z');
+  d.setUTCDate(d.getUTCDate() + 1);
+  return d.toISOString().slice(0, 10);
+}
+
+/**
+ * Normalises a stored RRULE into a Google-/RFC5545-valid recurrence line.
+ * - Google's recurrence[] entries must carry the `RRULE:` property name.
+ *   Oikos stores locally-created rules without it (e.g. "FREQ=WEEKLY;..."),
+ *   which Google rejects as "Invalid recurrence rule".
+ * - UNTIL must match DTSTART's value type: a date-valued (all-day) DTSTART
+ *   needs UNTIL=YYYYMMDD, a datetime DTSTART needs UNTIL=YYYYMMDDTHHMMSSZ.
+ * @param {string} rule    - stored recurrence rule (with or without RRULE: prefix)
+ * @param {boolean} allDay - whether the event is all-day (date-valued DTSTART)
+ * @returns {string} a single "RRULE:..." line
+ */
+function buildGoogleRecurrence(rule, allDay) {
+  // Drop any existing RRULE: prefix so we can normalise the body uniformly.
+  let body = rule.replace(/^RRULE:/i, '').trim();
+
+  // Reconcile UNTIL with the DTSTART value type Google will see.
+  body = body.replace(/UNTIL=([0-9TZ]+)/i, (_m, val) => {
+    const ymd = val.replace(/[TZ]/g, '').slice(0, 8);
+    if (allDay) {
+      // date-valued DTSTART → date-valued UNTIL
+      return `UNTIL=${ymd}`;
+    }
+    // datetime DTSTART → datetime UNTIL in UTC (trailing Z required)
+    return `UNTIL=${ymd}T000000Z`;
+  });
+
+  return `RRULE:${body}`;
+}
+
 function localEventToGoogle(event) {
   const allDay = !!event.all_day;
   const gEvent = {
@@ -325,18 +368,22 @@ function localEventToGoogle(event) {
   };
 
   if (allDay) {
-    gEvent.start = { date: event.start_datetime.slice(0, 10) };
-    gEvent.end   = { date: event.end_datetime ? event.end_datetime.slice(0, 10) : event.start_datetime.slice(0, 10) };
+    const startDate = event.start_datetime.slice(0, 10);
+    // Inclusive stored end → exclusive Google end (add one day).
+    const endInclusive = event.end_datetime ? event.end_datetime.slice(0, 10) : startDate;
+    gEvent.start = { date: startDate };
+    gEvent.end   = { date: nextDay(endInclusive) };
   } else {
     gEvent.start = { dateTime: event.start_datetime, timeZone: 'Europe/Berlin' };
     gEvent.end   = { dateTime: event.end_datetime   || event.start_datetime, timeZone: 'Europe/Berlin' };
   }
 
   if (event.recurrence_rule) {
-    gEvent.recurrence = [event.recurrence_rule];
+    gEvent.recurrence = [buildGoogleRecurrence(event.recurrence_rule, allDay)];
   }
 
   return gEvent;
 }
 
 export { getAuthUrl, handleCallback, getStatus, disconnect, sync };
+export const __test = { localEventToGoogle, buildGoogleRecurrence, nextDay };

--- a/test/test-calendar.js
+++ b/test/test-calendar.js
@@ -8,6 +8,7 @@
 import { DatabaseSync } from 'node:sqlite';
 import { MIGRATIONS_SQL } from '../server/db-schema-test.js';
 const { __test: calendarHelpers } = await import('../public/pages/calendar.js');
+const { __test: googleHelpers } = await import('../server/services/google-calendar.js');
 
 let passed = 0;
 let failed = 0;
@@ -328,6 +329,68 @@ test('filterTasksForCalendar: in_progress-Tasks werden behalten', () => {
 
 test('filterTasksForCalendar: leeres Array gibt leeres Array zurück', () => {
   assert(ftc([]).length === 0, 'Leeres Array erwartet');
+});
+
+// --------------------------------------------------------
+// Google-Calendar Outbound-Konvertierung (Issue #203)
+// --------------------------------------------------------
+const { localEventToGoogle, buildGoogleRecurrence } = googleHelpers;
+
+test('Google outbound: mehrtägiges Ganztages-Event nutzt exklusives End-Datum', () => {
+  // Urlaub vom 28.03. bis einschließlich 04.04. (inklusiv gespeichert).
+  // Google verlangt ein EXKLUSIVES end.date → der Tag NACH dem letzten Tag.
+  const g = localEventToGoogle({
+    title: 'Urlaub', all_day: 1,
+    start_datetime: '2026-03-28', end_datetime: '2026-04-04',
+  });
+  assert(g.start.date === '2026-03-28', `start.date falsch: ${g.start.date}`);
+  assert(g.end.date === '2026-04-05', `end.date muss exklusiv (+1 Tag) sein, war: ${g.end.date}`);
+  assert(!g.start.dateTime, 'Ganztages-Event darf kein dateTime haben');
+});
+
+test('Google outbound: eintägiges Ganztages-Event endet am Folgetag (exklusiv)', () => {
+  const g = localEventToGoogle({
+    title: 'Ostern', all_day: 1, start_datetime: '2026-04-05', end_datetime: null,
+  });
+  assert(g.start.date === '2026-04-05', `start.date falsch: ${g.start.date}`);
+  assert(g.end.date === '2026-04-06', `end.date muss +1 Tag sein, war: ${g.end.date}`);
+});
+
+test('Google outbound: lokale RRULE erhält RRULE:-Präfix (gültig für Google)', () => {
+  const g = localEventToGoogle({
+    title: 'Müll', all_day: 1, start_datetime: '2026-03-28', end_datetime: '2026-03-30',
+    recurrence_rule: 'FREQ=WEEKLY;BYDAY=MO',
+  });
+  assert(Array.isArray(g.recurrence) && g.recurrence.length === 1, 'recurrence muss ein Array sein');
+  assert(g.recurrence[0] === 'RRULE:FREQ=WEEKLY;BYDAY=MO',
+    `RRULE: muss vorangestellt sein, war: ${g.recurrence[0]}`);
+});
+
+test('Google outbound: vorhandenes RRULE:-Präfix wird nicht verdoppelt', () => {
+  const out = buildGoogleRecurrence('RRULE:FREQ=DAILY', false);
+  assert(out === 'RRULE:FREQ=DAILY', `Präfix verdoppelt: ${out}`);
+});
+
+test('Google outbound: UNTIL eines Ganztages-Events bleibt datumswertig', () => {
+  const out = buildGoogleRecurrence('FREQ=WEEKLY;BYDAY=MO;UNTIL=20260601T000000Z', true);
+  assert(out === 'RRULE:FREQ=WEEKLY;BYDAY=MO;UNTIL=20260601',
+    `UNTIL muss bei Ganztages datumswertig sein, war: ${out}`);
+});
+
+test('Google outbound: UNTIL eines Termins mit Uhrzeit ist UTC (Z)', () => {
+  const out = buildGoogleRecurrence('FREQ=WEEKLY;UNTIL=20260601', false);
+  assert(out === 'RRULE:FREQ=WEEKLY;UNTIL=20260601T000000Z',
+    `UNTIL muss bei Termin mit Uhrzeit ein Z-Suffix haben, war: ${out}`);
+});
+
+test('Google outbound: mehrtägiges wiederholendes Event liefert gültige RRULE + exklusives Ende', () => {
+  const g = localEventToGoogle({
+    title: 'Sprint', all_day: 1, start_datetime: '2026-03-28', end_datetime: '2026-03-30',
+    recurrence_rule: 'FREQ=WEEKLY;UNTIL=20260601',
+  });
+  assert(g.end.date === '2026-03-31', `mehrtägiges Ende muss exklusiv sein, war: ${g.end.date}`);
+  assert(g.recurrence[0] === 'RRULE:FREQ=WEEKLY;UNTIL=20260601',
+    `RRULE ungültig: ${g.recurrence[0]}`);
 });
 
 // --------------------------------------------------------


### PR DESCRIPTION
## Problem (Fixes #203)

Google Calendar sync had two outbound bugs for multi-day events:

1. **Multi-day all-day events synced with an off-by-one end date.** Google all-day events use an **exclusive** `end.date` (the day *after* the last day), while Oikos stores the **inclusive** last day. `localEventToGoogle` passed the stored date straight through, so the span was wrong by a day.

2. **Multi-day repeating events failed with `[Google] Outbound error ...: Invalid recurrence rule.`** Locally-created rules are stored without the `RRULE:` property name (validator requires `^FREQ=`), but Google's `recurrence[]` entries must be full RFC 5545 lines (`RRULE:FREQ=...`). Additionally, `UNTIL` could carry a value type (date vs date-time) that didn't match the `DTSTART` Google derives, which Google also rejects.

## Root cause

- Bug 1: `gEvent.end.date = event.end_datetime.slice(0,10)` sent the inclusive end directly. The Apple/CalDAV sync already does the `+1 day` exclusive conversion (`apple-calendar.js`); Google was missing it.
- Bug 2: `gEvent.recurrence = [event.recurrence_rule]` sent a prefix-less rule, and never reconciled the `UNTIL` value type with the all-day vs timed event.

## Fix

`server/services/google-calendar.js` — `localEventToGoogle`:
- All-day `end.date` now uses `nextDay(inclusiveEnd)` (exclusive), matching the Apple sync convention. Single-day all-day events correctly become start..start+1.
- Recurrence is normalised via `buildGoogleRecurrence`: prepends `RRULE:` idempotently (won't double an existing prefix), and rewrites `UNTIL` to a date value for all-day events or a UTC date-time (`...T000000Z`) for timed events.

## Testing

- Extended `test/test-calendar.js` with 7 cases: exclusive end for multi-day and single-day all-day events, `RRULE:` prefixing, no double-prefix, `UNTIL` value-type normalisation (both directions), and a combined multi-day-repeating case.
- `npm run test:calendar` → 36/36 pass.
- `npm test` → full suite green.
- `node --check` on changed files passes.