### PR TITLE
fix(dashboard): show recurring events on the Overview page (#224)

### DIFF
--- a/server/routes/calendar.js
+++ b/server/routes/calendar.js
@@ -15,7 +15,7 @@ import * as caldavSync from '../services/caldav-sync.js';
 import * as caldavReminders from '../services/caldav-reminders-sync.js';
 import { requireAdmin } from '../auth.js';
 import { str, color, datetime, rrule, collectErrors, MAX_TITLE, MAX_TEXT, DATE_RE, DATETIME_RE } from '../middleware/validate.js';
-import { nextOccurrence } from '../services/recurrence.js';
+import { expandRecurringEvents, getUpcomingEvents } from '../services/calendar-events.js';
 
 const log = createLogger('Calendar');
 
@@ -157,88 +157,9 @@ function serializeEvent(event) {
   };
 }
 
-// --------------------------------------------------------
-// RRULE-Expansion: alle Vorkommen eines wiederkehrenden Events
-// innerhalb [from, to] generieren (inklusive beider Grenzen).
-// --------------------------------------------------------
-
-/**
- * @param {object[]} events  Rohe DB-Events (können recurrence_rule haben)
- * @param {string}   from    YYYY-MM-DD
- * @param {string}   to      YYYY-MM-DD
- * @returns {object[]}  Expandiertes, sortiertes Array
- */
-function expandRecurringEvents(events, from, to) {
-  const result = [];
-
-  for (const event of events) {
-    if (!event.recurrence_rule) {
-      result.push(event);
-      continue;
-    }
-
-    // Dauer des Events in ms (für End-Zeit-Berechnung der Instanzen)
-    const startMs    = new Date(event.start_datetime).getTime();
-    const endMs      = event.end_datetime ? new Date(event.end_datetime).getTime() : null;
-    const durationMs = endMs !== null ? endMs - startMs : null;
-    // Duration in days for all-day events (for date-only end calculation)
-    const isAllDay     = !!event.all_day;
-    const durationDays = isAllDay && durationMs !== null ? Math.round(durationMs / 86400000) : 0;
-
-    // Original-Zeit-Teil erhalten (z.B. 'T14:30:00' oder '' bei All-Day)
-    const timeSuffix = event.start_datetime.slice(10);
-
-    let currentDate = event.start_datetime.slice(0, 10); // YYYY-MM-DD
-    let iterations  = 0;
-    const MAX_ITER  = 1000; // Sicherheitsgrenze
-
-    while (currentDate <= to && iterations < MAX_ITER) {
-      iterations++;
-
-      // For multi-day events, check if the instance end reaches into [from, to]
-      let instanceEnd = currentDate;
-      if (isAllDay && durationDays > 0) {
-        const d = new Date(currentDate + 'T00:00:00');
-        d.setDate(d.getDate() + durationDays);
-        instanceEnd = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
-      }
-
-      if (currentDate >= from || instanceEnd >= from) {
-        const newStart = currentDate + timeSuffix;
-        let newEnd = event.end_datetime;
-        if (durationMs !== null) {
-          if (isAllDay) {
-            // Keep date-only format for all-day events
-            const d = new Date(currentDate + 'T00:00:00');
-            d.setDate(d.getDate() + durationDays);
-            newEnd = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
-          } else {
-            const endDate = new Date(new Date(newStart).getTime() + durationMs);
-            if (timeSuffix.includes('Z')) {
-              newEnd = endDate.toISOString().replace('.000Z', 'Z');
-            } else {
-              const p = n => String(n).padStart(2, '0');
-              newEnd = `${endDate.getFullYear()}-${p(endDate.getMonth() + 1)}-${p(endDate.getDate())}T${p(endDate.getHours())}:${p(endDate.getMinutes())}`;
-            }
-          }
-        }
-
-        result.push({
-          ...event,
-          start_datetime:       newStart,
-          end_datetime:         newEnd,
-          is_recurring_instance: currentDate !== event.start_datetime.slice(0, 10) ? 1 : 0,
-        });
-      }
-
-      const next = nextOccurrence(currentDate, event.recurrence_rule);
-      if (!next || next <= currentDate) break;
-      currentDate = next;
-    }
-  }
-
-  return result.sort((a, b) => a.start_datetime.localeCompare(b.start_datetime));
-}
+// RRULE-Expansion (expandRecurringEvents) lebt nun in
+// server/services/calendar-events.js, damit Kalender und Dashboard exakt
+// dieselbe Wiederholungs-Logik nutzen.
 
 // --------------------------------------------------------
 // GET /api/v1/calendar
@@ -317,38 +238,8 @@ router.get('/', (req, res) => {
 // --------------------------------------------------------
 router.get('/upcoming', (req, res) => {
   try {
-    const limit   = Math.min(parseInt(req.query.limit, 10) || 5, 20);
-    const nowDate = new Date().toISOString().slice(0, 10);
-    // Fenster: heute bis 90 Tage voraus (für Wiederholungs-Expansion)
-    const future  = new Date(Date.now() + 90 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
-
-    const rawEvents = db.get().prepare(`
-      SELECT e.*,
-             u_assigned.display_name AS assigned_name,
-             u_assigned.avatar_color AS assigned_color,
-             ec.name  AS cal_name,
-             ec.color AS cal_color,
-             ${ASSIGNED_USERS_SQL}
-      FROM calendar_events e
-      LEFT JOIN users u_assigned ON u_assigned.id = e.assigned_to
-      LEFT JOIN external_calendars ec ON ec.id = e.calendar_ref_id
-      WHERE (
-        (e.recurrence_rule IS NULL AND DATE(e.start_datetime) BETWEEN ? AND ?)
-        OR
-        (e.recurrence_rule IS NOT NULL AND DATE(e.start_datetime) <= ?)
-      )
-      AND (
-        e.external_source <> 'ics'
-        OR e.subscription_id IN (
-          SELECT id FROM ics_subscriptions WHERE shared = 1 OR created_by = ?
-        )
-      )
-      ORDER BY e.start_datetime ASC
-    `).all(nowDate, future, future, getUserId(req));
-
-    const expanded = expandRecurringEvents(rawEvents, nowDate, future)
-      .filter((e) => e.start_datetime >= new Date().toISOString())
-      .slice(0, limit)
+    const limit    = Math.min(parseInt(req.query.limit, 10) || 5, 20);
+    const expanded = getUpcomingEvents(db.get(), { userId: getUserId(req), limit })
       .map(serializeEvent);
 
     res.json({ data: expanded });

--- a/server/routes/dashboard.js
+++ b/server/routes/dashboard.js
@@ -8,6 +8,7 @@ import { createLogger } from '../logger.js';
 import express from 'express';
 import * as db from '../db.js';
 import { hydrateBirthday } from '../services/birthdays.js';
+import { getUpcomingEvents } from '../services/calendar-events.js';
 
 const log = createLogger('Dashboard');
 
@@ -39,22 +40,12 @@ router.get('/', (req, res) => {
   const currentMonth = todayStr.slice(0, 7);
   const deadline48h = new Date(now.getTime() + 48 * 60 * 60 * 1000).toISOString();
 
-  // Anstehende Termine (nächste 5, ab jetzt)
+  // Anstehende Termine (nächste 5, ab jetzt).
+  // Geteilte Logik mit /calendar/upcoming: expandiert wiederkehrende Serien,
+  // sodass auch Termine erscheinen, deren Master-Start in der Vergangenheit liegt.
   try {
-    result.upcomingEvents = d.prepare(`
-      SELECT
-        ce.*,
-        u.display_name  AS assigned_name,
-        u.avatar_color  AS assigned_color,
-        ec.name  AS cal_name,
-        ec.color AS cal_color
-      FROM calendar_events ce
-      LEFT JOIN users u  ON ce.assigned_to = u.id
-      LEFT JOIN external_calendars ec ON ec.id = ce.calendar_ref_id
-      WHERE ce.start_datetime >= ?
-      ORDER BY ce.start_datetime ASC
-      LIMIT 5
-    `).all(now.toISOString());
+    result.upcomingEvents = getUpcomingEvents(d, { userId, limit: 5 })
+      .map(({ assigned_users_json, ...event }) => event);
   } catch (err) {
     log.error('upcomingEvents error:', err.message);
     result.upcomingEvents = [];

--- a/server/services/calendar-events.js
+++ b/server/services/calendar-events.js
@@ -1,0 +1,150 @@
+/**
+ * Modul: Kalender-Events (geteilte Abfrage-Logik)
+ * Zweck: Wiederholungs-Expansion und "anstehende Termine" zentral bereitstellen,
+ *        damit Kalender-Route und Dashboard exakt dieselbe Logik nutzen.
+ * Abhängigkeiten: server/services/recurrence.js
+ */
+
+import { nextOccurrence } from './recurrence.js';
+
+// Zugewiesene Personen eines Events als JSON-Array (Multi-Assignment).
+const ASSIGNED_USERS_SQL = `(
+  SELECT json_group_array(json_object(
+    'id', u.id, 'display_name', u.display_name, 'color', u.avatar_color
+  ))
+  FROM event_assignments ea JOIN users u ON u.id = ea.user_id
+  WHERE ea.event_id = e.id
+) AS assigned_users_json`;
+
+// --------------------------------------------------------
+// RRULE-Expansion: alle Vorkommen eines wiederkehrenden Events
+// innerhalb [from, to] generieren (inklusive beider Grenzen).
+// --------------------------------------------------------
+
+/**
+ * @param {object[]} events  Rohe DB-Events (können recurrence_rule haben)
+ * @param {string}   from    YYYY-MM-DD
+ * @param {string}   to      YYYY-MM-DD
+ * @returns {object[]}  Expandiertes, sortiertes Array
+ */
+export function expandRecurringEvents(events, from, to) {
+  const result = [];
+
+  for (const event of events) {
+    if (!event.recurrence_rule) {
+      result.push(event);
+      continue;
+    }
+
+    // Dauer des Events in ms (für End-Zeit-Berechnung der Instanzen)
+    const startMs    = new Date(event.start_datetime).getTime();
+    const endMs      = event.end_datetime ? new Date(event.end_datetime).getTime() : null;
+    const durationMs = endMs !== null ? endMs - startMs : null;
+    // Duration in days for all-day events (for date-only end calculation)
+    const isAllDay     = !!event.all_day;
+    const durationDays = isAllDay && durationMs !== null ? Math.round(durationMs / 86400000) : 0;
+
+    // Original-Zeit-Teil erhalten (z.B. 'T14:30:00' oder '' bei All-Day)
+    const timeSuffix = event.start_datetime.slice(10);
+
+    let currentDate = event.start_datetime.slice(0, 10); // YYYY-MM-DD
+    let iterations  = 0;
+    const MAX_ITER  = 1000; // Sicherheitsgrenze
+
+    while (currentDate <= to && iterations < MAX_ITER) {
+      iterations++;
+
+      // For multi-day events, check if the instance end reaches into [from, to]
+      let instanceEnd = currentDate;
+      if (isAllDay && durationDays > 0) {
+        const d = new Date(currentDate + 'T00:00:00');
+        d.setDate(d.getDate() + durationDays);
+        instanceEnd = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+      }
+
+      if (currentDate >= from || instanceEnd >= from) {
+        const newStart = currentDate + timeSuffix;
+        let newEnd = event.end_datetime;
+        if (durationMs !== null) {
+          if (isAllDay) {
+            // Keep date-only format for all-day events
+            const d = new Date(currentDate + 'T00:00:00');
+            d.setDate(d.getDate() + durationDays);
+            newEnd = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+          } else {
+            const endDate = new Date(new Date(newStart).getTime() + durationMs);
+            if (timeSuffix.includes('Z')) {
+              newEnd = endDate.toISOString().replace('.000Z', 'Z');
+            } else {
+              const p = n => String(n).padStart(2, '0');
+              newEnd = `${endDate.getFullYear()}-${p(endDate.getMonth() + 1)}-${p(endDate.getDate())}T${p(endDate.getHours())}:${p(endDate.getMinutes())}`;
+            }
+          }
+        }
+
+        result.push({
+          ...event,
+          start_datetime:       newStart,
+          end_datetime:         newEnd,
+          is_recurring_instance: currentDate !== event.start_datetime.slice(0, 10) ? 1 : 0,
+        });
+      }
+
+      const next = nextOccurrence(currentDate, event.recurrence_rule);
+      if (!next || next <= currentDate) break;
+      currentDate = next;
+    }
+  }
+
+  return result.sort((a, b) => a.start_datetime.localeCompare(b.start_datetime));
+}
+
+// --------------------------------------------------------
+// Anstehende Termine ab jetzt (für Dashboard-Widget & Kalender-Upcoming).
+// Berücksichtigt Wiederholungen, indem das Master-Event innerhalb eines
+// Fensters [heute, heute+windowDays] expandiert wird. Dadurch erscheinen
+// auch wiederkehrende Serien, deren Master-Start in der Vergangenheit liegt.
+// --------------------------------------------------------
+
+/**
+ * @param {import('node:sqlite').DatabaseSync} d  Geöffnete DB-Verbindung
+ * @param {object}  opts
+ * @param {number?} opts.userId      Aktueller User (für ICS-Sichtbarkeit)
+ * @param {number}  opts.limit       Maximale Anzahl Termine (default 5)
+ * @param {number}  opts.windowDays  Vorausschau-Fenster in Tagen (default 90)
+ * @returns {object[]}  Rohe, expandierte Event-Zeilen (inkl. assigned_users_json)
+ */
+export function getUpcomingEvents(d, { userId = null, limit = 5, windowDays = 90 } = {}) {
+  const nowIso  = new Date().toISOString();
+  const nowDate = nowIso.slice(0, 10);
+  // Fenster: heute bis +windowDays voraus (für Wiederholungs-Expansion)
+  const future  = new Date(Date.now() + windowDays * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+
+  const rawEvents = d.prepare(`
+    SELECT e.*,
+           u_assigned.display_name AS assigned_name,
+           u_assigned.avatar_color AS assigned_color,
+           ec.name  AS cal_name,
+           ec.color AS cal_color,
+           ${ASSIGNED_USERS_SQL}
+    FROM calendar_events e
+    LEFT JOIN users u_assigned ON u_assigned.id = e.assigned_to
+    LEFT JOIN external_calendars ec ON ec.id = e.calendar_ref_id
+    WHERE (
+      (e.recurrence_rule IS NULL AND DATE(e.start_datetime) BETWEEN ? AND ?)
+      OR
+      (e.recurrence_rule IS NOT NULL AND DATE(e.start_datetime) <= ?)
+    )
+    AND (
+      e.external_source <> 'ics'
+      OR e.subscription_id IN (
+        SELECT id FROM ics_subscriptions WHERE shared = 1 OR created_by = ?
+      )
+    )
+    ORDER BY e.start_datetime ASC
+  `).all(nowDate, future, future, userId);
+
+  return expandRecurringEvents(rawEvents, nowDate, future)
+    .filter((e) => e.start_datetime >= nowIso)
+    .slice(0, limit);
+}

--- a/test/test-dashboard.js
+++ b/test/test-dashboard.js
@@ -8,6 +8,7 @@ import { DatabaseSync } from 'node:sqlite';
 import { register } from 'node:module';
 import { MIGRATIONS_SQL } from '../server/db-schema-test.js';
 import { hydrateBirthday } from '../server/services/birthdays.js';
+import { getUpcomingEvents } from '../server/services/calendar-events.js';
 
 register('./test-browser-loader.mjs', import.meta.url);
 
@@ -278,6 +279,127 @@ test('Budget: Monatswerte für Einnahmen, Ausgaben, Saldo und Top-Ausgabe', () =
   assert(totals.balance === 1350, `Saldo sollte 1350 sein, erhalten ${totals.balance}`);
   assert(totals.entry_count === 3, `Erwartet 3 Einträge, erhalten ${totals.entry_count}`);
   assert(topExpense.category === 'housing', 'Wohnen sollte Top-Ausgabenkategorie sein');
+});
+
+// --------------------------------------------------------
+// Tests: getUpcomingEvents (geteilte Dashboard/Kalender-Logik)
+// Regression für Issue #224: wiederkehrende Termine, deren Master-Start in
+// der Vergangenheit liegt, müssen auf der Übersicht erscheinen.
+// --------------------------------------------------------
+
+// Eigene DB mit vollständigem Kalender-Schema (subscription_id, calendar_ref_id).
+const cdb = new DatabaseSync(':memory:');
+cdb.exec('PRAGMA foreign_keys = ON;');
+cdb.exec(`
+  CREATE TABLE users (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    username TEXT UNIQUE NOT NULL, display_name TEXT NOT NULL,
+    password_hash TEXT NOT NULL, avatar_color TEXT NOT NULL DEFAULT '#007AFF'
+  );
+  CREATE TABLE external_calendars (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL, color TEXT
+  );
+  CREATE TABLE ics_subscriptions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL, shared INTEGER NOT NULL DEFAULT 0,
+    created_by INTEGER REFERENCES users(id) ON DELETE CASCADE
+  );
+  CREATE TABLE calendar_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    title TEXT NOT NULL, description TEXT,
+    start_datetime TEXT NOT NULL, end_datetime TEXT,
+    all_day INTEGER NOT NULL DEFAULT 0, location TEXT,
+    color TEXT NOT NULL DEFAULT '#007AFF', icon TEXT NOT NULL DEFAULT 'calendar',
+    assigned_to INTEGER REFERENCES users(id) ON DELETE SET NULL,
+    created_by INTEGER REFERENCES users(id) ON DELETE CASCADE,
+    external_source TEXT NOT NULL DEFAULT 'local',
+    recurrence_rule TEXT,
+    subscription_id INTEGER REFERENCES ics_subscriptions(id) ON DELETE CASCADE,
+    calendar_ref_id INTEGER REFERENCES external_calendars(id) ON DELETE SET NULL
+  );
+  CREATE TABLE event_assignments (
+    event_id INTEGER NOT NULL REFERENCES calendar_events(id) ON DELETE CASCADE,
+    user_id  INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    PRIMARY KEY (event_id, user_id)
+  );
+`);
+
+const cu1 = cdb.prepare(`INSERT INTO users (username, display_name, password_hash, avatar_color)
+  VALUES ('theodore', 'Theodore', 'x', '#34C759')`).run();
+const cu2 = cdb.prepare(`INSERT INTO users (username, display_name, password_hash, avatar_color)
+  VALUES ('sofia', 'Sofia', 'x', '#AF52DE')`).run();
+const cuTheo = cu1.lastInsertRowid;
+const cuSofia = cu2.lastInsertRowid;
+
+function insertEvent(fields) {
+  const cols = Object.keys(fields);
+  const placeholders = cols.map(() => '?').join(', ');
+  const r = cdb.prepare(`INSERT INTO calendar_events (${cols.join(', ')}) VALUES (${placeholders})`)
+    .run(...cols.map((c) => fields[c]));
+  return r.lastInsertRowid;
+}
+
+const isoIn = (ms) => new Date(Date.now() + ms).toISOString().slice(0, 19);
+const HOUR = 3600000;
+const DAY = 24 * HOUR;
+
+// Wiederkehrender Wochentermin, dessen Master-Start 14 Tage in der Vergangenheit liegt.
+// Die nächste Instanz liegt in 7 Tagen relativ zum Master, also innerhalb des Fensters.
+const recurStart = isoIn(-14 * DAY + 5 * HOUR);
+const recurId = insertEvent({
+  title: "Sofia Field Trip",
+  start_datetime: recurStart,
+  recurrence_rule: 'FREQ=WEEKLY;INTERVAL=1',
+  created_by: cuSofia,
+  assigned_to: cuSofia,
+});
+
+// Nicht-wiederkehrender Termin in der Vergangenheit -> darf NICHT erscheinen.
+insertEvent({ title: 'Past one-off', start_datetime: isoIn(-2 * DAY), created_by: cuTheo });
+
+// Nicht-wiederkehrender Termin in der Zukunft -> erscheint.
+insertEvent({ title: 'Theodore Soccer Game', start_datetime: isoIn(3 * DAY), created_by: cuTheo });
+
+test('getUpcomingEvents: wiederkehrender Termin mit Vergangenheits-Start erscheint (Issue #224)', () => {
+  const events = getUpcomingEvents(cdb, { userId: cuTheo, limit: 10 });
+  const sofia = events.find((e) => e.title === 'Sofia Field Trip');
+  assert(sofia, 'Wiederkehrender "Sofia Field Trip" muss in den anstehenden Terminen erscheinen');
+  assert(sofia.start_datetime >= new Date().toISOString(), 'Die expandierte Instanz liegt in der Zukunft');
+  assert(sofia.id === recurId, 'Behält die Original-Event-ID der Serie');
+});
+
+test('getUpcomingEvents: vergangene Einzeltermine erscheinen nicht', () => {
+  const events = getUpcomingEvents(cdb, { userId: cuTheo, limit: 10 });
+  assert(!events.find((e) => e.title === 'Past one-off'), 'Vergangener Einzeltermin darf nicht erscheinen');
+});
+
+test('getUpcomingEvents: zukünftige Termine sortiert und auf limit begrenzt', () => {
+  const events = getUpcomingEvents(cdb, { userId: cuTheo, limit: 10 });
+  assert(events.find((e) => e.title === 'Theodore Soccer Game'), 'Zukünftiger Einzeltermin erscheint');
+  for (let i = 1; i < events.length; i++) {
+    assert(events[i - 1].start_datetime <= events[i].start_datetime, 'Aufsteigend nach Startzeit sortiert');
+  }
+  const limited = getUpcomingEvents(cdb, { userId: cuTheo, limit: 1 });
+  assert(limited.length === 1, `limit=1 liefert genau 1 Event, erhalten ${limited.length}`);
+});
+
+test('getUpcomingEvents: private ICS-Termine fremder User werden ausgeblendet', () => {
+  const sub = cdb.prepare(`INSERT INTO ics_subscriptions (name, shared, created_by) VALUES ('Privat', 0, ?)`)
+    .run(cuSofia).lastInsertRowid;
+  insertEvent({
+    title: 'Sofias privater ICS-Termin',
+    start_datetime: isoIn(2 * DAY),
+    external_source: 'ics',
+    subscription_id: sub,
+    created_by: cuSofia,
+  });
+  const events = getUpcomingEvents(cdb, { userId: cuTheo, limit: 20 });
+  assert(!events.find((e) => e.title === 'Sofias privater ICS-Termin'),
+    'Privates ICS-Abo eines anderen Users darf nicht erscheinen');
+  const ownerEvents = getUpcomingEvents(cdb, { userId: cuSofia, limit: 20 });
+  assert(ownerEvents.find((e) => e.title === 'Sofias privater ICS-Termin'),
+    'Eigentümer sieht seinen privaten ICS-Termin');
 });
 
 // --------------------------------------------------------


### PR DESCRIPTION
## Problem

Closes #224. On the Overview (dashboard) page, calendar items for some family members did not show up, while the same events appeared correctly on the Calendar page.

## Root cause

`server/routes/dashboard.js` used its own simplified upcoming-events query:

```sql
WHERE ce.start_datetime >= now
ORDER BY ce.start_datetime ASC
LIMIT 5
```

This filters on the **master** `start_datetime` and never expands recurrence rules. A weekly/recurring series whose master event started in the past has `start_datetime < now`, so it was silently excluded from the Overview — even though it has upcoming occurrences. The Calendar page avoided this because `/calendar/upcoming` expands recurring events. The result looked member-specific: members whose events were recurring appeared to be missing.

## Fix

Extracted the shared, recurrence-aware logic into `server/services/calendar-events.js`:

- `expandRecurringEvents()` (moved verbatim from the calendar route)
- `getUpcomingEvents()` — window-based query (today … +90d) + recurrence expansion + ICS visibility filtering

Both the dashboard route and `/calendar/upcoming` now call the same code path, eliminating the divergence.

## Tests

Added regression tests in `test/test-dashboard.js` for `getUpcomingEvents`:
- recurring series with a past master start now appears
- past one-off events stay excluded
- ordering + limit
- private ICS events of other users stay hidden

Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)