### PR TITLE
feat(currency): add Kazakhstani Tenge (KZT) (#272)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -549,7 +549,7 @@
       <div class="feat-card reveal reveal-d1">
         <div class="feat-card-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="1" x2="12" y2="23"></line><path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"></path></svg></div>
         <h3 data-t="f_budget_t">Budget Tracking</h3>
-        <p data-t="f_budget_d">Track income and expenses with 15 currency options, recurring entries, loan tracking, and CSV export.</p>
+        <p data-t="f_budget_d">Track income and expenses with 22 currency options, recurring entries, loan tracking, and CSV export.</p>
       </div>
       <div class="feat-card reveal reveal-d2">
         <div class="feat-card-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="7" width="20" height="15" rx="2" ry="2"></rect><polyline points="17 2 12 7 7 2"></polyline></svg></div>
@@ -615,7 +615,7 @@
     <div class="feat-row reverse reveal">
       <div class="feat-info">
         <h3 data-t="f_budget_feat_t">No surprise at the end of the month.</h3>
-        <p data-t="f_budget_feat_d">Track who spent what, split shared costs automatically, and see exactly where the money goes. 15 currencies, recurring entries, loan tracking, and CSV export.</p>
+        <p data-t="f_budget_feat_d">Track who spent what, split shared costs automatically, and see exactly where the money goes. 22 currencies, recurring entries, loan tracking, and CSV export.</p>
       </div>
       <div class="feat-visual">
         <img class="sc" data-light="screenshots/budget-light-desktop.png" data-dark="screenshots/budget-dark-desktop.png" src="screenshots/budget-light-desktop.png" alt="Budget">
@@ -760,14 +760,14 @@ cp .env.example .env
       f_tasks_t:'Everyone knows what needs to be done.', f_tasks_d:"No more 'I forgot.' Shared tasks with deadlines, priorities, subtasks, and recurring schedules. Assign to multiple family members simultaneously with stacked avatar display. Kanban board with one-tap status changes.",
       f_meals_t:'Dinner sorted before anyone asks.', f_meals_d:'From plan to shopping list in one click. Weekly drag-and-drop planner with ingredient lists that exports directly to shopping.',
       f_cal_t:'One calendar for the whole family.', f_cal_d:'Google Calendar, iCloud, Nextcloud — all in one place. Two-way CalDAV sync, public ICS subscriptions, recurring events with yearly support, and file attachments.',
-      f_budget_feat_t:'No surprise at the end of the month.', f_budget_feat_d:'Track who spent what, split shared costs automatically, and see exactly where the money goes. 15 currencies, recurring entries, loan tracking, and CSV export.',
+      f_budget_feat_t:'No surprise at the end of the month.', f_budget_feat_d:'Track who spent what, split shared costs automatically, and see exactly where the money goes. 22 currencies, recurring entries, loan tracking, and CSV export.',
       f_shop_feat_t:'The list everyone actually checks.', f_shop_feat_d:'One shared shopping list for the whole family. Add ingredients from your meal plan in one tap — everyone sees updates in real time, organized by aisle.',
       more_label:'Your Data. Your Private Place', more_title:'Everything your family actually uses.',
       f_shop_t:'Shopping Lists', f_shop_d:'Collaborative lists with aisle categories. Import ingredients directly from your meal plans.',
       f_docs_t:'Documents', f_docs_d:'Upload and manage family files in custom folders with 14 category tags, per-document visibility, and drag-and-drop support.',
       f_recipes_t:'Recipes', f_recipes_d:'Create, duplicate, and scale reusable recipes. Pre-fill meal slots or save any meal as a recipe.',
       f_birthdays_t:'Birthdays', f_birthdays_d:'Birthday tracker with automatic annual calendar events, age display, and customizable reminders.',
-      f_budget_t:'Budget & Split Expenses', f_budget_d:'Track income and expenses with 15 currency options, recurring entries, and loan tracking. Split shared costs in groups with equal, percentage, or exact-amount splits, multi-currency support, and automatic debt simplification.',
+      f_budget_t:'Budget & Split Expenses', f_budget_d:'Track income and expenses with 22 currency options, recurring entries, and loan tracking. Split shared costs in groups with equal, percentage, or exact-amount splits, multi-currency support, and automatic debt simplification.',
       f_notes_t:'Notes', f_notes_d:'Colored sticky notes with Markdown support. Perfect for recipes, family memos, and quick reminders.',
       f_contacts_t:'Contacts', f_contacts_d:'Shared family contact directory with CardDAV sync, vCard import/export, and multi-account support.',
       f_pwa_t:'Works Everywhere', f_pwa_d:'Installable PWA on any device. Offline support, polished mobile navigation, touch-safe controls, dark mode, and responsive layouts from phone to desktop.',
@@ -810,14 +810,14 @@ cp .env.example .env
       f_tasks_t:'Alle wissen, was zu tun ist.', f_tasks_d:'Kein „Hab ich vergessen" mehr. Gemeinsame Aufgaben mit Fristen, Prioritäten, Unteraufgaben und Wiederholungen. Mehrere Mitglieder gleichzeitig zuweisen. Kanban-Board mit Ein-Tipp-Status.',
       f_meals_t:'Das Abendessen ist geplant, bevor jemand fragt.', f_meals_d:'Von der Planung zur Einkaufsliste mit einem Klick. Wöchentlicher Drag-and-Drop-Planer mit Zutatenlisten.',
       f_cal_t:'Ein Kalender für die ganze Familie.', f_cal_d:'Google Calendar, iCloud, Nextcloud — alles an einem Ort. CalDAV-Sync, ICS-Abos, wiederkehrende Termine und Dateianhänge.',
-      f_budget_feat_t:'Keine böse Überraschung am Monatsende.', f_budget_feat_d:'Wer hat was ausgegeben? Gemeinsame Kosten automatisch aufteilen und genau sehen, wohin das Geld fließt. 15 Währungen, wiederkehrende Einträge, Kreditverwaltung und CSV-Export.',
+      f_budget_feat_t:'Keine böse Überraschung am Monatsende.', f_budget_feat_d:'Wer hat was ausgegeben? Gemeinsame Kosten automatisch aufteilen und genau sehen, wohin das Geld fließt. 22 Währungen, wiederkehrende Einträge, Kreditverwaltung und CSV-Export.',
       f_shop_feat_t:'Die Liste, die alle wirklich nutzen.', f_shop_feat_d:'Eine gemeinsame Einkaufsliste für die ganze Familie. Zutaten aus dem Mahlzeitenplan per Tipp hinzufügen — alle sehen Änderungen sofort, sortiert nach Gang.',
       more_label:'Deine Daten. Dein privater Raum', more_title:'Alles, was eure Familie wirklich braucht.',
       f_shop_t:'Einkaufslisten', f_shop_d:'Gemeinsame Listen mit Gang-Kategorien. Zutaten direkt aus Mahlzeitenplänen importieren.',
       f_docs_t:'Dokumente', f_docs_d:'Familiendateien in eigenen Ordnern verwalten, mit 14 Kategorien, individueller Sichtbarkeit und Drag-and-Drop-Upload.',
       f_recipes_t:'Rezepte', f_recipes_d:'Wiederverwendbare Rezepte erstellen, duplizieren und skalieren. Mahlzeiten vorausfüllen oder als Rezept speichern.',
       f_birthdays_t:'Geburtstage', f_birthdays_d:'Geburtstags-Tracker mit automatischen jährlichen Kalendereinträgen, Altersanzeige und konfigurierbaren Erinnerungen.',
-      f_budget_t:'Budget & Ausgaben teilen', f_budget_d:'Einnahmen und Ausgaben verfolgen mit 15 Währungen, wiederkehrenden Einträgen und Kreditverwaltung. Gemeinsame Ausgaben in Gruppen aufteilen — gleich, prozentual oder exakt, mit Multi-Währungs-Support und automatischer Schulden-Vereinfachung.',
+      f_budget_t:'Budget & Ausgaben teilen', f_budget_d:'Einnahmen und Ausgaben verfolgen mit 22 Währungen, wiederkehrenden Einträgen und Kreditverwaltung. Gemeinsame Ausgaben in Gruppen aufteilen — gleich, prozentual oder exakt, mit Multi-Währungs-Support und automatischer Schulden-Vereinfachung.',
       f_notes_t:'Notizen', f_notes_d:'Farbige Haftnotizen mit Markdown-Support. Perfekt für Rezepte, Familien-Memos und schnelle Erinnerungen.',
       f_contacts_t:'Kontakte', f_contacts_d:'Gemeinsames Familien-Kontaktverzeichnis mit CardDAV-Sync, vCard-Import/-Export und Multi-Account-Support.',
       f_pwa_t:'Überall nutzbar', f_pwa_d:'Installierbare PWA auf jedem Gerät. Offline-Support, optimierte mobile Navigation, touch-sichere Controls, Dark Mode und responsive Layouts vom Handy bis Desktop.',

--- a/public/pages/settings.js
+++ b/public/pages/settings.js
@@ -13,7 +13,7 @@ import { renderSubTabs } from '/utils/sub-tabs.js';
 import '/components/oikos-locale-picker.js';
 import { getPwaInstallState, onPwaInstallStateChanged, promptPwaInstall } from '/utils/pwa-install.js';
 
-const SUPPORTED_CURRENCIES = ['AED', 'AUD', 'BRL', 'CAD', 'CHF', 'CNY', 'CZK', 'DKK', 'EUR', 'GBP', 'HUF', 'INR', 'JPY', 'NOK', 'PLN', 'RUB', 'SAR', 'SEK', 'TRY', 'UAH', 'USD'];
+const SUPPORTED_CURRENCIES = ['AED', 'AUD', 'BRL', 'CAD', 'CHF', 'CNY', 'CZK', 'DKK', 'EUR', 'GBP', 'HUF', 'INR', 'JPY', 'KZT', 'NOK', 'PLN', 'RUB', 'SAR', 'SEK', 'TRY', 'UAH', 'USD'];
 const SETTINGS_TAB_KEY = 'oikos:settings:tab';
 const APP_NAME_STORAGE_KEY = 'oikos-app-name';
 const DEFAULT_APP_NAME = 'Oikos';

--- a/server/routes/preferences.js
+++ b/server/routes/preferences.js
@@ -16,7 +16,7 @@ const router = express.Router();
 const VALID_MEAL_TYPES = ['breakfast', 'lunch', 'dinner', 'snack'];
 const DEFAULT_MEAL_TYPES = VALID_MEAL_TYPES.join(',');
 
-const VALID_CURRENCIES = ['AED', 'AUD', 'BRL', 'CAD', 'CHF', 'CNY', 'CZK', 'DKK', 'EUR', 'GBP', 'HUF', 'INR', 'JPY', 'NOK', 'PLN', 'RUB', 'SAR', 'SEK', 'TRY', 'UAH', 'USD'];
+const VALID_CURRENCIES = ['AED', 'AUD', 'BRL', 'CAD', 'CHF', 'CNY', 'CZK', 'DKK', 'EUR', 'GBP', 'HUF', 'INR', 'JPY', 'KZT', 'NOK', 'PLN', 'RUB', 'SAR', 'SEK', 'TRY', 'UAH', 'USD'];
 const DEFAULT_CURRENCY = 'EUR';
 const DEFAULT_APP_NAME = 'Oikos';
 

--- a/server/routes/split-expenses.js
+++ b/server/routes/split-expenses.js
@@ -19,7 +19,7 @@ const GROUP_TYPES = ['household', 'couple', 'travel', 'event', 'shopping', 'gene
 const GROUP_ROLES = ['owner', 'admin', 'guest'];
 const SPLIT_METHODS = ['equal', 'exact', 'percentage', 'shares'];
 const CATEGORIES = ['groceries', 'rent', 'utilities', 'baby', 'pets', 'school', 'travel', 'shopping', 'subscriptions', 'health', 'home', 'general'];
-const CURRENCIES = ['AED', 'AUD', 'BRL', 'CAD', 'CHF', 'CNY', 'CZK', 'DKK', 'EUR', 'GBP', 'HUF', 'INR', 'JPY', 'NOK', 'PLN', 'RUB', 'SAR', 'SEK', 'TRY', 'UAH', 'USD'];
+const CURRENCIES = ['AED', 'AUD', 'BRL', 'CAD', 'CHF', 'CNY', 'CZK', 'DKK', 'EUR', 'GBP', 'HUF', 'INR', 'JPY', 'KZT', 'NOK', 'PLN', 'RUB', 'SAR', 'SEK', 'TRY', 'UAH', 'USD'];
 const FREQUENCIES = ['weekly', 'monthly', 'yearly'];
 const FAMILY_ROLES = ['dad', 'mom', 'parent', 'child', 'grandparent', 'relative', 'other'];
 


### PR DESCRIPTION
Closes #272 (requested by @cartoonsss in #270).

## What

Adds **Kazakhstani Tenge (KZT 🇰🇿)** to the supported currencies:

- `server/routes/split-expenses.js` — `CURRENCIES` (Split Expenses groups/expenses)
- `server/routes/preferences.js` — `VALID_CURRENCIES` (global household currency)
- `public/pages/settings.js` — `SUPPORTED_CURRENCIES` (settings dropdown)

Inserted alphabetically between JPY and NOK. Currency display names come from `Intl.DisplayNames` and minor units from the existing `CURRENCY_MINOR_UNITS` map (KZT = 2 decimals, the default), so no label keys or rounding changes are required.

## Docs

Corrected the landing page (`docs/index.html`) currency count from "15" to "22" — it was already stale versus the actual list (21 before this change).

## Tests

`test:split-expenses` and `test:frontend-audit` pass; full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)