### PR TITLE
docs(installer): note in-app Google calendar selection

### DIFF
--- a/tools/installer/install.html
+++ b/tools/installer/install.html
@@ -246,6 +246,7 @@
               <label for="gcal-secret" data-i18n="calendar.googleSecretLabel">Client Secret</label>
               <input type="password" id="gcal-secret">
             </div>
+            <p class="hint" data-i18n="calendar.googleSelectNote">After connecting, you can choose which calendar to sync in the app settings (default: primary calendar).</p>
           </div>
         </div>
         <div class="toggle-card">

--- a/tools/installer/locales/ar.json
+++ b/tools/installer/locales/ar.json
@@ -52,6 +52,7 @@
     "googleLink": "console.cloud.google.com",
     "googleIdLabel": "معرّف العميل",
     "googleSecretLabel": "سرّ العميل",
+    "googleSelectNote": "بعد الاتصال، يمكنك اختيار التقويم الذي تتم مزامنته من إعدادات التطبيق (الافتراضي: التقويم الأساسي).",
     "apple": "Apple iCloud CalDAV",
     "appleHint": "أنشئ كلمة مرور خاصة بالتطبيق على {{link}}.",
     "appleLink": "appleid.apple.com",

--- a/tools/installer/locales/de.json
+++ b/tools/installer/locales/de.json
@@ -52,6 +52,7 @@
     "googleLink": "console.cloud.google.com",
     "googleIdLabel": "Client-ID",
     "googleSecretLabel": "Client-Secret",
+    "googleSelectNote": "Nach der Verbindung kannst du in den App-Einstellungen wählen, welcher Kalender synchronisiert wird (Standard: primärer Kalender).",
     "apple": "Apple iCloud CalDAV",
     "appleHint": "Erstelle ein app-spezifisches Passwort unter {{link}}.",
     "appleLink": "appleid.apple.com",

--- a/tools/installer/locales/el.json
+++ b/tools/installer/locales/el.json
@@ -52,6 +52,7 @@
     "googleLink": "console.cloud.google.com",
     "googleIdLabel": "Αναγνωριστικό πελάτη",
     "googleSecretLabel": "Μυστικό πελάτη",
+    "googleSelectNote": "Μετά τη σύνδεση, μπορείτε να επιλέξετε ποιο ημερολόγιο θα συγχρονίζεται στις ρυθμίσεις της εφαρμογής (προεπιλογή: κύριο ημερολόγιο).",
     "apple": "Apple iCloud CalDAV",
     "appleHint": "Δημιουργήστε έναν κωδικό πρόσβασης ειδικό για την εφαρμογή στο {{link}}.",
     "appleLink": "appleid.apple.com",

--- a/tools/installer/locales/en.json
+++ b/tools/installer/locales/en.json
@@ -52,6 +52,7 @@
     "googleLink": "console.cloud.google.com",
     "googleIdLabel": "Client ID",
     "googleSecretLabel": "Client Secret",
+    "googleSelectNote": "After connecting, you can choose which calendar to sync in the app settings (default: primary calendar).",
     "apple": "Apple iCloud CalDAV",
     "appleHint": "Create an app-specific password at {{link}}.",
     "appleLink": "appleid.apple.com",

--- a/tools/installer/locales/es.json
+++ b/tools/installer/locales/es.json
@@ -52,6 +52,7 @@
     "googleLink": "console.cloud.google.com",
     "googleIdLabel": "ID de cliente",
     "googleSecretLabel": "Secreto de cliente",
+    "googleSelectNote": "Tras conectar, puedes elegir qué calendario sincronizar en los ajustes de la app (predeterminado: calendario principal).",
     "apple": "Apple iCloud CalDAV",
     "appleHint": "Crea una contraseña específica de la aplicación en {{link}}.",
     "appleLink": "appleid.apple.com",

--- a/tools/installer/locales/fr.json
+++ b/tools/installer/locales/fr.json
@@ -52,6 +52,7 @@
     "googleLink": "console.cloud.google.com",
     "googleIdLabel": "ID client",
     "googleSecretLabel": "Secret client",
+    "googleSelectNote": "Une fois connecté, vous pouvez choisir l'agenda à synchroniser dans les paramètres de l'application (par défaut : agenda principal).",
     "apple": "Apple iCloud CalDAV",
     "appleHint": "Créez un mot de passe spécifique à l'application sur {{link}}.",
     "appleLink": "appleid.apple.com",

--- a/tools/installer/locales/hi.json
+++ b/tools/installer/locales/hi.json
@@ -52,6 +52,7 @@
     "googleLink": "console.cloud.google.com",
     "googleIdLabel": "क्लाइंट ID",
     "googleSecretLabel": "क्लाइंट सीक्रेट",
+    "googleSelectNote": "कनेक्ट करने के बाद, आप ऐप सेटिंग्स में चुन सकते हैं कि कौन सा कैलेंडर सिंक हो (डिफ़ॉल्ट: प्राथमिक कैलेंडर)।",
     "apple": "Apple iCloud CalDAV",
     "appleHint": "{{link}} पर ऐप-विशिष्ट पासवर्ड बनाएँ।",
     "appleLink": "appleid.apple.com",

--- a/tools/installer/locales/it.json
+++ b/tools/installer/locales/it.json
@@ -52,6 +52,7 @@
     "googleLink": "console.cloud.google.com",
     "googleIdLabel": "ID client",
     "googleSecretLabel": "Client secret",
+    "googleSelectNote": "Dopo la connessione, puoi scegliere quale calendario sincronizzare nelle impostazioni dell'app (predefinito: calendario principale).",
     "apple": "Apple iCloud CalDAV",
     "appleHint": "Crea una password specifica per l'app su {{link}}.",
     "appleLink": "appleid.apple.com",

--- a/tools/installer/locales/ja.json
+++ b/tools/installer/locales/ja.json
@@ -52,6 +52,7 @@
     "googleLink": "console.cloud.google.com",
     "googleIdLabel": "クライアント ID",
     "googleSecretLabel": "クライアントシークレット",
+    "googleSelectNote": "接続後、どのカレンダーを同期するかをアプリの設定で選択できます（デフォルト: メインカレンダー）。",
     "apple": "Apple iCloud CalDAV",
     "appleHint": "{{link}} で App 用パスワードを作成します。",
     "appleLink": "appleid.apple.com",

--- a/tools/installer/locales/pl.json
+++ b/tools/installer/locales/pl.json
@@ -52,6 +52,7 @@
     "googleLink": "console.cloud.google.com",
     "googleIdLabel": "Identyfikator klienta",
     "googleSecretLabel": "Sekret klienta",
+    "googleSelectNote": "Po połączeniu możesz wybrać w ustawieniach aplikacji, który kalendarz synchronizować (domyślnie: kalendarz główny).",
     "apple": "Apple iCloud CalDAV",
     "appleHint": "Utwórz hasło specyficzne dla aplikacji na {{link}}.",
     "appleLink": "appleid.apple.com",

--- a/tools/installer/locales/pt.json
+++ b/tools/installer/locales/pt.json
@@ -52,6 +52,7 @@
     "googleLink": "console.cloud.google.com",
     "googleIdLabel": "ID do cliente",
     "googleSecretLabel": "Segredo do cliente",
+    "googleSelectNote": "Após conectar, você pode escolher qual calendário sincronizar nas configurações do app (padrão: calendário principal).",
     "apple": "Apple iCloud CalDAV",
     "appleHint": "Crie uma senha específica do app em {{link}}.",
     "appleLink": "appleid.apple.com",

--- a/tools/installer/locales/ru.json
+++ b/tools/installer/locales/ru.json
@@ -52,6 +52,7 @@
     "googleLink": "console.cloud.google.com",
     "googleIdLabel": "Идентификатор клиента",
     "googleSecretLabel": "Секрет клиента",
+    "googleSelectNote": "После подключения вы можете выбрать в настройках приложения, какой календарь синхронизировать (по умолчанию: основной календарь).",
     "apple": "Apple iCloud CalDAV",
     "appleHint": "Создайте пароль для приложения на {{link}}.",
     "appleLink": "appleid.apple.com",

--- a/tools/installer/locales/sv.json
+++ b/tools/installer/locales/sv.json
@@ -52,6 +52,7 @@
     "googleLink": "console.cloud.google.com",
     "googleIdLabel": "Klient-ID",
     "googleSecretLabel": "Klienthemlighet",
+    "googleSelectNote": "Efter anslutning kan du välja vilken kalender som ska synkroniseras i appens inställningar (standard: primär kalender).",
     "apple": "Apple iCloud CalDAV",
     "appleHint": "Skapa ett appspecifikt lösenord på {{link}}.",
     "appleLink": "appleid.apple.com",

--- a/tools/installer/locales/tr.json
+++ b/tools/installer/locales/tr.json
@@ -52,6 +52,7 @@
     "googleLink": "console.cloud.google.com",
     "googleIdLabel": "İstemci kimliği",
     "googleSecretLabel": "İstemci gizli anahtarı",
+    "googleSelectNote": "Bağlandıktan sonra, hangi takvimin senkronize edileceğini uygulama ayarlarından seçebilirsiniz (varsayılan: birincil takvim).",
     "apple": "Apple iCloud CalDAV",
     "appleHint": "{{link}} adresinde uygulamaya özel bir parola oluşturun.",
     "appleLink": "appleid.apple.com",

--- a/tools/installer/locales/uk.json
+++ b/tools/installer/locales/uk.json
@@ -52,6 +52,7 @@
     "googleLink": "console.cloud.google.com",
     "googleIdLabel": "Ідентифікатор клієнта",
     "googleSecretLabel": "Секрет клієнта",
+    "googleSelectNote": "Після підключення ви можете вибрати в налаштуваннях застосунку, який календар синхронізувати (за замовчуванням: основний календар).",
     "apple": "Apple iCloud CalDAV",
     "appleHint": "Створіть пароль для застосунку на {{link}}.",
     "appleLink": "appleid.apple.com",

--- a/tools/installer/locales/zh.json
+++ b/tools/installer/locales/zh.json
@@ -52,6 +52,7 @@
     "googleLink": "console.cloud.google.com",
     "googleIdLabel": "客户端 ID",
     "googleSecretLabel": "客户端密钥",
+    "googleSelectNote": "连接后，您可以在应用设置中选择要同步的日历（默认：主日历）。",
     "apple": "Apple iCloud CalDAV",
     "appleHint": "在 {{link}} 创建 App 专用密码。",
     "appleLink": "appleid.apple.com",


### PR DESCRIPTION
## Was

Ergänzt einen Hinweis im Web-Installer (Google-Kalender-Abschnitt), der erklärt, dass der konkrete zu synchronisierende Kalender nach dem Verbinden in den App-Einstellungen gewählt wird (Standard: primärer Kalender).

## Warum

Das Kalenderauswahl-Feature aus v0.59.0 (#220) ist eine reine Laufzeit-/In-App-Einstellung (gespeichert in `sync_config` als `google_calendar_id`) — es führt **keine** neuen Env-Variablen oder Installationsschritte ein. Der Installer richtet weiterhin nur die OAuth-Credentials ein. Dieser Hinweis schließt die UX-Lücke zwischen Installer und App.

## Änderungen

- `tools/installer/install.html`: Hinweis-Absatz unter dem Client-Secret-Feld
- `tools/installer/locales/*.json`: neuer Key `calendar.googleSelectNote` in allen 16 Locales (de als Referenz)

## Tests

- `test:installer-schema` → 9/9 ✔
- `test-installer-i18n.js` → Key-Parität aller Locales + alle in `install.html` referenzierten Keys vorhanden ✔
- `test-installer-static.js` → ✔

🤖 Generated with [Claude Code](https://claude.com/claude-code)