### PR TITLE
fix(caldav): normalize RRULE: prefix before writing ICS

### DIFF
--- a/server/services/caldav-sync.js
+++ b/server/services/caldav-sync.js
@@ -66,7 +66,12 @@ function buildCalDAVICS(event) {
 
   if (event.description)     lines.push(`DESCRIPTION:${escapeICSText(event.description)}`);
   if (event.location)        lines.push(`LOCATION:${escapeICSText(event.location)}`);
-  if (event.recurrence_rule) lines.push(event.recurrence_rule);
+  if (event.recurrence_rule) {
+    const rule = event.recurrence_rule.startsWith('RRULE:')
+      ? event.recurrence_rule
+      : `RRULE:${event.recurrence_rule}`;
+    lines.push(rule);
+  }
 
   lines.push('END:VEVENT', 'END:VCALENDAR');
   return lines.join('\r\n');


### PR DESCRIPTION
## Summary

- `rrule-ui.js` speichert Wiederholungsregeln ohne `RRULE:`-Präfix (z. B. `FREQ=WEEKLY;BYDAY=MO`)
- `buildCalDAVICS` emittierte bisher rohe Zeilen ohne Präfix → ungültiges ICS
- CalDAV-Server können solche Zeilen ablehnen oder ignorieren, was Termine als Einzelevents speichert
- Fix: `RRULE:`-Präfix wird beim Schreiben normalisiert, falls es fehlt

Fixes #249 (review comment r3363206799)

## Test plan

- [x] `npm run test:caldav` — alle 15 Tests grün
- [ ] Manuell: CalDAV-Event mit RRULE erstellen und auf Server prüfen

🤖 Generated with [Claude Code](https://claude.com/claude-code)