### PR TITLE
feat(avatars): show profile photo in all user avatar circles

### DIFF
--- a/public/components/user-multi-select.js
+++ b/public/components/user-multi-select.js
@@ -27,10 +27,13 @@ export function renderAvatarStack(users, { size = 28, maxVisible = 3 } = {}) {
       .join('')
       .toUpperCase()
       .slice(0, 2);
+    const inner = u.avatar_data
+      ? `<img src="${esc(u.avatar_data)}" alt="${esc(u.display_name ?? '')}" loading="lazy">`
+      : esc(initials);
     return `<span class="avatar-stack__item"
       style="width:${size}px;height:${size}px;font-size:${fs}px;background-color:${esc(u.color ?? '#8E8E93')}"
       title="${esc(u.display_name ?? '')}">
-      ${esc(initials)}
+      ${inner}
     </span>`;
   });
   if (overflow > 0) {
@@ -59,12 +62,15 @@ export function renderUserMultiSelect(allUsers, selectedIds, inputName, labelKey
       .join('')
       .toUpperCase()
       .slice(0, 2);
+    const inner = u.avatar_data
+      ? `<img src="${esc(u.avatar_data)}" alt="${esc(u.display_name ?? '')}" loading="lazy">`
+      : esc(initials);
     return `
       <label class="user-ms__option">
         <input type="checkbox" class="user-ms__checkbox" value="${u.id}" ${checked}
                data-ms-input="${esc(inputName)}">
         <span class="user-ms__avatar" style="background-color:${esc(u.avatar_color ?? '#8E8E93')}">
-          ${esc(initials)}
+          ${inner}
         </span>
         <span class="user-ms__name">${esc(u.display_name)}</span>
       </label>`;

--- a/public/pages/dashboard.js
+++ b/public/pages/dashboard.js
@@ -422,7 +422,11 @@ function renderUrgentTasks(tasks) {
         </div>
         ${t.assigned_color ? `
           <div class="task-item__avatar" style="background-color:${esc(t.assigned_color)}"
-               title="${esc(t.assigned_name)}">${esc(initials(t.assigned_name || ''))}</div>` : ''}
+               title="${esc(t.assigned_name)}">
+            ${t.assigned_avatar
+              ? `<img src="${esc(t.assigned_avatar)}" alt="${esc(t.assigned_name || '')}" loading="lazy">`
+              : esc(initials(t.assigned_name || ''))}
+          </div>` : ''}
       </div>
     `;
   }).join('');

--- a/public/pages/notes.js
+++ b/public/pages/notes.js
@@ -188,7 +188,11 @@ function renderNoteCard(note) {
       <div class="note-card__footer">
         <div class="note-card__creator">
           <span class="note-card__avatar"
-                style="background-color:${esc(note.creator_color || '#8E8E93')}">${initials}</span>
+                style="background-color:${esc(note.creator_color || '#8E8E93')}">
+            ${note.creator_avatar
+              ? `<img src="${esc(note.creator_avatar)}" alt="${esc(note.creator_name || '')}" loading="lazy">`
+              : initials}
+          </span>
           <span>${esc(note.creator_name || '')}</span>
         </div>
         <button class="note-card__delete" data-action="delete" data-id="${note.id}" aria-label="${t('notes.deleteLabel')}">

--- a/public/styles/dashboard.css
+++ b/public/styles/dashboard.css
@@ -612,6 +612,13 @@
   color: var(--color-text-on-accent);
   flex-shrink: 0;
   margin-top: 1px;
+  overflow: hidden;
+}
+
+.task-item__avatar img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
 }
 
 /* --------------------------------------------------------

--- a/public/styles/notes.css
+++ b/public/styles/notes.css
@@ -224,6 +224,13 @@
   font-weight: var(--font-weight-bold);
   color: var(--color-text-on-accent);
   flex-shrink: 0;
+  overflow: hidden;
+}
+
+.note-card__avatar img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
 }
 
 .note-card__delete {

--- a/public/styles/user-multi-select.css
+++ b/public/styles/user-multi-select.css
@@ -18,6 +18,13 @@
   border: 2px solid var(--color-surface);
   flex-shrink: 0;
   margin-left: -6px;
+  overflow: hidden;
+}
+
+.avatar-stack__item img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
 }
 
 .avatar-stack__item:last-child {
@@ -84,6 +91,13 @@
   font-weight: var(--font-weight-bold);
   color: var(--color-text-on-accent);
   flex-shrink: 0;
+  overflow: hidden;
+}
+
+.user-ms__avatar img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
 }
 
 .user-ms__avatar--none {

--- a/server/routes/calendar.js
+++ b/server/routes/calendar.js
@@ -166,7 +166,8 @@ function attachmentDataUrl(event) {
 
 const ASSIGNED_USERS_SQL = `(
   SELECT json_group_array(json_object(
-    'id', u.id, 'display_name', u.display_name, 'color', u.avatar_color
+    'id', u.id, 'display_name', u.display_name, 'color', u.avatar_color,
+    'avatar_data', u.avatar_data
   ))
   FROM event_assignments ea JOIN users u ON u.id = ea.user_id
   WHERE ea.event_id = e.id

--- a/server/routes/notes.js
+++ b/server/routes/notes.js
@@ -21,7 +21,7 @@ const router  = express.Router();
 router.get('/', (req, res) => {
   try {
     const notes = db.get().prepare(`
-      SELECT n.*, u.display_name AS creator_name, u.avatar_color AS creator_color
+      SELECT n.*, u.display_name AS creator_name, u.avatar_color AS creator_color, u.avatar_data AS creator_avatar
       FROM notes n
       LEFT JOIN users u ON u.id = n.created_by
       ORDER BY n.pinned DESC, n.updated_at DESC
@@ -54,7 +54,7 @@ router.post('/', (req, res) => {
     `).run(vContent.value, vTitle.value, vColor.value, pinned ? 1 : 0, req.session.userId);
 
     const note = db.get().prepare(`
-      SELECT n.*, u.display_name AS creator_name, u.avatar_color AS creator_color
+      SELECT n.*, u.display_name AS creator_name, u.avatar_color AS creator_color, u.avatar_data AS creator_avatar
       FROM notes n LEFT JOIN users u ON u.id = n.created_by
       WHERE n.id = ?
     `).get(result.lastInsertRowid);
@@ -102,7 +102,7 @@ router.put('/:id', (req, res) => {
     );
 
     const updated = db.get().prepare(`
-      SELECT n.*, u.display_name AS creator_name, u.avatar_color AS creator_color
+      SELECT n.*, u.display_name AS creator_name, u.avatar_color AS creator_color, u.avatar_data AS creator_avatar
       FROM notes n LEFT JOIN users u ON u.id = n.created_by WHERE n.id = ?
     `).get(id);
 

--- a/server/routes/tasks.js
+++ b/server/routes/tasks.js
@@ -29,7 +29,8 @@ const VALID_CATEGORIES = ['household', 'school', 'shopping', 'repair',
 
 const ASSIGNED_USERS_SQL = `(
   SELECT json_group_array(json_object(
-    'id', u.id, 'display_name', u.display_name, 'color', u.avatar_color
+    'id', u.id, 'display_name', u.display_name, 'color', u.avatar_color,
+    'avatar_data', u.avatar_data
   ))
   FROM task_assignments ta JOIN users u ON u.id = ta.user_id
   WHERE ta.task_id = t.id
@@ -70,7 +71,7 @@ function syncHousekeepingPaymentStatus(d, taskId, status) {
 function loadSubtasks(taskId) {
   return db.get().prepare(`
     SELECT t.*, u.display_name AS assigned_name, u.avatar_color AS assigned_color,
-      ${ASSIGNED_USERS_SQL}
+      u.avatar_data AS assigned_avatar, ${ASSIGNED_USERS_SQL}
     FROM tasks t
     LEFT JOIN users u ON t.assigned_to = u.id
     WHERE t.parent_task_id = ?
@@ -120,6 +121,7 @@ router.get('/', (req, res) => {
         t.*,
         u.display_name AS assigned_name,
         u.avatar_color AS assigned_color,
+        u.avatar_data AS assigned_avatar,
         ${ASSIGNED_USERS_SQL},
         (SELECT COUNT(*) FROM tasks s WHERE s.parent_task_id = t.id)                           AS subtask_total,
         (SELECT COUNT(*) FROM tasks s WHERE s.parent_task_id = t.id AND s.status = 'done')     AS subtask_done
@@ -166,7 +168,7 @@ router.get('/:id', (req, res) => {
   try {
     const task = db.get().prepare(`
       SELECT t.*, u.display_name AS assigned_name, u.avatar_color AS assigned_color,
-        ${ASSIGNED_USERS_SQL}
+        u.avatar_data AS assigned_avatar, ${ASSIGNED_USERS_SQL}
       FROM tasks t
       LEFT JOIN users u ON t.assigned_to = u.id
       WHERE t.id = ? AND t.parent_task_id IS NULL
@@ -237,7 +239,7 @@ router.post('/', (req, res) => {
 
     const task = db.get().prepare(`
       SELECT t.*, u.display_name AS assigned_name, u.avatar_color AS assigned_color,
-        ${ASSIGNED_USERS_SQL}
+        u.avatar_data AS assigned_avatar, ${ASSIGNED_USERS_SQL}
       FROM tasks t LEFT JOIN users u ON t.assigned_to = u.id
       WHERE t.id = ?
     `).get(taskId);
@@ -299,7 +301,7 @@ router.put('/:id', (req, res) => {
 
     const updated = db.get().prepare(`
       SELECT t.*, u.display_name AS assigned_name, u.avatar_color AS assigned_color,
-        ${ASSIGNED_USERS_SQL}
+        u.avatar_data AS assigned_avatar, ${ASSIGNED_USERS_SQL}
       FROM tasks t LEFT JOIN users u ON t.assigned_to = u.id
       WHERE t.id = ?
     `).get(req.params.id);


### PR DESCRIPTION
## Summary

Closes #263

- Backend SQL queries for tasks, calendar events, and notes now include `avatar_data` alongside `avatar_color`
- `renderAvatarStack()` and `renderUserMultiSelect()` render a profile photo (`<img>`) when `avatar_data` is present, falling back to the coloured initials circle
- Dashboard task-item avatar and notes creator badge follow the same pattern
- Avatar container classes (`avatar-stack__item`, `user-ms__avatar`, `task-item__avatar`, `note-card__avatar`) gain `overflow: hidden` and an `img` rule (`object-fit: cover`) to clip photos into the circle shape

## Test plan

- [ ] Family member with a profile photo set: avatar shows photo in task cards, calendar agenda, user picker, dashboard widget, and notes
- [ ] Family member without a photo: coloured initials fallback unchanged
- [ ] All test suites pass (`npm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)