### PR TITLE
fix(google-calendar): correct all-day end date and RRULE prefix (#203)

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "test:split-expenses": "node --experimental-sqlite test/test-split-expenses.js",
     "test:oidc": "node --experimental-sqlite test/test-oidc.js",
     "test:family-contacts": "node --experimental-sqlite test/test-family-contacts.js",
+    "test:google-calendar": "node test/test-google-calendar.js",
     "test:installer-schema": "node --test test/test-installer-schema.js",
     "test:installer-env-write": "node --test test/test-installer-env-write.js",
     "test:installer-static": "node --test test/test-installer-static.js",
@@ -42,7 +43,7 @@
     "test:installer-cli-i18n": "node --test test/test-installer-cli-i18n.js",
     "test:installer-prereq": "node --test test/test-installer-prereq.js",
     "test:installer-a11y": "node --test test/test-installer-a11y.js",
-    "test": "node --experimental-sqlite test/test-db.js && node --experimental-sqlite test/test-dashboard.js && node --experimental-sqlite test/test-tasks.js && node --experimental-sqlite test/test-multi-assignment.js && node --experimental-sqlite test/test-shopping.js && npm run test:meals && npm run test:calendar && node --experimental-sqlite test/test-notes-contacts-budget.js && npm run test:ux-utils && npm run test:modal-utils && npm run test:reminders && npm run test:api && npm run test:ics-parser && npm run test:ics-sub && npm run test:setup && npm run test:kitchen-tabs && npm run test:mobile-scroll-layout && npm run test:frontend-audit && npm run test:backup-scheduler && npm run test:caldav && npm run test:carddav && npm run test:split-expenses && npm run test:oidc && npm run test:family-contacts && npm run test:installer-schema && npm run test:installer-env-write && npm run test:installer-static && npm run test:installer-i18n && npm run test:installer-cli-i18n && npm run test:installer-prereq && npm run test:installer-a11y"
+    "test": "node --experimental-sqlite test/test-db.js && node --experimental-sqlite test/test-dashboard.js && node --experimental-sqlite test/test-tasks.js && node --experimental-sqlite test/test-multi-assignment.js && node --experimental-sqlite test/test-shopping.js && npm run test:meals && npm run test:calendar && node --experimental-sqlite test/test-notes-contacts-budget.js && npm run test:ux-utils && npm run test:modal-utils && npm run test:reminders && npm run test:api && npm run test:ics-parser && npm run test:ics-sub && npm run test:setup && npm run test:kitchen-tabs && npm run test:mobile-scroll-layout && npm run test:frontend-audit && npm run test:backup-scheduler && npm run test:caldav && npm run test:carddav && npm run test:split-expenses && npm run test:oidc && npm run test:family-contacts && npm run test:google-calendar && npm run test:installer-schema && npm run test:installer-env-write && npm run test:installer-static && npm run test:installer-i18n && npm run test:installer-cli-i18n && npm run test:installer-prereq && npm run test:installer-a11y"
   },
   "dependencies": {
     "bcrypt": "^6.0.0",

--- a/server/services/google-calendar.js
+++ b/server/services/google-calendar.js
@@ -258,6 +258,24 @@ async function sync() {
   log.info(`Sync completed - ${localEvents.length} local → Google, inbound via syncToken.`);
 }
 
+// Google Calendar uses exclusive end dates for all-day events (RFC 5545).
+// A 2-day event Jan 1–2 is stored as end.date = "2026-01-03" (exclusive).
+// Subtract 1 day to convert to Oikos-style inclusive end date.
+function googleAllDayEndToInclusive(dateStr) {
+  if (!dateStr) return null;
+  const d = new Date(dateStr + 'T00:00:00Z');
+  d.setUTCDate(d.getUTCDate() - 1);
+  return d.toISOString().slice(0, 10);
+}
+
+// Oikos stores inclusive end dates. Add 1 day when sending to Google (exclusive).
+function localAllDayEndToExclusive(dateStr) {
+  if (!dateStr) return null;
+  const d = new Date(dateStr + 'T00:00:00Z');
+  d.setUTCDate(d.getUTCDate() + 1);
+  return d.toISOString().slice(0, 10);
+}
+
 // --------------------------------------------------------
 // Helfer: Google-Event in lokale DB upserten
 // --------------------------------------------------------
@@ -275,7 +293,9 @@ function upsertGoogleEvents(items, calRefId = null, calColor = GOOGLE_COLOR) {
 
     const allDay      = !!(item.start?.date && !item.start?.dateTime);
     const startDt     = allDay ? item.start.date : (item.start?.dateTime || item.start?.date);
-    const endDt       = allDay ? (item.end?.date || null) : (item.end?.dateTime || item.end?.date || null);
+    const endDt       = allDay
+      ? googleAllDayEndToInclusive(item.end?.date)
+      : (item.end?.dateTime || item.end?.date || null);
     const title       = item.summary || '(kein Titel)';
     const description = item.description || null;
     const location    = item.location    || null;
@@ -325,18 +345,24 @@ function localEventToGoogle(event) {
   };
 
   if (allDay) {
-    gEvent.start = { date: event.start_datetime.slice(0, 10) };
-    gEvent.end   = { date: event.end_datetime ? event.end_datetime.slice(0, 10) : event.start_datetime.slice(0, 10) };
+    const startDate = event.start_datetime.slice(0, 10);
+    const endDate   = event.end_datetime ? event.end_datetime.slice(0, 10) : startDate;
+    gEvent.start = { date: startDate };
+    gEvent.end   = { date: localAllDayEndToExclusive(endDate) };
   } else {
     gEvent.start = { dateTime: event.start_datetime, timeZone: 'Europe/Berlin' };
     gEvent.end   = { dateTime: event.end_datetime   || event.start_datetime, timeZone: 'Europe/Berlin' };
   }
 
   if (event.recurrence_rule) {
-    gEvent.recurrence = [event.recurrence_rule];
+    const rule = event.recurrence_rule.startsWith('RRULE:')
+      ? event.recurrence_rule
+      : `RRULE:${event.recurrence_rule}`;
+    gEvent.recurrence = [rule];
   }
 
   return gEvent;
 }
 
 export { getAuthUrl, handleCallback, getStatus, disconnect, sync };
+export const __test = { localEventToGoogle, googleAllDayEndToInclusive, localAllDayEndToExclusive };

--- a/test/test-google-calendar.js
+++ b/test/test-google-calendar.js
@@ -1,0 +1,150 @@
+/**
+ * Modul: Google Calendar Sync – Unit-Tests
+ * Zweck: Validiert die Hilfsfunktionen für die Datumskonvertierung (RFC 5545
+ *        exklusive Enddaten) und das RRULE-Präfix beim Outbound-Sync.
+ * Ausführen: node test/test-google-calendar.js
+ */
+
+const { __test } = await import('../server/services/google-calendar.js');
+const { localEventToGoogle, googleAllDayEndToInclusive, localAllDayEndToExclusive } = __test;
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try { fn(); console.log(`  ✓ ${name}`); passed++; }
+  catch (err) { console.error(`  ✗ ${name}: ${err.message}`); failed++; }
+}
+function assert(cond, msg) { if (!cond) throw new Error(msg || 'Assertion fehlgeschlagen'); }
+function assertEqual(a, b, msg) {
+  if (a !== b) throw new Error(msg || `Expected ${JSON.stringify(b)}, got ${JSON.stringify(a)}`);
+}
+
+console.log('\n[Google Calendar Test] Datumskonvertierung + RRULE-Präfix\n');
+
+// --------------------------------------------------------
+// googleAllDayEndToInclusive – Google exklusiv → Oikos inklusiv
+// --------------------------------------------------------
+test('googleAllDayEndToInclusive: 2-Tage-Event (Jan 1–2)', () => {
+  assertEqual(googleAllDayEndToInclusive('2026-01-03'), '2026-01-02');
+});
+
+test('googleAllDayEndToInclusive: 1-Tage-Event (Jan 1)', () => {
+  assertEqual(googleAllDayEndToInclusive('2026-01-02'), '2026-01-01');
+});
+
+test('googleAllDayEndToInclusive: Monatsgrenze (Feb 28 → Feb 27)', () => {
+  assertEqual(googleAllDayEndToInclusive('2026-03-01'), '2026-02-28');
+});
+
+test('googleAllDayEndToInclusive: null → null', () => {
+  assertEqual(googleAllDayEndToInclusive(null), null);
+});
+
+// --------------------------------------------------------
+// localAllDayEndToExclusive – Oikos inklusiv → Google exklusiv
+// --------------------------------------------------------
+test('localAllDayEndToExclusive: Jan 2 → Jan 3', () => {
+  assertEqual(localAllDayEndToExclusive('2026-01-02'), '2026-01-03');
+});
+
+test('localAllDayEndToExclusive: Jahresgrenze (Dec 31 → Jan 1)', () => {
+  assertEqual(localAllDayEndToExclusive('2026-12-31'), '2027-01-01');
+});
+
+test('localAllDayEndToExclusive: null → null', () => {
+  assertEqual(localAllDayEndToExclusive(null), null);
+});
+
+test('Roundtrip: inklusiv → exklusiv → inklusiv', () => {
+  const inclusive = '2026-06-15';
+  const exclusive = localAllDayEndToExclusive(inclusive);
+  assertEqual(googleAllDayEndToInclusive(exclusive), inclusive);
+});
+
+// --------------------------------------------------------
+// localEventToGoogle – Ganztätige Events
+// --------------------------------------------------------
+test('localEventToGoogle: all-day end date wird um 1 Tag erhöht (exklusiv)', () => {
+  const event = {
+    title: 'Urlaub',
+    all_day: 1,
+    start_datetime: '2026-06-01',
+    end_datetime:   '2026-06-07',
+    recurrence_rule: null,
+  };
+  const g = localEventToGoogle(event);
+  assertEqual(g.start.date, '2026-06-01', 'start.date korrekt');
+  assertEqual(g.end.date,   '2026-06-08', 'end.date muss +1 Tag sein (exklusiv)');
+});
+
+test('localEventToGoogle: all-day single-day (kein end_datetime)', () => {
+  const event = {
+    title: 'Feiertag',
+    all_day: 1,
+    start_datetime: '2026-12-25',
+    end_datetime:   null,
+    recurrence_rule: null,
+  };
+  const g = localEventToGoogle(event);
+  assertEqual(g.start.date, '2026-12-25');
+  assertEqual(g.end.date,   '2026-12-26', 'Eintägiges Event: end = start + 1');
+});
+
+// --------------------------------------------------------
+// localEventToGoogle – RRULE-Präfix
+// --------------------------------------------------------
+test('localEventToGoogle: RRULE-Präfix wird hinzugefügt (ohne Präfix)', () => {
+  const event = {
+    title: 'Wöchentlicher Termin',
+    all_day: 0,
+    start_datetime: '2026-06-01T10:00',
+    end_datetime:   '2026-06-01T11:00',
+    recurrence_rule: 'FREQ=WEEKLY;INTERVAL=2;UNTIL=20260620T235959Z',
+  };
+  const g = localEventToGoogle(event);
+  assert(Array.isArray(g.recurrence), 'recurrence ist Array');
+  assertEqual(g.recurrence[0], 'RRULE:FREQ=WEEKLY;INTERVAL=2;UNTIL=20260620T235959Z');
+});
+
+test('localEventToGoogle: RRULE-Präfix wird nicht doppelt hinzugefügt', () => {
+  const event = {
+    title: 'Import-Event',
+    all_day: 0,
+    start_datetime: '2026-06-01T10:00',
+    end_datetime:   '2026-06-01T11:00',
+    recurrence_rule: 'RRULE:FREQ=WEEKLY;INTERVAL=1',
+  };
+  const g = localEventToGoogle(event);
+  assertEqual(g.recurrence[0], 'RRULE:FREQ=WEEKLY;INTERVAL=1', 'Kein doppeltes RRULE:');
+});
+
+test('localEventToGoogle: kein recurrence_rule → kein recurrence-Feld', () => {
+  const event = {
+    title: 'Einmalig',
+    all_day: 0,
+    start_datetime: '2026-06-01T10:00',
+    end_datetime:   '2026-06-01T11:00',
+    recurrence_rule: null,
+  };
+  const g = localEventToGoogle(event);
+  assert(!g.recurrence, 'recurrence-Feld darf nicht vorhanden sein');
+});
+
+test('localEventToGoogle: biweekly mit UNTIL wird korrekt gesendet', () => {
+  const event = {
+    title: 'Mehrtägig + Wiederholung',
+    all_day: 1,
+    start_datetime: '2026-06-01',
+    end_datetime:   '2026-06-03',
+    recurrence_rule: 'FREQ=WEEKLY;INTERVAL=2;UNTIL=20260831T235959Z',
+  };
+  const g = localEventToGoogle(event);
+  assertEqual(g.start.date,    '2026-06-01');
+  assertEqual(g.end.date,      '2026-06-04', 'Mehrtägiges all-day end exklusiv');
+  assertEqual(g.recurrence[0], 'RRULE:FREQ=WEEKLY;INTERVAL=2;UNTIL=20260831T235959Z');
+});
+
+// --------------------------------------------------------
+console.log(`\n  ${passed} passed, ${failed} failed\n`);
+if (failed > 0) process.exit(1);


### PR DESCRIPTION
## Summary

- **Bug 1 – Extra day on inbound all-day events**: Google Calendar stores exclusive end dates per RFC 5545 (a 2-day event Jan 1–2 has `end.date = "2026-01-03"`). `upsertGoogleEvents` was storing this value as-is, making every imported multi-day event appear one day too long. Fixed by subtracting 1 day via `googleAllDayEndToInclusive()`.
- **Bug 2 – "Invalid recurrence rule" on outbound sync**: `localEventToGoogle` was passing `recurrence_rule` to Google's API without the required `RRULE:` prefix, causing Google to reject all recurring events. Also fixed the outbound all-day end date (must be exclusive for Google) via `localAllDayEndToExclusive()`.
- **14 new unit tests** in `test/test-google-calendar.js` covering both conversion helpers and `localEventToGoogle` (end date, RRULE prefix, roundtrip).

## Test plan

- [ ] Run `npm run test:google-calendar` → 14 passed, 0 failed
- [ ] Run `npm test` → full suite green
- [ ] Manual: import a 2-day all-day event from Google Calendar — end date should now match Google
- [ ] Manual: create a biweekly recurring event in Oikos, trigger sync — no "Invalid recurrence rule" error in logs

Closes #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)