### PR TITLE
docs: update language count to 17 and add nl to locale references

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Each module is independent. Use what fits, skip what doesn't.
 - **Privacy First** — fully self-hosted, SQLCipher AES-256 encrypted database, zero telemetry
 - **SSO / OpenID Connect** — optional single sign-on via any OIDC provider (Authentik, Keycloak, Google, Microsoft Entra). Configure with four env vars; Authorization Code + PKCE flow.
 - **Zero Build Step** — pure ES modules, no bundler, no transpiler, no framework
-- **Multilingual** — 16 languages with automatic locale detection (de, en, es, fr, it, sv, el, ru, tr, zh, ja, ar, hi, pt, uk, pl)
+- **Multilingual** — 17 languages with automatic locale detection (de, en, es, fr, it, sv, el, ru, tr, zh, ja, ar, hi, pt, uk, pl, nl)
 
 ---
 
@@ -78,7 +78,7 @@ git clone https://github.com/ulsklyc/oikos.git && cd oikos
 node tools/installer/install-server.js
 ```
 
-Open **http://localhost:8090** in your browser. The localized wizard (16 languages) detects your container engine (Docker or Podman), configures your `.env` — including optional reverse proxy/HTTPS, SSO (OIDC), and automatic backups — starts the container, and creates your admin account. Requires Node.js 18+ on the host.
+Open **http://localhost:8090** in your browser. The localized wizard (17 languages) detects your container engine (Docker or Podman), configures your `.env` — including optional reverse proxy/HTTPS, SSO (OIDC), and automatic backups — starts the container, and creates your admin account. Requires Node.js 18+ on the host.
 
 **Option B — Pre-built image (no clone required)**
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1180,7 +1180,7 @@ All UI strings are managed via `public/i18n.js`. No hardcoded text in JS files o
 ### Architecture
 
 - **Module:** `public/i18n.js` - exports: `initI18n()`, `setLocale()`, `t(key, params?)`, `getLocale()`, `getSupportedLocales()`, `formatDate(date)`, `formatTime(date)`
-- **Locale files:** `public/locales/de.json` (reference), `public/locales/en.json`, `public/locales/es.json`, `public/locales/fr.json`, `public/locales/it.json`, `public/locales/sv.json`, `public/locales/el.json`, `public/locales/ru.json`, `public/locales/tr.json`, `public/locales/zh.json`, `public/locales/ja.json`, `public/locales/ar.json`, `public/locales/hi.json`, `public/locales/pt.json`, `public/locales/uk.json`, `public/locales/pl.json` - structure: `{ "module.camelCaseKey": "Value" }`
+- **Locale files:** `public/locales/de.json` (reference), `public/locales/en.json`, `public/locales/es.json`, `public/locales/fr.json`, `public/locales/it.json`, `public/locales/sv.json`, `public/locales/el.json`, `public/locales/ru.json`, `public/locales/tr.json`, `public/locales/zh.json`, `public/locales/ja.json`, `public/locales/ar.json`, `public/locales/hi.json`, `public/locales/pt.json`, `public/locales/uk.json`, `public/locales/pl.json`, `public/locales/nl.json` - structure: `{ "module.camelCaseKey": "Value" }`
 - **Variables:** `{{variable}}` syntax in translation strings, e.g. `t('tasks.assignedTo', { name: 'Anna' })`
 - **Fallback chain:** active locale → German (`de`) → key itself
 - **Date format:** `Intl.DateTimeFormat` with current locale - use `formatDate()` and `formatTime()` from `i18n.js`

--- a/docs/index.html
+++ b/docs/index.html
@@ -439,7 +439,7 @@
         <span class="tag">Docker</span>
         <span class="tag">Podman</span>
         <span class="tag">PWA</span>
-        <span class="tag">16 languages</span>
+        <span class="tag">17 languages</span>
         <span class="tag" data-t="tag_nocloud">No Cloud Required</span>
       </div>
     </div>
@@ -459,11 +459,11 @@
     <span class="proof-sep proof-dt-only">·</span>
     <span class="proof-dt-only">14 modules</span>
     <span class="proof-sep">·</span>
-    <span>16 languages</span>
+    <span>17 languages</span>
     <span class="proof-sep proof-dt-only">·</span>
     <span class="proof-dt-only">MIT licensed</span>
     <span class="proof-sep">·</span>
-    <span>v0.59.0</span>
+    <span>v0.60.5</span>
   </div>
 </div>
 
@@ -729,7 +729,7 @@ cp .env.example .env
 
 <footer>
   <div class="wrap">
-    <p class="footer-meta"><span id="gh-stars-footer"></span><span id="footer-sep" style="display:none"> · </span>v0.59.0 · June 2026</p>
+    <p class="footer-meta"><span id="gh-stars-footer"></span><span id="footer-sep" style="display:none"> · </span>v0.60.5 · June 2026</p>
     <p data-t="footer_heart">Built with care for families who value privacy and simplicity.</p>
     <div class="footer-links">
       <a href="install.html" data-t="footer_install">Install</a>

--- a/docs/install.html
+++ b/docs/install.html
@@ -566,7 +566,7 @@
       <div class="tab-panel active" id="panel-installer" role="tabpanel" aria-labelledby="tab-installer">
         <div class="callout callout-success reveal">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>
-          <span data-t="option_installer_info">Recommended for most users. A localized browser wizard (16 languages) detects your container engine (Docker or Podman), then configures your .env — including optional reverse proxy/HTTPS, Single Sign-On (OIDC), and automatic backups — starts the container, and creates your admin account. No manual steps. Requires Node.js 18+ on the host.</span>
+          <span data-t="option_installer_info">Recommended for most users. A localized browser wizard (17 languages) detects your container engine (Docker or Podman), then configures your .env — including optional reverse proxy/HTTPS, Single Sign-On (OIDC), and automatic backups — starts the container, and creates your admin account. No manual steps. Requires Node.js 18+ on the host.</span>
         </div>
 
         <div class="step reveal">
@@ -971,7 +971,7 @@ docker compose logs | grep "Server läuft"</div>
           tab_installer: 'Option A \u2014 Web Installer',
           tab_a: 'Option B \u2014 Pre-built Image',
           tab_b: 'Option C \u2014 Build from Source',
-          option_installer_info: 'Recommended for most users. A localized browser wizard (16 languages) detects your container engine (Docker or Podman), then configures your .env \u2014 including optional reverse proxy/HTTPS, Single Sign-On (OIDC), and automatic backups \u2014 starts the container, and creates your admin account. No manual steps. Requires Node.js 18+ on the host.',
+          option_installer_info: 'Recommended for most users. A localized browser wizard (17 languages) detects your container engine (Docker or Podman), then configures your .env \u2014 including optional reverse proxy/HTTPS, Single Sign-On (OIDC), and automatic backups \u2014 starts the container, and creates your admin account. No manual steps. Requires Node.js 18+ on the host.',
           option_a_info: 'No Git, no build step \u2014 just two files and a single command. Requires only Docker or Podman (Podman: use podman-compose.yml).',
           option_b_info: 'For contributors or those who want to run a custom version. Requires Git. The first build takes a few minutes.',
           step_inst1_title: 'Clone the repository',
@@ -1067,7 +1067,7 @@ docker compose logs | grep "Server läuft"</div>
           tab_installer: 'Option A \u2014 Web-Installer',
           tab_a: 'Option B \u2014 Fertiges Image',
           tab_b: 'Option C \u2014 Aus Quellcode bauen',
-          option_installer_info: 'Empfohlen f\u00fcr die meisten Nutzer. Ein lokalisierter Browser-Assistent (16 Sprachen) erkennt eure Container-Engine (Docker oder Podman) und konfiguriert dann eure .env \u2014 inklusive optionalem Reverse-Proxy/HTTPS, Single Sign-On (OIDC) und automatischen Backups \u2014 startet den Container und erstellt euer Admin-Konto. Ganz ohne manuelle Schritte. Erfordert Node.js 18+ auf dem Host.',
+          option_installer_info: 'Empfohlen f\u00fcr die meisten Nutzer. Ein lokalisierter Browser-Assistent (17 Sprachen) erkennt eure Container-Engine (Docker oder Podman) und konfiguriert dann eure .env \u2014 inklusive optionalem Reverse-Proxy/HTTPS, Single Sign-On (OIDC) und automatischen Backups \u2014 startet den Container und erstellt euer Admin-Konto. Ganz ohne manuelle Schritte. Erfordert Node.js 18+ auf dem Host.',
           option_a_info: 'Kein Git, kein Build-Schritt \u2014 nur zwei Dateien und ein einziger Befehl. Nur Docker oder Podman erforderlich (Podman: podman-compose.yml verwenden).',
           option_b_info: 'F\u00fcr Mitwirkende oder wer eine eigene Version ausf\u00fchren m\u00f6chte. Erfordert Git. Der erste Build dauert einige Minuten.',
           step_inst1_title: 'Repository klonen',

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -10,7 +10,7 @@ node tools/installer/install-server.js
 # Open http://localhost:8090
 ```
 
-Requires Node.js 18+ on the host. The browser-based wizard is fully localized (16 languages, auto-detected from your browser), detects your container engine (Docker or Podman) first, then configures your `.env` — including optional reverse-proxy/HTTPS, Single Sign-On (OIDC), and automatic backups — starts the container, and creates your admin account. The engine still runs the app itself.
+Requires Node.js 18+ on the host. The browser-based wizard is fully localized (17 languages, auto-detected from your browser), detects your container engine (Docker or Podman) first, then configures your `.env` — including optional reverse-proxy/HTTPS, Single Sign-On (OIDC), and automatic backups — starts the container, and creates your admin account. The engine still runs the app itself.
 
 ### Option B — CLI Installer (Linux / macOS)
 
@@ -19,9 +19,9 @@ git clone https://github.com/ulsklyc/oikos.git && cd oikos
 bash install.sh
 ```
 
-The script checks prerequisites, generates security keys, configures optional integrations, starts the container (Docker or Podman — auto-detected), and creates your admin account. Like the web installer, it is fully localized in 16 languages and auto-detects yours from the shell environment (`LANG`/`LC_ALL`).
+The script checks prerequisites, generates security keys, configures optional integrations, starts the container (Docker or Podman — auto-detected), and creates your admin account. Like the web installer, it is fully localized in 17 languages and auto-detects yours from the shell environment (`LANG`/`LC_ALL`).
 
-Force a specific language with `--lang` (one of `de en es fr it sv el ru tr zh ja ar hi pt uk pl`):
+Force a specific language with `--lang` (one of `de en es fr it sv el ru tr zh ja ar hi pt uk pl nl`):
 
 ```bash
 bash install.sh --lang de
@@ -168,7 +168,7 @@ node tools/installer/install-server.js
 
 #### 3. Open the Wizard
 
-Open your browser and navigate to **http://localhost:8090**. The wizard detects your browser language (16 languages supported), verifies that a container engine is available (Docker with Compose v2, or Podman with `podman compose` / `podman-compose`), and reports any existing `.env` file or running container before you start. It then guides you through:
+Open your browser and navigate to **http://localhost:8090**. The wizard detects your browser language (17 languages supported), verifies that a container engine is available (Docker with Compose v2, or Podman with `podman compose` / `podman-compose`), and reports any existing `.env` file or running container before you start. It then guides you through:
 
 - Basics — timezone (`TZ`) and HTTP host port (`OIKOS_HTTP_PORT`)
 - Security key generation (`SESSION_SECRET`, `DB_ENCRYPTION_KEY`)

--- a/tools/installer/README.md
+++ b/tools/installer/README.md
@@ -48,17 +48,17 @@ dedicated `podman-compose.yml` (SELinux `:Z` labels).
 
 ## Localization
 
-The wizard is fully localized into all 16 languages supported by the app and
+The wizard is fully localized into all 17 languages supported by the app and
 detects the browser language automatically (`de` is the reference locale, `en`
 the fallback). Translations live in `tools/installer/locales/*.json` and are
 loaded by `i18n-mini.js`, which mirrors the app's locale resolution.
 
 The **CLI installer** (`install.sh` at the repo root) is localized into the same
-16 languages. It detects the language from the shell environment
+17 languages. It detects the language from the shell environment
 (`OIKOS_INSTALLER_LANG` > `LC_ALL` > `LC_MESSAGES` > `LANG`) and accepts a
 `--lang <code>` override. Its strings live in `tools/installer/locales/cli/<lang>.sh`
 — one sourced shell file per language that sets `MSG_*` variables; `en.sh` is the
-fallback base, the active language overlays it. Key parity across all 16 files is
+fallback base, the active language overlays it. Key parity across all 17 files is
 enforced by `test-installer-cli-i18n.js`.
 
 ## Design


### PR DESCRIPTION
## Summary
- Bump language count from 16 → 17 in all user-facing docs (README, installer README, docs/index.html, docs/install.html, docs/installation.md, docs/SPEC.md)
- Add `nl` to the `--lang` code list in installation.md and to the locale file list in SPEC.md
- Update version badge in docs/index.html from v0.59.0 → v0.60.5

## Test plan
- [ ] Verify "17 languages" appears correctly on the landing page and install page
- [ ] Confirm no remaining "16 languages" references: `grep -r "16 lang" docs/ README.md tools/installer/README.md`

🤖 Generated with [Claude Code](https://claude.ai/code)