### PR TITLE
fix(auth): default SESSION_SECURE to false for direct HTTP access

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,7 +22,7 @@ OIKOS_HTTP_PORT=3000
 
 # Session
 SESSION_SECRET=REPLACE_WITH_A_LONG_RANDOM_STRING
-# SESSION_SECURE=false   # Only set when not using HTTPS/reverse proxy (e.g. direct localhost)
+# SESSION_SECURE=true    # Set when running behind an HTTPS reverse proxy (Caddy, Nginx, Traefik)
 
 # Database (SQLite/SQLCipher)
 DB_PATH=/data/oikos.db

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -322,7 +322,7 @@ All configuration happens in the `.env` file. The container reads these values o
 | Variable | Description | Default | Required |
 |----------|-------------|---------|----------|
 | `SESSION_SECRET` | Secret key for signing session cookies. **Change this!** | - | **Yes** |
-| `SESSION_SECURE` | Set to `false` if accessing without HTTPS (e.g. direct localhost). Set in `docker-compose.yml` by default. | `true` | No |
+| `SESSION_SECURE` | Set to `true` when running behind an HTTPS reverse proxy (Caddy, Nginx, Traefik). Leave unset for direct HTTP access (e.g. TrueNAS, bare Docker). | `false` | No |
 | `RATE_LIMIT_WINDOW_MS` | Time window for rate limiting (ms) | `60000` | No |
 | `RATE_LIMIT_MAX_ATTEMPTS` | Max login attempts per window | `5` | No |
 | `RATE_LIMIT_BLOCK_DURATION_MS` | Block duration after exceeding limit (ms) | `900000` | No |

--- a/server/auth.js
+++ b/server/auth.js
@@ -126,8 +126,8 @@ const sessionMiddleware = session({
   name: 'oikos.sid',
   cookie: {
     httpOnly: true,
-    // secure=true by default; set SESSION_SECURE=false in .env to allow HTTP (local dev without reverse proxy)
-    secure: process.env.SESSION_SECURE !== 'false',
+    // secure=false by default; set SESSION_SECURE=true when behind an HTTPS reverse proxy
+    secure: process.env.SESSION_SECURE === 'true',
     // lax (not strict): Safari ITP blocks strict cookies on certain navigations
     // (e.g. reverse proxy, direct URL entry), causing 401 on login. Lax is safe
     // because CSRF is protected by the double-submit token and HTTPS secure flag.
@@ -398,7 +398,7 @@ function setupAuthSession(req, res, user) {
       res.cookie('csrf-token', req.session.csrfToken, {
         httpOnly: false,
         sameSite: 'lax',
-        secure: process.env.SESSION_SECURE !== 'false',
+        secure: process.env.SESSION_SECURE === 'true',
         maxAge: 1000 * 60 * 60 * 24 * 7,
       });
       resolve();

--- a/server/index.js
+++ b/server/index.js
@@ -58,7 +58,7 @@ const PORT = process.env.PORT || 3000;
 // --------------------------------------------------------
 // Security-Middleware
 // --------------------------------------------------------
-const isSecure = process.env.SESSION_SECURE !== 'false';
+const isSecure = process.env.SESSION_SECURE === 'true';
 app.use(helmet({
   contentSecurityPolicy: {
     directives: {

--- a/server/middleware/csrf.js
+++ b/server/middleware/csrf.js
@@ -39,7 +39,7 @@ function csrfMiddleware(req, res, next) {
   res.cookie('csrf-token', req.session.csrfToken, {
     httpOnly: false,
     sameSite: 'lax',
-    secure: process.env.SESSION_SECURE !== 'false',
+    secure: process.env.SESSION_SECURE === 'true',
     maxAge: 1000 * 60 * 60 * 24 * 7, // 7 Tage (gleich wie Session)
   });
 


### PR DESCRIPTION
## Summary

- Changes `SESSION_SECURE` default from `true` to `false` so that direct HTTP deployments (TrueNAS, bare Docker, Podman) work out of the box
- Updates `.env.example` and `docs/installation.md` to reflect the new opt-in model
- No regression for Docker/Podman Compose users — all three Compose files already explicitly set `SESSION_SECURE=${SESSION_SECURE:-false}`, overriding the app default

## Root cause

`secure: true` cookies are silently dropped by browsers over plain HTTP. Login returned 200 (session created), but every subsequent request returned 401 (browser never sent the cookie back). Reported by maintainer stavros-k during TrueNAS Apps Catalog review ([truenas/apps#5090](https://github.com/truenas/apps/pull/5090)).

## Behaviour change

| Context | Before | After |
|---|---|---|
| Docker/Podman Compose (all variants) | `false` via `${SESSION_SECURE:-false}` in Compose | Unchanged |
| Installer-generated `.env` | explicit `true` or `false` | Unchanged |
| TrueNAS / bare `node server/index.js` | `true` (broken on HTTP) | `false` (fixed) |

Set `SESSION_SECURE=true` explicitly when running behind an HTTPS reverse proxy (Caddy, Nginx, Traefik).

## Test plan

- [x] `npm run test:api` — pass
- [x] `npm run test:oidc` — pass
- [x] Existing Compose deployments unaffected (Compose injects `false` regardless of app default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)