### PR TITLE
fix(calendar): show multi-day events as a continuous span (#225)

### DIFF
--- a/public/locales/ar.json
+++ b/public/locales/ar.json
@@ -408,6 +408,8 @@
     "dayLongThursday": "الخميس",
     "dayLongFriday": "الجمعة",
     "dayLongSaturday": "السبت",
+    "spanFrom": "من {{time}}",
+    "spanUntil": "حتى {{time}}",
     "timeSuffix": "",
     "ics": {
       "reset": "إعادة التعيين للأصل",

--- a/public/locales/de.json
+++ b/public/locales/de.json
@@ -424,6 +424,8 @@
     "dayLongThursday": "Donnerstag",
     "dayLongFriday": "Freitag",
     "dayLongSaturday": "Samstag",
+    "spanFrom": "ab {{time}}",
+    "spanUntil": "bis {{time}}",
     "timeSuffix": "Uhr",
     "ics": {
       "reset": "Auf Original zurücksetzen",

--- a/public/locales/el.json
+++ b/public/locales/el.json
@@ -408,6 +408,8 @@
     "dayLongThursday": "Πέμπτη",
     "dayLongFriday": "Παρασκευή",
     "dayLongSaturday": "Σάββατο",
+    "spanFrom": "από {{time}}",
+    "spanUntil": "έως {{time}}",
     "timeSuffix": "",
     "ics": {
       "reset": "Επαναφορά στο αρχικό",

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -408,6 +408,8 @@
     "dayLongThursday": "Thursday",
     "dayLongFriday": "Friday",
     "dayLongSaturday": "Saturday",
+    "spanFrom": "from {{time}}",
+    "spanUntil": "until {{time}}",
     "timeSuffix": "",
     "ics": {
       "reset": "Reset to original",

--- a/public/locales/es.json
+++ b/public/locales/es.json
@@ -408,6 +408,8 @@
     "dayLongThursday": "Jueves",
     "dayLongFriday": "Viernes",
     "dayLongSaturday": "Sábado",
+    "spanFrom": "desde las {{time}}",
+    "spanUntil": "hasta las {{time}}",
     "timeSuffix": "",
     "ics": {
       "reset": "Restaurar original",

--- a/public/locales/fr.json
+++ b/public/locales/fr.json
@@ -408,6 +408,8 @@
     "dayLongThursday": "Jeudi",
     "dayLongFriday": "Vendredi",
     "dayLongSaturday": "Samedi",
+    "spanFrom": "à partir de {{time}}",
+    "spanUntil": "jusqu'à {{time}}",
     "timeSuffix": "",
     "ics": {
       "reset": "Réinitialiser",

--- a/public/locales/hi.json
+++ b/public/locales/hi.json
@@ -408,6 +408,8 @@
     "dayLongThursday": "गुरुवार",
     "dayLongFriday": "शुक्रवार",
     "dayLongSaturday": "शनिवार",
+    "spanFrom": "{{time}} से",
+    "spanUntil": "{{time}} तक",
     "timeSuffix": "",
     "ics": {
       "reset": "मूल पर वापस जाएं",

--- a/public/locales/it.json
+++ b/public/locales/it.json
@@ -408,6 +408,8 @@
     "dayLongThursday": "Giovedì",
     "dayLongFriday": "Venerdì",
     "dayLongSaturday": "Sabato",
+    "spanFrom": "dalle {{time}}",
+    "spanUntil": "fino alle {{time}}",
     "timeSuffix": "",
     "ics": {
       "reset": "Ripristina originale",

--- a/public/locales/ja.json
+++ b/public/locales/ja.json
@@ -408,6 +408,8 @@
     "dayLongThursday": "木曜日",
     "dayLongFriday": "金曜日",
     "dayLongSaturday": "土曜日",
+    "spanFrom": "{{time}}から",
+    "spanUntil": "{{time}}まで",
     "timeSuffix": "",
     "ics": {
       "reset": "元に戻す",

--- a/public/locales/pl.json
+++ b/public/locales/pl.json
@@ -424,6 +424,8 @@
     "dayLongThursday": "Czwartek",
     "dayLongFriday": "Piątek",
     "dayLongSaturday": "Sobota",
+    "spanFrom": "od {{time}}",
+    "spanUntil": "do {{time}}",
     "timeSuffix": "",
     "ics": {
       "reset": "Przywróć oryginał",

--- a/public/locales/pt.json
+++ b/public/locales/pt.json
@@ -408,6 +408,8 @@
     "dayLongThursday": "Quinta-feira",
     "dayLongFriday": "Sexta-feira",
     "dayLongSaturday": "Sábado",
+    "spanFrom": "a partir das {{time}}",
+    "spanUntil": "até às {{time}}",
     "timeSuffix": "",
     "ics": {
       "reset": "Restaurar original",

--- a/public/locales/ru.json
+++ b/public/locales/ru.json
@@ -408,6 +408,8 @@
     "dayLongThursday": "Четверг",
     "dayLongFriday": "Пятница",
     "dayLongSaturday": "Суббота",
+    "spanFrom": "с {{time}}",
+    "spanUntil": "до {{time}}",
     "timeSuffix": "",
     "ics": {
       "reset": "Сбросить к исходному",

--- a/public/locales/sv.json
+++ b/public/locales/sv.json
@@ -408,6 +408,8 @@
     "dayLongThursday": "Torsdag",
     "dayLongFriday": "Fredag",
     "dayLongSaturday": "Lördag",
+    "spanFrom": "från {{time}}",
+    "spanUntil": "till {{time}}",
     "timeSuffix": "",
     "ics": {
       "reset": "Återställ till original",

--- a/public/locales/tr.json
+++ b/public/locales/tr.json
@@ -408,6 +408,8 @@
     "dayLongThursday": "Perşembe",
     "dayLongFriday": "Cuma",
     "dayLongSaturday": "Cumartesi",
+    "spanFrom": "{{time}}'den itibaren",
+    "spanUntil": "{{time}}'a kadar",
     "timeSuffix": "",
     "ics": {
       "reset": "Orijinale sıfırla",

--- a/public/locales/uk.json
+++ b/public/locales/uk.json
@@ -408,6 +408,8 @@
     "dayLongThursday": "Четвер",
     "dayLongFriday": "П'ятниця",
     "dayLongSaturday": "Субота",
+    "spanFrom": "з {{time}}",
+    "spanUntil": "до {{time}}",
     "timeSuffix": "",
     "ics": {
       "reset": "Скинути до оригіналу",

--- a/public/locales/zh.json
+++ b/public/locales/zh.json
@@ -408,6 +408,8 @@
     "dayLongThursday": "星期四",
     "dayLongFriday": "星期五",
     "dayLongSaturday": "星期六",
+    "spanFrom": "从 {{time}} 起",
+    "spanUntil": "至 {{time}}",
     "timeSuffix": "",
     "ics": {
       "reset": "重置为原始",

--- a/public/pages/calendar.js
+++ b/public/pages/calendar.js
@@ -635,6 +635,38 @@ function eventsOnDay(dateStr) {
   });
 }
 
+/** True, wenn Start- und Enddatum auf verschiedene Kalendertage fallen. */
+function isMultiDayEvent(ev) {
+  if (!ev || !ev.start_datetime || !ev.end_datetime) return false;
+  return localDate(ev.start_datetime) !== localDate(ev.end_datetime);
+}
+
+/**
+ * Events, die in der Ganztags-Zeile statt im Zeitraster gezeigt werden:
+ * echte Ganztags-Events, datums-only Events und mehrtägige Zeit-Events.
+ * Mehrtägige Events erscheinen dadurch als durchgehender Balken über alle Tage,
+ * statt auf jedem Tag fälschlich als identischer Zeitblock (#225).
+ */
+function isAllDayLike(ev) {
+  return !!ev.all_day || !ev.start_datetime.includes('T') || isMultiDayEvent(ev);
+}
+
+/**
+ * Einordnung eines Events für einen bestimmten Tag in der Agenda:
+ *   'all-day' | 'single' | 'start' | 'middle' | 'end'.
+ * Mehrtägige Events liefern je nach Tag start/middle/end, damit die Uhrzeit den
+ * durchgehenden Zeitraum widerspiegelt statt auf jedem Tag start–end (#225).
+ */
+function agendaSegmentKind(ev, dayStr) {
+  if (ev.all_day || !ev.start_datetime.includes('T')) return 'all-day';
+  if (!isMultiDayEvent(ev)) return 'single';
+  const startDay = localDate(ev.start_datetime);
+  const endDay   = localDate(ev.end_datetime);
+  if (dayStr === startDay) return 'start';
+  if (dayStr === endDay)   return 'end';
+  return 'middle';
+}
+
 /** Filtert Tasks: nur open/in_progress mit due_date werden angezeigt. */
 function filterTasksForCalendar(tasks) {
   return tasks.filter(
@@ -996,10 +1028,10 @@ function renderWeekView(container) {
   const colCount = days.length;
 
   const alldayEvs = days.map((d) =>
-    eventsOnDay(d).filter((e) => e.all_day || !e.start_datetime.includes('T'))
+    eventsOnDay(d).filter(isAllDayLike)
   );
   const timedEvs = days.map((d) =>
-    eventsOnDay(d).filter((e) => !e.all_day && e.start_datetime.includes('T'))
+    eventsOnDay(d).filter((e) => !isAllDayLike(e))
   );
   const layouts = timedEvs.map((events) => layoutOverlaps(events));
 
@@ -1192,8 +1224,8 @@ function layoutOverlaps(events) {
 function renderDayView(container) {
   const dt      = new Date(state.cursor + 'T00:00:00');
   const dayEvs  = eventsOnDay(state.cursor);
-  const allday  = dayEvs.filter((e) => e.all_day || !e.start_datetime.includes('T'));
-  const timed   = dayEvs.filter((e) => !e.all_day && e.start_datetime.includes('T'));
+  const allday  = dayEvs.filter(isAllDayLike);
+  const timed   = dayEvs.filter((e) => !isAllDayLike(e));
   const layout = layoutOverlaps(timed);
 
   container.replaceChildren();
@@ -1287,7 +1319,7 @@ function renderAgendaView(container) {
               <span class="agenda-day__date">${formatDate(date)}</span>
               <span class="agenda-day__weekday">${DAY_NAMES_LONG()[new Date(date + 'T00:00:00').getDay()]}</span>
             </div>
-            ${events.map((ev) => renderAgendaEvent(ev)).join('')}
+            ${events.map((ev) => renderAgendaEvent(ev, date)).join('')}
             ${tasks.length ? `<div class="agenda-tasks">${tasks.map(renderTaskChip).join('')}</div>` : ''}
           </div>
         `).join('')
@@ -1311,13 +1343,26 @@ function renderAgendaView(container) {
   });
 }
 
-export const __test = { normalizeCalendarView, defaultCalendarViewFromState, filterTasksForCalendar, tasksOnDay };
+export const __test = { normalizeCalendarView, defaultCalendarViewFromState, filterTasksForCalendar, tasksOnDay, isMultiDayEvent, isAllDayLike, agendaSegmentKind };
 
-function renderAgendaEvent(ev) {
-  const timeStr = ev.all_day
-    ? t('calendar.allDay')
-    : formatTime(ev.start_datetime)
-      + (ev.end_datetime ? ` – ${formatTime(ev.end_datetime)} ${t('calendar.timeSuffix')}`.trimEnd() : ` ${t('calendar.timeSuffix')}`.trimEnd());
+function renderAgendaEvent(ev, dayStr) {
+  const kind = agendaSegmentKind(ev, dayStr ?? localDate(ev.start_datetime));
+  let timeStr;
+  switch (kind) {
+    case 'all-day':
+    case 'middle':
+      timeStr = t('calendar.allDay');
+      break;
+    case 'start':
+      timeStr = t('calendar.spanFrom', { time: formatTime(ev.start_datetime) });
+      break;
+    case 'end':
+      timeStr = t('calendar.spanUntil', { time: formatTime(ev.end_datetime) });
+      break;
+    default: // single
+      timeStr = formatTime(ev.start_datetime)
+        + (ev.end_datetime ? ` – ${formatTime(ev.end_datetime)} ${t('calendar.timeSuffix')}`.trimEnd() : ` ${t('calendar.timeSuffix')}`.trimEnd());
+  }
 
   const displayColor = ev.color || ev.cal_color;
   const assignedUsers = ev.assigned_users ?? [];

--- a/test/test-calendar.js
+++ b/test/test-calendar.js
@@ -331,6 +331,58 @@ test('filterTasksForCalendar: leeres Array gibt leeres Array zurück', () => {
 });
 
 // --------------------------------------------------------
+// Mehrtägige Events (#225)
+// --------------------------------------------------------
+const { isMultiDayEvent, isAllDayLike, agendaSegmentKind } = calendarHelpers;
+
+test('isMultiDayEvent: gleicher Tag ist nicht mehrtägig', () => {
+  assert(isMultiDayEvent({ start_datetime: '2026-06-14T03:00', end_datetime: '2026-06-14T08:05' }) === false,
+    'Start/Ende am selben Tag → false');
+});
+
+test('isMultiDayEvent: verschiedene Tage sind mehrtägig', () => {
+  assert(isMultiDayEvent({ start_datetime: '2026-06-14T03:00', end_datetime: '2026-06-19T08:05' }) === true,
+    'Start 14., Ende 19. → true');
+});
+
+test('isMultiDayEvent: ohne Enddatum nicht mehrtägig', () => {
+  assert(isMultiDayEvent({ start_datetime: '2026-06-14T03:00', end_datetime: null }) === false,
+    'kein Enddatum → false');
+});
+
+test('isAllDayLike: mehrtägiges Zeit-Event gehört in die Ganztags-Zeile', () => {
+  assert(isAllDayLike({ start_datetime: '2026-06-14T03:00', end_datetime: '2026-06-19T08:05', all_day: 0 }) === true,
+    'Mehrtägiges Event → Ganztags-Zeile');
+});
+
+test('isAllDayLike: eintägiges Zeit-Event bleibt im Zeitraster', () => {
+  assert(isAllDayLike({ start_datetime: '2026-06-14T03:00', end_datetime: '2026-06-14T08:05', all_day: 0 }) === false,
+    'Eintägiges Zeit-Event → Zeitraster');
+});
+
+test('isAllDayLike: echtes Ganztags-Event gehört in die Ganztags-Zeile', () => {
+  assert(isAllDayLike({ start_datetime: '2026-06-14', end_datetime: '2026-06-14', all_day: 1 }) === true,
+    'all_day=1 → Ganztags-Zeile');
+});
+
+test('agendaSegmentKind: mehrtägiges Event liefert start/middle/end pro Tag', () => {
+  const ev = { start_datetime: '2026-06-14T03:00', end_datetime: '2026-06-19T08:05', all_day: 0 };
+  assert(agendaSegmentKind(ev, '2026-06-14') === 'start',  'Starttag → start');
+  assert(agendaSegmentKind(ev, '2026-06-16') === 'middle', 'Zwischentag → middle');
+  assert(agendaSegmentKind(ev, '2026-06-19') === 'end',    'Endtag → end');
+});
+
+test('agendaSegmentKind: eintägiges Zeit-Event ist single', () => {
+  const ev = { start_datetime: '2026-06-14T03:00', end_datetime: '2026-06-14T08:05', all_day: 0 };
+  assert(agendaSegmentKind(ev, '2026-06-14') === 'single', 'Eintägig → single');
+});
+
+test('agendaSegmentKind: Ganztags-Event ist all-day', () => {
+  const ev = { start_datetime: '2026-06-14', end_datetime: '2026-06-14', all_day: 1 };
+  assert(agendaSegmentKind(ev, '2026-06-14') === 'all-day', 'Ganztägig → all-day');
+});
+
+// --------------------------------------------------------
 // Ergebnis
 // --------------------------------------------------------
 console.log(`\n[Calendar-Test] Ergebnis: ${passed} bestanden, ${failed} fehlgeschlagen\n`);


### PR DESCRIPTION
## Problem

Closes #225. A multi-day timed event (e.g. 14th 03:00 → 19th 08:05) was bucketed into every day of its range, and every renderer used the raw `start_datetime`/`end_datetime` clock times regardless of the day being drawn. The result: an identical `03:00–08:05` block on **each** day instead of one event spanning the whole window.

## Fix

- New pure helpers in `public/pages/calendar.js`: `isMultiDayEvent`, `isAllDayLike`, `agendaSegmentKind`.
- **Week/Day view:** multi-day events are placed in the all-day row, so they read as a continuous bar across the days instead of a repeated timed block (this also avoids a multi-day block hijacking the overlap layout of every other event).
- **Agenda view:** per-day segment labels — `from {time}` on the start day, `all day` on middle days, `until {time}` on the end day.
- New i18n keys `calendar.spanFrom` / `calendar.spanUntil` added to all 16 locales.

## Tests

Added 9 unit tests covering the new helpers (`npm run test:calendar`). Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)