### PR TITLE
fix(calendar): use opaque surface token for event popup background

### DIFF
--- a/public/styles/calendar.css
+++ b/public/styles/calendar.css
@@ -927,7 +927,7 @@
 .event-popup {
   position: fixed;
   z-index: calc(var(--z-modal) - 1);
-  background-color: var(--glass-bg-card);
+  background-color: var(--color-surface);
   border-radius: var(--radius-glass-card);
   box-shadow: var(--glass-shadow-lg);
   border: 1px solid var(--glass-border-subtle);


### PR DESCRIPTION
## Summary

- Replaces `var(--glass-bg-card)` (→ `rgba(255,255,255,0.70)`, 70% opacity) with `var(--color-surface)` (fully opaque) on `.event-popup`
- The popup is a detail overlay showing event text — it must be legible regardless of what calendar content is rendered behind it
- `var(--color-surface)` correctly resolves to an opaque value in all themes (light, dark, no-glass, high-contrast)

## Test plan

- [ ] Open Calendar, click any event → popup is fully opaque and text is clearly readable
- [ ] Verify in dark mode: popup uses the dark surface color (no bleed-through)
- [ ] Verify in no-glass / high-contrast mode: no visual regression

Fixes #252

🤖 Generated with [Claude Code](https://claude.ai/claude-code)