### PR TITLE
fix(tasks): centre filter chip remove icon (#265)

### DIFF
--- a/public/pages/tasks.js
+++ b/public/pages/tasks.js
@@ -1087,6 +1087,17 @@ function renderTaskList(container) {
   });
 }
 
+function makeRemoveSpan() {
+  const rm = document.createElement('span');
+  rm.className = 'filter-chip__remove';
+  rm.setAttribute('aria-hidden', 'true');
+  const icon = document.createElement('i');
+  icon.setAttribute('data-lucide', 'x');
+  icon.className = 'icon-sm';
+  rm.appendChild(icon);
+  return rm;
+}
+
 function renderFilters(container) {
   const bar   = container.querySelector('#filter-bar');
   const panel = container.querySelector('#filter-panel');
@@ -1105,11 +1116,7 @@ function renderFilters(container) {
     chip.className = 'filter-chip filter-chip--active';
     chip.dataset.filter = 'status';
     chip.textContent = statusLabels[state.filters.status];
-    const rm = document.createElement('span');
-    rm.className = 'filter-chip__remove';
-    rm.setAttribute('aria-hidden', 'true');
-    rm.textContent = '×';
-    chip.appendChild(rm);
+    chip.appendChild(makeRemoveSpan());
     bar.appendChild(chip);
   }
   if (state.filters.priority) {
@@ -1117,11 +1124,7 @@ function renderFilters(container) {
     chip.className = 'filter-chip filter-chip--active';
     chip.dataset.filter = 'priority';
     chip.textContent = priorityLabels[state.filters.priority];
-    const rm = document.createElement('span');
-    rm.className = 'filter-chip__remove';
-    rm.setAttribute('aria-hidden', 'true');
-    rm.textContent = '×';
-    chip.appendChild(rm);
+    chip.appendChild(makeRemoveSpan());
     bar.appendChild(chip);
   }
   if (state.filters.assigned_to) {
@@ -1130,11 +1133,7 @@ function renderFilters(container) {
     chip.className = 'filter-chip filter-chip--active';
     chip.dataset.filter = 'assigned_to';
     chip.textContent = u?.display_name ?? t('tasks.filterGroupPerson');
-    const rm = document.createElement('span');
-    rm.className = 'filter-chip__remove';
-    rm.setAttribute('aria-hidden', 'true');
-    rm.textContent = '×';
-    chip.appendChild(rm);
+    chip.appendChild(makeRemoveSpan());
     bar.appendChild(chip);
   }
 
@@ -1144,11 +1143,7 @@ function renderFilters(container) {
   futureChip.id = 'filter-show-future';
   futureChip.textContent = t('tasks.showFuture');
   if (state.showFuture) {
-    const rm = document.createElement('span');
-    rm.className = 'filter-chip__remove';
-    rm.setAttribute('aria-hidden', 'true');
-    rm.textContent = '×';
-    futureChip.appendChild(rm);
+    futureChip.appendChild(makeRemoveSpan());
   }
   bar.appendChild(futureChip);
 
@@ -1244,11 +1239,7 @@ function renderFilters(container) {
         chip.dataset.value = item.value;
         chip.textContent = item.label;
         if (isActive) {
-          const rm = document.createElement('span');
-          rm.className = 'filter-chip__remove';
-          rm.setAttribute('aria-hidden', 'true');
-          rm.textContent = '×';
-          chip.appendChild(rm);
+          chip.appendChild(makeRemoveSpan());
         }
         row.appendChild(chip);
       });
@@ -1264,6 +1255,7 @@ function renderFilters(container) {
       clearBtn.textContent = t('tasks.filterClearAll');
       panel.appendChild(clearBtn);
     }
+    if (window.lucide) window.lucide.createIcons({ el: panel });
   }
 
   wireFilterChips(container);

--- a/public/styles/tasks.css
+++ b/public/styles/tasks.css
@@ -258,14 +258,13 @@
 .filter-chip__remove {
   width: 16px;
   height: 16px;
+  flex-shrink: 0;
   display: flex;
   align-items: center;
   justify-content: center;
   border-radius: var(--radius-full);
   background-color: var(--color-accent);
   color: var(--color-text-on-accent);
-  font-size: var(--text-xs);
-  line-height: 1;
 }
 
 /* Filter-Toggle-Button */


### PR DESCRIPTION
## Summary

- Replaces the `×` text character in filter chip remove buttons with a Lucide `x` SVG icon
- The SVG is geometrically centred in the 16 × 16 px circle by flexbox, independent of font metrics
- Removes `font-size` and `line-height` from `.filter-chip__remove` (no longer needed for text)
- Adds `createIcons` call for the filter panel so panel chips also get the SVG rendered
- Extracts `makeRemoveSpan()` helper to avoid repeating the 4-line DOM construction 5 times

Fixes #265

## Test plan

- [ ] Go to **Aufgaben**, activate one or more filter chips — close icon appears perfectly centred
- [ ] Open the filter panel and activate a chip there — same result
- [ ] Toggle "Geplante anzeigen" — close icon centred when chip is active
- [ ] All 57 frontend-audit tests pass (`npm run test:frontend-audit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)