### PR TITLE
fix(api): use req.authUserId for created_by across routes (#270)

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "test:frontend-audit": "node --test test/test-frontend-audit.js",
     "test:reminders": "node --experimental-sqlite test/test-reminders.js",
     "test:api": "node test/test-api.js",
+    "test:auth-userid": "node --test test/test-auth-userid.js",
     "test:setup": "node test/test-setup.js",
     "test:ics-parser": "node test/test-ics-parser.js",
     "test:ics-sub": "node --experimental-sqlite test/test-ics-subscription.js",
@@ -52,7 +53,7 @@
     "test:installer-a11y": "node --test test/test-installer-a11y.js",
     "truenas:generate": "node tools/truenas/generate.mjs",
     "test:truenas": "node --test test/test-truenas-generate.js",
-    "test": "node --experimental-sqlite test/test-db.js && node --experimental-sqlite test/test-dashboard.js && node --experimental-sqlite test/test-tasks.js && node --experimental-sqlite test/test-multi-assignment.js && node --experimental-sqlite test/test-shopping.js && npm run test:meals && npm run test:calendar && node --experimental-sqlite test/test-notes-contacts-budget.js && npm run test:budget-recurrence && npm run test:ux-utils && npm run test:date-utils && npm run test:modal-utils && npm run test:reminders && npm run test:api && npm run test:ics-parser && npm run test:ics-sub && npm run test:setup && npm run test:kitchen-tabs && npm run test:mobile-scroll-layout && npm run test:frontend-audit && npm run test:backup-scheduler && npm run test:caldav && npm run test:caldav-reminders && npm run test:caldav-event-target && npm run test:carddav && npm run test:split-expenses && npm run test:oidc && npm run test:family-contacts && npm run test:google-calendar && npm run test:google-multi && npm run test:housekeeping && npm run test:installer-schema && npm run test:installer-env-write && npm run test:installer-static && npm run test:installer-i18n && npm run test:installer-cli-i18n && npm run test:installer-prereq && npm run test:installer-a11y && npm run test:truenas"
+    "test": "node --experimental-sqlite test/test-db.js && node --experimental-sqlite test/test-dashboard.js && node --experimental-sqlite test/test-tasks.js && node --experimental-sqlite test/test-multi-assignment.js && node --experimental-sqlite test/test-shopping.js && npm run test:meals && npm run test:calendar && node --experimental-sqlite test/test-notes-contacts-budget.js && npm run test:budget-recurrence && npm run test:ux-utils && npm run test:date-utils && npm run test:modal-utils && npm run test:reminders && npm run test:api && npm run test:auth-userid && npm run test:ics-parser && npm run test:ics-sub && npm run test:setup && npm run test:kitchen-tabs && npm run test:mobile-scroll-layout && npm run test:frontend-audit && npm run test:backup-scheduler && npm run test:caldav && npm run test:caldav-reminders && npm run test:caldav-event-target && npm run test:carddav && npm run test:split-expenses && npm run test:oidc && npm run test:family-contacts && npm run test:google-calendar && npm run test:google-multi && npm run test:housekeeping && npm run test:installer-schema && npm run test:installer-env-write && npm run test:installer-static && npm run test:installer-i18n && npm run test:installer-cli-i18n && npm run test:installer-prereq && npm run test:installer-a11y && npm run test:truenas"
   },
   "dependencies": {
     "bcrypt": "^6.0.0",

--- a/server/routes/budget.js
+++ b/server/routes/budget.js
@@ -561,7 +561,7 @@ router.post('/loans', (req, res) => {
       installmentCount,
       vStartMonth.value,
       vNotes.value,
-      req.session.userId
+      req.authUserId || req.session.userId
     );
 
     res.status(201).json({ data: loadLoan(result.lastInsertRowid) });
@@ -661,13 +661,13 @@ router.post('/loans/:id/payments', (req, res) => {
         paymentAmount,
         'Geschenke & Transfers',
         vDate.value,
-        req.session.userId
+        req.authUserId || req.session.userId
       );
       const paymentResult = db.get().prepare(`
         INSERT INTO budget_loan_payments
           (loan_id, installment_number, amount, paid_date, budget_entry_id, created_by)
         VALUES (?, ?, ?, ?, ?, ?)
-      `).run(id, installmentNumber, paymentAmount, vDate.value, budgetResult.lastInsertRowid, req.session.userId);
+      `).run(id, installmentNumber, paymentAmount, vDate.value, budgetResult.lastInsertRowid, req.authUserId || req.session.userId);
       return paymentResult.lastInsertRowid;
     });
 
@@ -893,7 +893,7 @@ router.post('/', (req, res) => {
       vTitle.value, storeAmount, vCat.value || fallbackCategory, subcategory, vDate.value,
       isRecurring, vRrule.value,
       interval, isVirtual, fullAmount,
-      req.session.userId
+      req.authUserId || req.session.userId
     );
 
     const entry = entryWithLoanMeta(result.lastInsertRowid);

--- a/server/routes/meals.js
+++ b/server/routes/meals.js
@@ -170,7 +170,7 @@ router.post('/', (req, res) => {
       const result = db.get().prepare(`
         INSERT INTO meals (date, meal_type, title, notes, recipe_url, recipe_id, created_by)
         VALUES (?, ?, ?, ?, ?, ?, ?)
-      `).run(vDate.value, vType.value, vTitle.value, vNotes.value, vRecipeUrl.value, vRecipeId.value, req.session.userId);
+      `).run(vDate.value, vType.value, vTitle.value, vNotes.value, vRecipeUrl.value, vRecipeId.value, req.authUserId || req.session.userId);
 
       const mealId = result.lastInsertRowid;
 

--- a/server/routes/notes.js
+++ b/server/routes/notes.js
@@ -51,7 +51,7 @@ router.post('/', (req, res) => {
     const result = db.get().prepare(`
       INSERT INTO notes (content, title, color, pinned, created_by)
       VALUES (?, ?, ?, ?, ?)
-    `).run(vContent.value, vTitle.value, vColor.value, pinned ? 1 : 0, req.session.userId);
+    `).run(vContent.value, vTitle.value, vColor.value, pinned ? 1 : 0, req.authUserId || req.session.userId);
 
     const note = db.get().prepare(`
       SELECT n.*, u.display_name AS creator_name, u.avatar_color AS creator_color, u.avatar_data AS creator_avatar

--- a/server/routes/recipes.js
+++ b/server/routes/recipes.js
@@ -79,7 +79,7 @@ router.post('/', (req, res) => {
       const result = db.get().prepare(`
         INSERT INTO recipes (title, notes, recipe_url, created_by)
         VALUES (?, ?, ?, ?)
-      `).run(vTitle.value, vNotes.value, vRecipeUrl.value, req.session.userId);
+      `).run(vTitle.value, vNotes.value, vRecipeUrl.value, req.authUserId || req.session.userId);
 
       const rid = Number(result.lastInsertRowid);
       const insertIng = db.get().prepare(`
@@ -112,7 +112,7 @@ router.put('/:id', (req, res) => {
 
     const existing = db.get().prepare('SELECT id, created_by FROM recipes WHERE id = ?').get(id);
     if (!existing) return res.status(404).json({ error: 'Recipe not found', code: 404 });
-    if (existing.created_by !== req.session.userId) return res.status(403).json({ error: 'Not authorized.', code: 403 });
+    if (existing.created_by !== (req.authUserId || req.session.userId)) return res.status(403).json({ error: 'Not authorized.', code: 403 });
 
     const { ingredients = [] } = req.body;
 
@@ -159,7 +159,7 @@ router.delete('/:id', (req, res) => {
 
     const existing = db.get().prepare('SELECT id, created_by FROM recipes WHERE id = ?').get(id);
     if (!existing) return res.status(404).json({ error: 'Recipe not found.', code: 404 });
-    if (existing.created_by !== req.session.userId) return res.status(403).json({ error: 'Not authorized.', code: 403 });
+    if (existing.created_by !== (req.authUserId || req.session.userId)) return res.status(403).json({ error: 'Not authorized.', code: 403 });
 
     const result = db.get().prepare('DELETE FROM recipes WHERE id = ?').run(id);
     if (result.changes === 0) return res.status(404).json({ error: 'Recipe not found', code: 404 });

--- a/server/routes/search.js
+++ b/server/routes/search.js
@@ -21,7 +21,7 @@ router.get('/', (req, res) => {
     const q = String(req.query.q ?? '').trim();
     if (q.length < 2) return res.json({ tasks: [], events: [], notes: [], contacts: [], items: [] });
 
-    const userId = req.session.userId;
+    const userId = req.authUserId || req.session.userId;
     res.json(runSearch(db.get(), q, userId));
   } catch (err) {
     res.status(500).json({ error: 'Internal server error.', code: 500 });

--- a/server/routes/shopping.js
+++ b/server/routes/shopping.js
@@ -304,7 +304,7 @@ router.post('/', (req, res) => {
 
     const result = db.get()
       .prepare('INSERT INTO shopping_lists (name, created_by) VALUES (?, ?)')
-      .run(vName.value, req.session.userId);
+      .run(vName.value, req.authUserId || req.session.userId);
 
     const list = db.get()
       .prepare('SELECT * FROM shopping_lists WHERE id = ?')

--- a/server/routes/tasks.js
+++ b/server/routes/tasks.js
@@ -230,7 +230,7 @@ router.post('/', (req, res) => {
         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       `).run(
         title.trim(), description, category, priority,
-        start_date, due_date, due_time, firstUid, req.session.userId, parent_task_id,
+        start_date, due_date, due_time, firstUid, req.authUserId || req.session.userId, parent_task_id,
         is_recurring ? 1 : 0, recurrence_rule
       );
       setAssignments(db.get(), result.lastInsertRowid, userIds);

--- a/test/test-auth-userid.js
+++ b/test/test-auth-userid.js
@@ -1,0 +1,43 @@
+/**
+ * Auth-User-ID regression guard (Issue #270).
+ *
+ * API-Token-Requests haben kein `req.session` — `requireAuth` setzt für beide
+ * Auth-Methoden (Session + Token) `req.authUserId`. Route-Handler, die bare
+ * `req.session.userId` lesen (z. B. für `created_by`-Inserts), crashen daher mit
+ * NOT-NULL-Constraint, sobald ein API-Token genutzt wird. Dieser Test stellt
+ * sicher, dass keine Route `req.session.userId` ohne `req.authUserId`-Fallback
+ * verwendet.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync } from 'node:fs';
+
+const routesDir = new URL('../server/routes/', import.meta.url);
+
+function routeFiles() {
+  return readdirSync(routesDir, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && entry.name.endsWith('.js'))
+    .map((entry) => entry.name);
+}
+
+test('route handlers never read bare req.session.userId (must use req.authUserId)', () => {
+  const offenders = [];
+
+  for (const file of routeFiles()) {
+    const source = readFileSync(new URL(file, routesDir), 'utf8');
+    source.split('\n').forEach((line, index) => {
+      if (!line.includes('req.session.userId')) return;
+      // Erlaubt: der Fallback-Ausdruck `req.authUserId || req.session.userId`.
+      const sanitized = line.replaceAll('req.authUserId || req.session.userId', '');
+      if (sanitized.includes('req.session.userId')) {
+        offenders.push(`${file}:${index + 1}`);
+      }
+    });
+  }
+
+  assert.deepEqual(
+    offenders,
+    [],
+    `Diese Stellen lesen bare req.session.userId und brechen bei API-Token-Auth:\n${offenders.join('\n')}`,
+  );
+});


### PR DESCRIPTION
## Problem

`POST /api/v1/budget` (und weitere Routes) crashen mit **500** bei Nutzung eines API-Tokens (`Authorization: Bearer <token>`). Gemeldet in #270.

## Ursache

`requireAuth` setzt für **Session- und Token-Auth** einheitlich `req.authUserId`. Token-Requests besitzen aber kein `req.session`, daher ist `req.session.userId` `undefined`. INSERTs mit `NOT NULL created_by` brechen dadurch mit einem Constraint-Fehler → 500.

Das war ein **systemisches** Problem über mehrere Routes hinweg, nicht nur Budget.

## Fix

Betroffene Routes lesen nun `req.authUserId || req.session.userId` — konsistent mit der bereits etablierten Konvention der übrigen Routen (`reminders`, `birthdays`, `dashboard`, `documents`, `split-expenses`, `housekeeping`):

- `budget.js` (Loans, Loan-Payments, Entries)
- `notes.js`, `tasks.js`, `shopping.js`, `meals.js`, `recipes.js` (inkl. Authorization-Checks), `search.js`

## Test

Neuer Source-Guard `test:auth-userid` stellt sicher, dass keine Route bare `req.session.userId` ohne `req.authUserId`-Fallback verwendet. Verifiziert: schlägt fehl bei Regression, besteht mit Fix. Restliche Suite grün (einziger Fehlschlag ist der vorbestehende, datumsabhängige Dashboard-Test #230, unabhängig von dieser Änderung).

Fixes #270

🤖 Generated with [Claude Code](https://claude.com/claude-code)