### PR TITLE
fix(settings): restore visible border on input fields

### DIFF
--- a/public/styles/glass.css
+++ b/public/styles/glass.css
@@ -217,7 +217,7 @@
 .form-input,
 select.form-input,
 textarea.form-input {
-  border-color: var(--glass-border-subtle);
+  border-color: var(--color-border);
   background-color: color-mix(in srgb, var(--color-surface) 95%, transparent);
 }
 


### PR DESCRIPTION
## Summary

- `glass.css` was overriding `.form-input` `border-color` with `--glass-border-subtle`, which resolves to `rgba(255,255,255,0.35)` in light mode — nearly invisible on white/light backgrounds
- Changed to `--color-border` so input fields have a legible, consistent border in all themes

Fixes #253

## Test plan

- [ ] Open Settings and verify all input fields have a visible border
- [ ] Check light mode and dark mode
- [ ] Verify focus state still works (border turns accent color on focus)
- [ ] Confirm no visual regressions on other pages using `.form-input`

🤖 Generated with [Claude Code](https://claude.com/claude-code)