### PR TITLE
fix(a11y): restore high-contrast form border in glass.css

### DIFF
--- a/public/styles/glass.css
+++ b/public/styles/glass.css
@@ -221,6 +221,15 @@ textarea.form-input {
   background-color: color-mix(in srgb, var(--color-surface) 95%, transparent);
 }
 
+@media (prefers-contrast: more) {
+  .input,
+  .form-input,
+  select.form-input,
+  textarea.form-input {
+    border-color: var(--color-text-primary);
+  }
+}
+
 .input:focus,
 .form-input:focus {
   border-color: var(--active-module-accent, var(--color-accent));


### PR DESCRIPTION
## Summary

- `glass.css` is loaded after `layout.css` in `index.html`
- Its unconditional `.form-input { border-color: var(--color-border) }` (→ `#E8E7E2`, very faint on white) was silently overriding `layout.css`'s `@media (prefers-contrast: more)` rule that sets `border-color: var(--color-text-primary)` (high contrast, 2px)
- Fix: adds a `@media (prefers-contrast: more)` block in `glass.css` that explicitly restores `border-color: var(--color-text-primary)`, preserving the accessibility intent

Found via automated Codex review on #257.

## Test plan

- [ ] Enable OS "Increase Contrast" (macOS: Accessibility → Display) or set `prefers-contrast: more` via browser devtools
- [ ] Open any form (Settings, new event, etc.) — input borders should be thick and dark, not faint gray
- [ ] Normal mode: no visual change to form borders

🤖 Generated with [Claude Code](https://claude.ai/claude-code)