### PR TITLE
fix(google): preserve user-assigned event colors across syncs (#219)

### DIFF
--- a/public/pages/calendar.js
+++ b/public/pages/calendar.js
@@ -956,7 +956,7 @@ function renderMonthDay(date, inMonth) {
   const extra    = evs.length - MAX_SHOW;
 
   const evHtml = shown.map((ev) => {
-    const bg = ev.cal_color || ev.color;
+    const bg = ev.color || ev.cal_color;
     const fg = getContrastColor(bg);
     return `
     <div class="month-day__event"
@@ -1024,7 +1024,7 @@ function renderWeekView(container) {
           <div class="allday-cell">
             ${alldayEvs[i].map((ev) => `
               <div class="allday-event" data-id="${ev.id}"
-                   style="${ev.cal_color || ev.color ? `background-color:${esc(ev.cal_color || ev.color)};` : ''}${getContrastColor(ev.cal_color || ev.color) ? `color:${getContrastColor(ev.cal_color || ev.color)};` : ''}"
+                   style="${ev.color || ev.cal_color ? `background-color:${esc(ev.color || ev.cal_color)};` : ''}${getContrastColor(ev.color || ev.cal_color) ? `color:${getContrastColor(ev.color || ev.cal_color)};` : ''}"
                    title="${esc(ev.title)}${ev.cal_name ? ' · ' + ev.cal_name : ''}">${eventIconHtml(ev.icon, 'event-icon event-icon--compact')}<span>${esc(ev.title)}</span></div>
             `).join('')}
             ${tasksOnDay(d).map(renderTaskChip).join('')}
@@ -1106,7 +1106,7 @@ function renderWeekEvent(ev, layout = null) {
 
   return `
     <div class="week-event" data-id="${ev.id}"
-         style="top:${top}px;height:${height}px;left:${left};width:${width};${ev.cal_color || ev.color ? `background-color:${esc(ev.cal_color || ev.color)};` : ''}${getContrastColor(ev.cal_color || ev.color) ? `color:${getContrastColor(ev.cal_color || ev.color)};` : ''}">
+         style="top:${top}px;height:${height}px;left:${left};width:${width};${ev.color || ev.cal_color ? `background-color:${esc(ev.color || ev.cal_color)};` : ''}${getContrastColor(ev.color || ev.cal_color) ? `color:${getContrastColor(ev.color || ev.cal_color)};` : ''}">
       <div class="week-event__title">${eventIconHtml(ev.icon, 'event-icon event-icon--compact')}<span>${esc(ev.title)}</span>${(ev.recurrence_rule || ev.is_recurring_instance) ? calendarRepeatIconHtml() : ''}</div>
       <div class="week-event__time">${formatTime(ev.start_datetime)}${ev.end_datetime ? '–' + formatTime(ev.end_datetime) : ''}</div>
     </div>
@@ -1208,7 +1208,7 @@ function renderDayView(container) {
         <div class="allday-cell">
           ${allday.map((ev) => `
             <div class="allday-event" data-id="${ev.id}"
-                 style="${ev.cal_color || ev.color ? `background-color:${esc(ev.cal_color || ev.color)};` : ''}${getContrastColor(ev.cal_color || ev.color) ? `color:${getContrastColor(ev.cal_color || ev.color)};` : ''}"
+                 style="${ev.color || ev.cal_color ? `background-color:${esc(ev.color || ev.cal_color)};` : ''}${getContrastColor(ev.color || ev.cal_color) ? `color:${getContrastColor(ev.color || ev.cal_color)};` : ''}"
                  title="${esc(ev.title)}${ev.cal_name ? ' · ' + ev.cal_name : ''}">${eventIconHtml(ev.icon, 'event-icon event-icon--compact')}<span>${esc(ev.title)}</span></div>`).join('')}
           ${tasksOnDay(state.cursor).map(renderTaskChip).join('')}
         </div>
@@ -1319,7 +1319,7 @@ function renderAgendaEvent(ev) {
     : formatTime(ev.start_datetime)
       + (ev.end_datetime ? ` – ${formatTime(ev.end_datetime)} ${t('calendar.timeSuffix')}`.trimEnd() : ` ${t('calendar.timeSuffix')}`.trimEnd());
 
-  const displayColor = ev.cal_color || ev.color;
+  const displayColor = ev.color || ev.cal_color;
   const assignedUsers = ev.assigned_users ?? [];
   return `
     <div class="agenda-event" data-id="${ev.id}">
@@ -1353,7 +1353,7 @@ function showEventPopup(ev, anchor) {
     : formatDateTime(ev.start_datetime)
       + (ev.end_datetime ? ` – ${formatTime(ev.end_datetime)}${t('calendar.timeSuffix') ? ' ' + t('calendar.timeSuffix') : ''}`.trim() : '');
 
-  const displayColor = ev.cal_color || ev.color;
+  const displayColor = ev.color || ev.cal_color;
   popup.insertAdjacentHTML('beforeend', `
     <div class="event-popup__color-bar" style="background-color:${esc(displayColor)};"></div>
     <div class="event-popup__title">${eventIconHtml(ev.icon)}<span>${esc(ev.title)}</span></div>

--- a/public/pages/dashboard.js
+++ b/public/pages/dashboard.js
@@ -452,7 +452,7 @@ function renderUpcomingEvents(events) {
     const timeStr = e.all_day ? t('dashboard.allDay') : `${formatTime(d)}${_suffix ? ' ' + _suffix : ''}`.trim();
     return `
       <div class="event-item" data-route="/calendar" role="button" tabindex="0">
-        <div class="event-item__bar" style="background-color:${esc(e.cal_color || e.color) || 'var(--color-accent)'}"></div>
+        <div class="event-item__bar" style="background-color:${esc(e.color || e.cal_color) || 'var(--color-accent)'}"></div>
         <div class="event-item__content">
           <div class="event-item__title">${esc(e.title)}</div>
           <div class="event-item__time">

--- a/server/services/google-calendar.js
+++ b/server/services/google-calendar.js
@@ -306,12 +306,15 @@ function upsertGoogleEvents(items, calRefId = null, calColor = GOOGLE_COLOR) {
     ).get(item.id, 'google');
 
     if (existing) {
+      // color wird bewusst NICHT aktualisiert: benutzerdefinierte Event-Farben
+      // sollen über Syncs hinweg erhalten bleiben (Issue #219). Die Kalenderfarbe
+      // dient nur als Default beim ersten Import (INSERT).
       db.get().prepare(`
         UPDATE calendar_events
         SET title = ?, description = ?, start_datetime = ?, end_datetime = ?,
-            all_day = ?, location = ?, recurrence_rule = ?, color = ?, calendar_ref_id = ?
+            all_day = ?, location = ?, recurrence_rule = ?, calendar_ref_id = ?
         WHERE id = ?
-      `).run(title, description, startDt, endDt, allDay ? 1 : 0, location, rrule, calColor, calRefId, existing.id);
+      `).run(title, description, startDt, endDt, allDay ? 1 : 0, location, rrule, calRefId, existing.id);
     } else {
       db.get().prepare(`
         INSERT INTO calendar_events
@@ -390,4 +393,4 @@ function localEventToGoogle(event) {
 }
 
 export { getAuthUrl, handleCallback, getStatus, disconnect, sync };
-export const __test = { localEventToGoogle, googleAllDayEndToInclusive, localAllDayEndToExclusive };
+export const __test = { localEventToGoogle, googleAllDayEndToInclusive, localAllDayEndToExclusive, upsertGoogleEvents, upsertExternalCalendar };

--- a/test/test-google-calendar.js
+++ b/test/test-google-calendar.js
@@ -5,8 +5,15 @@
  * Ausführen: node test/test-google-calendar.js
  */
 
+// In-Memory-DB für die DB-gestützten Tests (upsertGoogleEvents).
+// Muss VOR dem Import von google-calendar.js gesetzt werden, da db.js beim
+// Import init() ausführt und sich mit DB_PATH verbindet.
+process.env.DB_PATH = ':memory:';
+
+const db = (await import('../server/db.js')).get();
 const { __test } = await import('../server/services/google-calendar.js');
-const { localEventToGoogle, googleAllDayEndToInclusive, localAllDayEndToExclusive } = __test;
+const { localEventToGoogle, googleAllDayEndToInclusive, localAllDayEndToExclusive,
+        upsertGoogleEvents, upsertExternalCalendar } = __test;
 
 let passed = 0;
 let failed = 0;
@@ -217,6 +224,56 @@ test('localEventToGoogle: getimtes UNTIL ohne Zeitteil wird zu UTC date-time', (
   };
   const g = localEventToGoogle(event);
   assertEqual(g.recurrence[0], 'RRULE:FREQ=WEEKLY;UNTIL=20260831T235959Z');
+});
+
+// --------------------------------------------------------
+// upsertGoogleEvents – Event-Farben über Syncs erhalten (Issue #219)
+// --------------------------------------------------------
+console.log('\n[Google Calendar Test] upsertGoogleEvents – Farberhalt\n');
+
+// Seed-User (created_by = 1 in upsertGoogleEvents)
+db.prepare(`INSERT INTO users (username, display_name, password_hash, role)
+  VALUES ('admin', 'Admin', 'x', 'admin')`).run();
+
+const gEvent = {
+  id: 'evt-color-219',
+  status: 'confirmed',
+  summary: 'Team-Meeting',
+  start: { dateTime: '2026-06-03T10:00:00Z' },
+  end:   { dateTime: '2026-06-03T11:00:00Z' },
+};
+
+test('Erst-Import setzt die Kalenderfarbe als Default', () => {
+  const calRefId = upsertExternalCalendar('google', 'primary', 'Mein Kalender', '#FF0000');
+  upsertGoogleEvents([gEvent], calRefId, '#FF0000');
+  const row = db.prepare(
+    'SELECT color FROM calendar_events WHERE external_calendar_id = ?'
+  ).get(gEvent.id);
+  assertEqual(row.color, '#FF0000');
+});
+
+test('Re-Sync überschreibt benutzerdefinierte Event-Farbe NICHT', () => {
+  // Nutzer ändert die Event-Farbe
+  db.prepare('UPDATE calendar_events SET color = ? WHERE external_calendar_id = ?')
+    .run('#00FF00', gEvent.id);
+  // Erneuter Sync mit unveränderter Kalenderfarbe
+  const calRefId = upsertExternalCalendar('google', 'primary', 'Mein Kalender', '#FF0000');
+  upsertGoogleEvents([gEvent], calRefId, '#FF0000');
+  const row = db.prepare(
+    'SELECT color FROM calendar_events WHERE external_calendar_id = ?'
+  ).get(gEvent.id);
+  assertEqual(row.color, '#00FF00', 'Benutzerfarbe muss über den Sync hinweg erhalten bleiben');
+});
+
+test('Re-Sync aktualisiert weiterhin die übrigen Felder', () => {
+  const updated = { ...gEvent, summary: 'Team-Meeting (verschoben)' };
+  const calRefId = upsertExternalCalendar('google', 'primary', 'Mein Kalender', '#FF0000');
+  upsertGoogleEvents([updated], calRefId, '#FF0000');
+  const row = db.prepare(
+    'SELECT title, color FROM calendar_events WHERE external_calendar_id = ?'
+  ).get(gEvent.id);
+  assertEqual(row.title, 'Team-Meeting (verschoben)');
+  assertEqual(row.color, '#00FF00', 'Farbe bleibt trotz Titeländerung erhalten');
 });
 
 // --------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #219.

- **Backend:** `upsertGoogleEvents()` no longer overwrites `calendar_events.color` on update. User-assigned event colors now survive every sync; the Google calendar color remains the default only on first import (INSERT).
- **Frontend:** Calendar (`public/pages/calendar.js`) and dashboard (`public/pages/dashboard.js`) now prioritize the event color over the calendar color (`ev.color || ev.cal_color`), so user color categories are displayed for synced events.

## Tests

Adds DB-backed regression tests for `upsertGoogleEvents` color handling (verified failing before the fix). Full suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)