### PR TITLE
fix(dashboard): show today's events throughout the day

### DIFF
--- a/server/routes/dashboard.js
+++ b/server/routes/dashboard.js
@@ -44,7 +44,7 @@ router.get('/', (req, res) => {
   // Geteilte Logik mit /calendar/upcoming: expandiert wiederkehrende Serien,
   // sodass auch Termine erscheinen, deren Master-Start in der Vergangenheit liegt.
   try {
-    result.upcomingEvents = getUpcomingEvents(d, { userId, limit: 5 })
+    result.upcomingEvents = getUpcomingEvents(d, { userId, limit: 5, fromToday: true })
       .map(({ assigned_users_json, ...event }) => event);
   } catch (err) {
     log.error('upcomingEvents error:', err.message);

--- a/server/services/calendar-events.js
+++ b/server/services/calendar-events.js
@@ -112,11 +112,14 @@ export function expandRecurringEvents(events, from, to) {
  * @param {number?} opts.userId      Aktueller User (für ICS-Sichtbarkeit)
  * @param {number}  opts.limit       Maximale Anzahl Termine (default 5)
  * @param {number}  opts.windowDays  Vorausschau-Fenster in Tagen (default 90)
+ * @param {boolean} opts.fromToday   true = ab Tagesbeginn (Dashboard); false = ab jetzt (default)
  * @returns {object[]}  Rohe, expandierte Event-Zeilen (inkl. assigned_users_json)
  */
-export function getUpcomingEvents(d, { userId = null, limit = 5, windowDays = 90 } = {}) {
+export function getUpcomingEvents(d, { userId = null, limit = 5, windowDays = 90, fromToday = false } = {}) {
   const nowIso  = new Date().toISOString();
   const nowDate = nowIso.slice(0, 10);
+  // fromToday: ganztägige Sichtbarkeit heutiger Termine (Dashboard-Widget)
+  const filterFrom = fromToday ? `${nowDate}T00:00:00` : nowIso;
   // Fenster: heute bis +windowDays voraus (für Wiederholungs-Expansion)
   const future  = new Date(Date.now() + windowDays * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
 
@@ -145,6 +148,6 @@ export function getUpcomingEvents(d, { userId = null, limit = 5, windowDays = 90
   `).all(nowDate, future, future, userId);
 
   return expandRecurringEvents(rawEvents, nowDate, future)
-    .filter((e) => e.start_datetime >= nowIso)
+    .filter((e) => e.start_datetime >= filterFrom)
     .slice(0, limit);
 }

--- a/test/test-dashboard.js
+++ b/test/test-dashboard.js
@@ -358,6 +358,9 @@ const recurId = insertEvent({
 // Nicht-wiederkehrender Termin in der Vergangenheit -> darf NICHT erscheinen.
 insertEvent({ title: 'Past one-off', start_datetime: isoIn(-2 * DAY), created_by: cuTheo });
 
+// Termin von heute Morgen (Vergangenheit, aber noch heute) -> bei fromToday erscheinen.
+insertEvent({ title: 'Morning Meeting Today', start_datetime: isoIn(-3 * HOUR), created_by: cuTheo });
+
 // Nicht-wiederkehrender Termin in der Zukunft -> erscheint.
 insertEvent({ title: 'Theodore Soccer Game', start_datetime: isoIn(3 * DAY), created_by: cuTheo });
 
@@ -372,6 +375,15 @@ test('getUpcomingEvents: wiederkehrender Termin mit Vergangenheits-Start erschei
 test('getUpcomingEvents: vergangene Einzeltermine erscheinen nicht', () => {
   const events = getUpcomingEvents(cdb, { userId: cuTheo, limit: 10 });
   assert(!events.find((e) => e.title === 'Past one-off'), 'Vergangener Einzeltermin darf nicht erscheinen');
+  assert(!events.find((e) => e.title === 'Morning Meeting Today'), 'Vergangener Heute-Termin ohne fromToday nicht erscheinen');
+});
+
+test('getUpcomingEvents: fromToday=true zeigt heutige vergangene Termine (Issue #230)', () => {
+  const events = getUpcomingEvents(cdb, { userId: cuTheo, limit: 10, fromToday: true });
+  assert(events.find((e) => e.title === 'Morning Meeting Today'),
+    'Heute-Morgen-Termin muss mit fromToday=true erscheinen');
+  assert(!events.find((e) => e.title === 'Past one-off'),
+    'Termin von gestern darf auch mit fromToday nicht erscheinen');
 });
 
 test('getUpcomingEvents: zukünftige Termine sortiert und auf limit begrenzt', () => {


### PR DESCRIPTION
## Summary

- Dashboard upcoming-events widget filtered by the current UTC timestamp, so calendar entries from earlier today disappeared from the overview after their scheduled time passed
- Added `fromToday` option to `getUpcomingEvents` in `server/services/calendar-events.js`; dashboard now passes `fromToday: true`, filtering from midnight of the current day
- `/calendar/upcoming` API endpoint retains the existing "from now" semantics
- Regression test added for Issue #230

Fixes #230

## Test plan

- [ ] Run `npm run test:dashboard` — all 16 tests pass including new `fromToday` regression test
- [ ] Start the app (`npm run dev`), create calendar events for today at past times (e.g. 9am, 10am), verify they remain visible on the dashboard overview after noon
- [ ] Verify future events and events from other days still appear correctly
- [ ] Verify `/api/v1/calendar/upcoming` still returns only events from now onward (unchanged behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)