### PR TITLE
feat(meals): allow multiple meal items per slot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.63.3] - 2026-06-05
+
+### Added
+- The meal planner now supports **multiple items per slot**: each day/meal-type cell can hold any number of meals, displayed as stacked cards with a separator. A hover-visible `+` button lets you add another item to an already-filled slot without opening a different view (#262).
+
 ## [0.63.2] - 2026-06-05
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oikos",
-  "version": "0.63.2",
+  "version": "0.63.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oikos",
-      "version": "0.63.2",
+      "version": "0.63.3",
       "license": "MIT",
       "dependencies": {
         "bcrypt": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oikos",
-  "version": "0.63.2",
+  "version": "0.63.3",
   "description": "Self-hosted family planner - calendar, tasks, shopping, meal planning, budget and more. Private, open-source, no subscription.",
   "main": "server/index.js",
   "type": "module",

--- a/public/pages/meals.js
+++ b/public/pages/meals.js
@@ -268,9 +268,9 @@ function renderWeekGrid() {
 export const __test = { buildMobileMealDays };
 
 function renderSlot(date, type, mealsForDay) {
-  const meal = mealsForDay.find((m) => m.meal_type === type.key);
+  const meals = mealsForDay.filter((m) => m.meal_type === type.key);
 
-  if (!meal) {
+  if (!meals.length) {
     return `
       <div class="meal-slot meal-slot--empty" data-date="${date}" data-type="${type.key}">
         <div class="meal-slot__type-label">${type.label}</div>
@@ -290,15 +290,14 @@ function renderSlot(date, type, mealsForDay) {
     `;
   }
 
-  const ingCount = meal.ingredients?.length ?? 0;
-  const ingDone  = meal.ingredients?.filter((i) => i.on_shopping_list).length ?? 0;
-  const ingLabel = ingCount > 0 ? (ingCount !== 1 ? t('meals.ingredientCountPlural', { count: ingCount }) : t('meals.ingredientCount', { count: ingCount })) : '';
-  const ingDoneLabel = ingCount > 0 && ingDone === ingCount ? ' ✓' : '';
-  const canTransfer  = ingCount > 0 && ingDone < ingCount;
+  const cardsHTML = meals.map((meal) => {
+    const ingCount    = meal.ingredients?.length ?? 0;
+    const ingDone     = meal.ingredients?.filter((i) => i.on_shopping_list).length ?? 0;
+    const ingLabel    = ingCount > 0 ? (ingCount !== 1 ? t('meals.ingredientCountPlural', { count: ingCount }) : t('meals.ingredientCount', { count: ingCount })) : '';
+    const ingDoneLabel = ingCount > 0 && ingDone === ingCount ? ' ✓' : '';
+    const canTransfer  = ingCount > 0 && ingDone < ingCount;
 
-  return `
-    <div class="meal-slot meal-slot--has-meal" data-meal-id="${meal.id}" data-date="${meal.date}" data-type="${type.key}">
-      <div class="meal-slot__type-label">${type.label}</div>
+    return `
       <div class="meal-card"
            data-action="edit-meal"
            data-meal-id="${meal.id}"
@@ -327,6 +326,20 @@ function renderSlot(date, type, mealsForDay) {
           ><i data-lucide="trash-2" class="icon-sm" aria-hidden="true"></i></button>
         </div>
       </div>
+    `;
+  }).join('');
+
+  return `
+    <div class="meal-slot meal-slot--has-meal" data-date="${date}" data-type="${type.key}">
+      <div class="meal-slot__type-label">${type.label}</div>
+      ${cardsHTML}
+      <button
+        class="meal-slot__add-more-btn"
+        data-action="add-meal"
+        data-date="${date}"
+        data-type="${type.key}"
+        aria-label="${t('meals.addMeal', { type: type.label })}"
+      ><i data-lucide="plus" class="icon-sm" aria-hidden="true"></i></button>
     </div>
   `;
 }
@@ -417,7 +430,7 @@ function wireDragDrop(grid) {
     const slot = card.closest('.meal-slot');
     if (!slot) return;
 
-    const mealId     = parseInt(slot.dataset.mealId, 10);
+    const mealId     = parseInt(card.dataset.mealId, 10);
     const sourceDate = slot.dataset.date;
     const sourceType = slot.dataset.type;
 
@@ -471,12 +484,11 @@ function wireDragDrop(grid) {
 
       const targetSlot = el?.closest('.meal-slot');
       if (targetSlot && targetSlot !== sourceSlot) {
-        const targetDate    = targetSlot.dataset.date;
-        const targetType    = targetSlot.dataset.type;
-        const targetMealId  = targetSlot.dataset.mealId ? parseInt(targetSlot.dataset.mealId, 10) : null;
+        const targetDate = targetSlot.dataset.date;
+        const targetType = targetSlot.dataset.type;
         _suppressNextClick = true;
         setTimeout(() => { _suppressNextClick = false; }, 300);
-        await moveMeal(mealId, sourceDate, sourceType, targetDate, targetType, targetMealId);
+        await moveMeal(mealId, targetDate, targetType);
       }
     }
 
@@ -506,27 +518,13 @@ function wireDragDrop(grid) {
   }, true);
 }
 
-async function moveMeal(mealId, sourceDate, sourceType, targetDate, targetType, targetMealId) {
+async function moveMeal(mealId, targetDate, targetType) {
   try {
-    if (targetMealId) {
-      // Swap: move both meals to each other's slots
-      await Promise.all([
-        api.put(`/meals/${mealId}`,       { date: targetDate, meal_type: targetType }),
-        api.put(`/meals/${targetMealId}`, { date: sourceDate, meal_type: sourceType }),
-      ]);
-      const m1 = state.meals.find((m) => m.id === mealId);
-      const m2 = state.meals.find((m) => m.id === targetMealId);
-      if (m1) { m1.date = targetDate; m1.meal_type = targetType; }
-      if (m2) { m2.date = sourceDate; m2.meal_type = sourceType; }
-    } else {
-      // Move to empty slot
-      await api.put(`/meals/${mealId}`, { date: targetDate, meal_type: targetType });
-      const m = state.meals.find((m) => m.id === mealId);
-      if (m) { m.date = targetDate; m.meal_type = targetType; }
-    }
+    await api.put(`/meals/${mealId}`, { date: targetDate, meal_type: targetType });
+    const m = state.meals.find((m) => m.id === mealId);
+    if (m) { m.date = targetDate; m.meal_type = targetType; }
     renderWeekGrid();
   } catch {
-    // Re-render to restore visual state
     renderWeekGrid();
   }
 }
@@ -986,7 +984,7 @@ function collectModalIngredients(overlay) {
 
 async function deleteMeal(mealId) {
   const meal = state.meals.find((m) => m.id === mealId);
-  const itemEl = _container.querySelector(`.meal-slot--has-meal[data-meal-id="${mealId}"]`);
+  const itemEl = _container.querySelector(`.meal-card[data-meal-id="${mealId}"]`);
   if (itemEl) itemEl.style.display = 'none';
 
   let undone = false;

--- a/public/styles/meals.css
+++ b/public/styles/meals.css
@@ -171,6 +171,10 @@
     opacity: 1;
   }
 
+  .meal-slot__add-more-btn {
+    opacity: 1;
+  }
+
   #fab-new-meal {
     display: none;
   }
@@ -233,17 +237,46 @@
   color: var(--color-accent);
 }
 
+.meal-slot__add-more-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  background: none;
+  border: none;
+  border-top: 1px dashed var(--color-border);
+  cursor: pointer;
+  color: var(--color-text-disabled);
+  padding: var(--space-1) var(--space-2);
+  min-height: 28px;
+  opacity: 0;
+  transition: color var(--transition-fast), background-color var(--transition-fast), opacity var(--transition-fast);
+}
+
+.meal-slot:hover .meal-slot__add-more-btn,
+.meal-slot:focus-within .meal-slot__add-more-btn {
+  opacity: 1;
+}
+
+.meal-slot__add-more-btn:hover {
+  color: var(--color-accent);
+  background-color: var(--color-accent-light);
+}
+
 /* --------------------------------------------------------
  * Mahlzeit-Karte (innerhalb des Slots)
  * -------------------------------------------------------- */
 .meal-card {
-  flex: 1;
   display: flex;
   flex-direction: column;
   align-items: flex-start;
   text-align: left;
   padding: var(--space-4);
   cursor: pointer;
+}
+
+.meal-card + .meal-card {
+  border-top: 1px solid var(--color-border-subtle);
 }
 
 .meal-card__title {

--- a/test/test-meals.js
+++ b/test/test-meals.js
@@ -293,6 +293,46 @@ test('added_from_meal FK auf meals(id) gesetzt', () => {
 });
 
 // --------------------------------------------------------
+// Mehrere Mahlzeiten pro Slot
+// --------------------------------------------------------
+test('Mehrere Mahlzeiten pro Slot anlegen (gleiche date + meal_type)', () => {
+  const m1 = db.prepare(`
+    INSERT INTO meals (date, meal_type, title, created_by)
+    VALUES ('2026-03-26', 'breakfast', 'Omelette', ?)
+  `).run(uid);
+  const m2 = db.prepare(`
+    INSERT INTO meals (date, meal_type, title, created_by)
+    VALUES ('2026-03-26', 'breakfast', 'French Toast', ?)
+  `).run(uid);
+  assert(m1.lastInsertRowid > 0, 'Erste Mahlzeit angelegt');
+  assert(m2.lastInsertRowid > 0, 'Zweite Mahlzeit angelegt');
+  assert(m1.lastInsertRowid !== m2.lastInsertRowid, 'Unterschiedliche IDs');
+});
+
+test('Mehrere Mahlzeiten desselben Slots werden gemeinsam abgefragt', () => {
+  const meals = db.prepare(`
+    SELECT * FROM meals
+    WHERE date = '2026-03-26' AND meal_type = 'breakfast'
+    ORDER BY id ASC
+  `).all();
+  assert(meals.length === 2, `Erwartet 2, erhalten ${meals.length}`);
+  assert(meals[0].title === 'Omelette');
+  assert(meals[1].title === 'French Toast');
+});
+
+test('Löschen einer Mahlzeit lässt die andere im Slot bestehen', () => {
+  const [first] = db.prepare(`
+    SELECT id FROM meals WHERE date = '2026-03-26' AND meal_type = 'breakfast' ORDER BY id ASC
+  `).all();
+  db.prepare('DELETE FROM meals WHERE id = ?').run(first.id);
+  const remaining = db.prepare(`
+    SELECT * FROM meals WHERE date = '2026-03-26' AND meal_type = 'breakfast'
+  `).all();
+  assert(remaining.length === 1, `Erwartet 1 verbleibende Mahlzeit, erhalten ${remaining.length}`);
+  assert(remaining[0].title === 'French Toast', 'Richtige Mahlzeit verblieben');
+});
+
+// --------------------------------------------------------
 // Autocomplete-Simulation
 // --------------------------------------------------------
 test('Mahlzeit-Autocomplete nach Prefix', () => {


### PR DESCRIPTION
## Summary

- Renders all meals for a day/type slot as individual stacked cards instead of only the first one
- Adds a hover-visible `+` button at the bottom of occupied slots so users can add a second (or third) item without leaving the week view
- Simplifies drag-and-drop to a plain move — any card can be dragged independently to any slot; the previous "swap two meals" behaviour is removed (no longer meaningful with multiple items per slot)
- Adds 3 new tests covering the multi-meal-per-slot data path

No DB migration required — `meals` has no unique constraint on `(date, meal_type)`.

## Test plan

- [ ] Add a single meal to a slot → still looks and behaves the same
- [ ] Hover a filled slot → small `+` button appears at the bottom; clicking it opens the add-meal modal pre-filled with correct date and type
- [ ] Add a second meal to the same slot → both cards are displayed with a subtle separator
- [ ] Delete one of the two meals → the other remains visible
- [ ] Drag a card from a multi-meal slot to another slot → card moves, remaining cards stay
- [ ] `npm run test:meals` → 28/28 pass

Closes #262

🤖 Generated with [Claude Code](https://claude.com/claude-code)