### PR TITLE
fix(caldav): correct outbound ICS datetime format (closes #246)

### DIFF
--- a/server/services/caldav-sync.js
+++ b/server/services/caldav-sync.js
@@ -22,6 +22,56 @@ function escapeICSText(str) {
   return str.replace(/\\/g, '\\\\').replace(/;/g, '\\;').replace(/,/g, '\\,').replace(/\n/g, '\\n');
 }
 
+// Convert a DB datetime string (YYYY-MM-DDThh:mm or ...hh:mm:ss[.ms][Z/±offset])
+// to RFC 5545 basic format (YYYYMMDDTHHmmss[Z/±hhmm]).
+// parseTimeInput returns HH:MM (no seconds) — without this, servers like mailbox.org
+// receive HHMM (4 digits) instead of HHMMSS (6), and default to 00:00 (#246).
+export function toICSDatetime(dt) {
+  if (!dt) return '';
+  if (!dt.includes('T')) return dt.replace(/-/g, '') + 'T000000';
+  const [datePart, rest] = dt.split('T');
+  const dateStr = datePart.replace(/-/g, '');
+  const m = rest.match(/^(\d{2}):(\d{2})(?::(\d{2}))?(?:\.\d+)?(Z|[+-]\d{2}:?\d{2})?$/);
+  if (!m) return `${dateStr}T000000`;
+  const ss = m[3] || '00';
+  const tz = (m[4] || '').replace(':', '');
+  return `${dateStr}T${m[1]}${m[2]}${ss}${tz}`;
+}
+
+function buildCalDAVICS(event) {
+  const uid  = `oikos-${event.id}@oikos.local`;
+  const now  = new Date().toISOString().replace(/[-:]/g, '').replace(/\.\d{3}/, '');
+  const lines = [
+    'BEGIN:VCALENDAR',
+    'VERSION:2.0',
+    'PRODID:-//Oikos//CalDAV Sync//EN',
+    'BEGIN:VEVENT',
+    `UID:${uid}`,
+    `DTSTAMP:${now}`,
+    `SUMMARY:${escapeICSText(event.title)}`,
+  ];
+
+  if (event.all_day) {
+    const startDate = event.start_datetime.slice(0, 10).replace(/-/g, '');
+    const endSrc    = (event.end_datetime || event.start_datetime).slice(0, 10);
+    const endD      = new Date(endSrc + 'T00:00:00');
+    endD.setDate(endD.getDate() + 1);
+    const endDate = `${endD.getFullYear()}${String(endD.getMonth() + 1).padStart(2, '0')}${String(endD.getDate()).padStart(2, '0')}`;
+    lines.push(`DTSTART;VALUE=DATE:${startDate}`);
+    lines.push(`DTEND;VALUE=DATE:${endDate}`);
+  } else {
+    lines.push(`DTSTART:${toICSDatetime(event.start_datetime)}`);
+    lines.push(`DTEND:${toICSDatetime(event.end_datetime || event.start_datetime)}`);
+  }
+
+  if (event.description)     lines.push(`DESCRIPTION:${escapeICSText(event.description)}`);
+  if (event.location)        lines.push(`LOCATION:${escapeICSText(event.location)}`);
+  if (event.recurrence_rule) lines.push(event.recurrence_rule);
+
+  lines.push('END:VEVENT', 'END:VCALENDAR');
+  return lines.join('\r\n');
+}
+
 // --------------------------------------------------------
 // Helper Functions
 // --------------------------------------------------------
@@ -443,20 +493,8 @@ async function sync() {
             continue;
           }
 
-          // Build ICS (need to import buildICS from apple-calendar or define it)
-          // For now, create simple ICS
-          const uid = `oikos-${event.id}@oikos.local`;
-          const icsData = `BEGIN:VCALENDAR
-VERSION:2.0
-PRODID:-//Oikos//CalDAV Sync//EN
-BEGIN:VEVENT
-UID:${uid}
-DTSTART:${event.start_datetime.replace(/[-:]/g, '')}
-DTEND:${event.end_datetime.replace(/[-:]/g, '')}
-SUMMARY:${escapeICSText(event.title)}
-DESCRIPTION:${escapeICSText(event.description)}
-END:VEVENT
-END:VCALENDAR`;
+          const uid     = `oikos-${event.id}@oikos.local`;
+          const icsData = buildCalDAVICS(event);
 
           // Upload to CalDAV
           await client.createCalendarObject({

--- a/test/test-caldav-sync.js
+++ b/test/test-caldav-sync.js
@@ -6,6 +6,7 @@
 import { describe, it, before } from 'node:test';
 import assert from 'node:assert/strict';
 import { DatabaseSync } from 'node:sqlite';
+import { toICSDatetime } from '../server/services/caldav-sync.js';
 
 const TEST_DB = ':memory:';
 
@@ -188,5 +189,36 @@ describe('CalDAV Multi-Account Sync', () => {
 
     const migrated = db2.prepare(`SELECT external_source FROM calendar_events_new WHERE title = 'Migrated'`).get();
     assert.strictEqual(migrated.external_source, 'caldav');
+  });
+});
+
+describe('toICSDatetime (#246)', () => {
+  it('pads missing seconds to HHMMSS (main bug: HH:MM → 4-digit time)', () => {
+    assert.strictEqual(toICSDatetime('2024-06-14T14:30'), '20240614T143000');
+  });
+
+  it('handles HH:MM:SS correctly', () => {
+    assert.strictEqual(toICSDatetime('2024-06-14T14:30:00'), '20240614T143000');
+  });
+
+  it('strips milliseconds', () => {
+    assert.strictEqual(toICSDatetime('2024-06-14T14:30:00.000'), '20240614T143000');
+  });
+
+  it('preserves Z suffix', () => {
+    assert.strictEqual(toICSDatetime('2024-06-14T14:30:00Z'), '20240614T143000Z');
+  });
+
+  it('preserves timezone offset and removes colon', () => {
+    assert.strictEqual(toICSDatetime('2024-06-14T14:30:00+02:00'), '20240614T143000+0200');
+  });
+
+  it('returns midnight for date-only strings', () => {
+    assert.strictEqual(toICSDatetime('2024-06-14'), '20240614T000000');
+  });
+
+  it('returns empty string for null/undefined', () => {
+    assert.strictEqual(toICSDatetime(null), '');
+    assert.strictEqual(toICSDatetime(''), '');
   });
 });


### PR DESCRIPTION
## Summary

- **Root cause:** `parseTimeInput` returns `HH:MM` (no seconds). The previous ICS builder used `.replace(/[-:]/g, '')`, producing a 4-digit time (`HHMM`) instead of the RFC 5545-required 6-digit `HHMMSS`. CalDAV servers like mailbox.org reject the invalid format and fall back to `00:00`.
- Added `toICSDatetime()` that normalises any DB datetime to `YYYYMMDDTHHmmss[Z/±hhmm]`, padding missing seconds with `00`.
- Replaced the ad-hoc ICS string template with `buildCalDAVICS()`, which also handles: all-day events (`VALUE=DATE` + exclusive `DTEND`), `DTSTAMP`, `LOCATION`, `RRULE`, and a null-safe `end_datetime` fallback.

## Test plan

- [ ] `npm run test:caldav` — 15 tests pass (8 existing + 7 new `toICSDatetime` cases)
- [ ] Create a timed event (e.g. 14:30), set CalDAV sync target → verify event appears at the correct time on mailbox.org (or any strict CalDAV server)
- [ ] Create an all-day event → verify it appears as all-day (not midnight) on the CalDAV server

Closes #246

🤖 Generated with [Claude Code](https://claude.com/claude-code)