### PR TITLE
Add JSDoc type annotations to theme-init.js

### DIFF
--- a/public/theme-init.js
+++ b/public/theme-init.js
@@ -1,3 +1,9 @@
+/**
+ * Initializes the theme based on stored user preference.
+ * Reads the 'oikos-theme' value from localStorage and applies the
+ * corresponding 'data-theme' attribute to the document element.
+ * If no valid value is found, the attribute is removed.
+ */
 (function() {
   var stored = localStorage.getItem('oikos-theme');
   if (stored === 'dark') {


### PR DESCRIPTION
## 问题背景
The theme initialization function in `public/theme-init.js` was missing type annotations, which could hinder code documentation and reduce tooling support in JavaScript environments. Adding JSDoc comments improves readability and enables better editor integration.

## 修改内容
Added JSDoc comments to describe the function's purpose, behavior, and localStorage usage, following the project's existing code style.

## 验证方式
Reviewed the added comments for accuracy and consistency. No functional changes were made, ensuring the code behavior remains unchanged.