### PR TITLE
test(dashboard): fix flaky #230 test failing in early-UTC CI runs

### DIFF
--- a/test/test-dashboard.js
+++ b/test/test-dashboard.js
@@ -343,6 +343,10 @@ function insertEvent(fields) {
 const isoIn = (ms) => new Date(Date.now() + ms).toISOString().slice(0, 19);
 const HOUR = 3600000;
 const DAY = 24 * HOUR;
+// Tagesbeginn heute (UTC). Robust gegen die Tageszeit: ein Event hier ist immer
+// "heute" und nie in der Zukunft, anders als now-Nh (rollt nach Mitternacht UTC
+// auf gestern und macht den fromToday-Test #230 flaky).
+const todayStartIso = () => `${new Date().toISOString().slice(0, 10)}T00:00:00`;
 
 // Wiederkehrender Wochentermin, dessen Master-Start 14 Tage in der Vergangenheit liegt.
 // Die nächste Instanz liegt in 7 Tagen relativ zum Master, also innerhalb des Fensters.
@@ -359,7 +363,7 @@ const recurId = insertEvent({
 insertEvent({ title: 'Past one-off', start_datetime: isoIn(-2 * DAY), created_by: cuTheo });
 
 // Termin von heute Morgen (Vergangenheit, aber noch heute) -> bei fromToday erscheinen.
-insertEvent({ title: 'Morning Meeting Today', start_datetime: isoIn(-3 * HOUR), created_by: cuTheo });
+insertEvent({ title: 'Morning Meeting Today', start_datetime: todayStartIso(), created_by: cuTheo });
 
 // Nicht-wiederkehrender Termin in der Zukunft -> erscheint.
 insertEvent({ title: 'Theodore Soccer Game', start_datetime: isoIn(3 * DAY), created_by: cuTheo });


### PR DESCRIPTION
## Problem

CI (run on the v0.63.7 release commit) failed on the dashboard test for #230:

> `getUpcomingEvents: fromToday=true zeigt heutige vergangene Termine (Issue #230)` — Heute-Morgen-Termin muss mit fromToday=true erscheinen

The job ran at **00:12 UTC**.

## Root cause

The test created the "earlier today" event with `now - 3h`. When the suite runs shortly after UTC midnight, `now - 3h` falls on **yesterday**, so the event drops out of both the SQL date filter (`DATE(start_datetime) >= today`) and the `fromToday` boundary (`>= todayT00:00:00`) in `getUpcomingEvents`. A pure time-of-day flake — not a product bug.

## Fix

Anchor the event to the **UTC start of today** (`${today}T00:00:00`) instead of `now - 3h`. That value is always "today" and always ≤ now, regardless of the hour. The companion assertions (event must NOT appear without `fromToday`) keep working because start-of-today is still in the past relative to `now`.

All 16 dashboard tests pass; full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)