### PR TITLE
Umbrel: fix linter (port/gallery) + in-place update workflow

### DIFF
--- a/.github/workflows/umbrel-publish.yml
+++ b/.github/workflows/umbrel-publish.yml
@@ -10,6 +10,10 @@ name: Umbrel Catalog Publish
 #   - The fork <owner>/umbrel-apps must exist (created during the initial submission).
 #   - Only acts once Oikos is already in upstream master (after the initial
 #     submission PR is merged); before that it skips to avoid re-submitting.
+#
+# It edits the maintainers' upstream files IN PLACE (version, releaseNotes,
+# image digest) — it never overwrites them with our source, so any review tweaks
+# (port, gallery, category, …) are preserved across updates.
 
 on:
   release:
@@ -31,11 +35,6 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout (Umbrel source under deploy/umbrel)
-        uses: actions/checkout@v6
-        with:
-          ref: main
-
       - name: Resolve version
         id: ver
         env:
@@ -86,56 +85,22 @@ jobs:
           echo "::error::image $IMG not found after ~20 min — did Docker Publish run?"
           exit 1
 
-      - name: Build updated app files
-        env:
-          RELEASE_BODY: ${{ github.event.release.body }}
-        run: |
-          set -euo pipefail
-          V="${{ steps.ver.outputs.version }}"
-          D="${{ steps.digest.outputs.digest }}"
-          OWNER="${{ github.repository_owner }}"
-          mkdir -p out/oikos
-          cp deploy/umbrel/umbrel-app.yml out/oikos/umbrel-app.yml
-          cp deploy/umbrel/docker-compose.yml out/oikos/docker-compose.yml
-
-          # version
-          sed -i -E "s|^version: .*|version: \"$V\"|" out/oikos/umbrel-app.yml
-          # image tag + pinned digest
-          sed -i -E "s|image: ghcr.io/$OWNER/oikos:[^@]+@sha256:[0-9a-f]+|image: ghcr.io/$OWNER/oikos:$V@$D|" out/oikos/docker-compose.yml
-
-          # releaseNotes from the GitHub release body (JSON-encoded string is valid YAML;
-          # handles arbitrary multi-line markdown safely)
-          python3 - <<'PY'
-          import json, os, re
-          body = os.environ.get("RELEASE_BODY", "").strip()
-          path = "out/oikos/umbrel-app.yml"
-          with open(path) as f:
-              text = f.read()
-          text = re.sub(r"^releaseNotes:.*$",
-                        "releaseNotes: " + json.dumps(body),
-                        text, count=1, flags=re.M)
-          with open(path, "w") as f:
-              f.write(text)
-          PY
-
-          echo "--- umbrel-app.yml (version/releaseNotes) ---"
-          grep -E '^(version|releaseNotes):' out/oikos/umbrel-app.yml
-          echo "--- docker-compose.yml (image) ---"
-          grep 'image:' out/oikos/docker-compose.yml
-
       - name: Open / update PR on getumbrel/umbrel-apps
         env:
           GH_TOKEN: ${{ secrets.UMBREL_FORK_TOKEN }}
+          RELEASE_BODY: ${{ github.event.release.body }}
+          VERSION: ${{ steps.ver.outputs.version }}
+          DIGEST: ${{ steps.digest.outputs.digest }}
+          OWNER: ${{ github.repository_owner }}
+          ACTOR: ${{ github.actor }}
         run: |
           set -euo pipefail
-          V="${{ steps.ver.outputs.version }}"
-          OWNER="${{ github.repository_owner }}"
           FORK="$OWNER/umbrel-apps"
           UPSTREAM="getumbrel/umbrel-apps"
           BRANCH="oikos-update"
 
           git config --global user.name "$OWNER"
-          git config --global user.email "${{ github.actor }}@users.noreply.github.com"
+          git config --global user.email "$ACTOR@users.noreply.github.com"
 
           gh repo fork "$UPSTREAM" --clone=false || true
 
@@ -145,32 +110,46 @@ jobs:
           git fetch --depth 1 upstream master
           git checkout -B "$BRANCH" upstream/master
 
-          # Guard: only update once Oikos is already accepted upstream. Before the
-          # initial submission is merged, rebuilding from master would re-submit the
-          # whole app — skip instead.
+          # Guard: only update once Oikos is already in upstream master. Before the
+          # initial submission is merged there is nothing to edit — skip.
           if [ ! -f oikos/umbrel-app.yml ]; then
             echo "::notice::Oikos is not yet in upstream master (initial submission still pending). Skipping auto-update."
             exit 0
           fi
 
-          cp ../out/oikos/umbrel-app.yml oikos/umbrel-app.yml
-          cp ../out/oikos/docker-compose.yml oikos/docker-compose.yml
+          # Edit the maintainers' files IN PLACE — never overwrite them with our
+          # source, so their port / gallery / category / review tweaks are preserved.
+          sed -i -E "s|^version: .*|version: \"$VERSION\"|" oikos/umbrel-app.yml
+          sed -i -E "s|image: ghcr.io/$OWNER/oikos:[^@[:space:]]+@sha256:[0-9a-f]+|image: ghcr.io/$OWNER/oikos:$VERSION@$DIGEST|" oikos/docker-compose.yml
+          # releaseNotes from the GitHub release body (JSON-encoded string is valid YAML)
+          python3 - <<'PY'
+          import json, os, re
+          body = os.environ.get("RELEASE_BODY", "").strip()
+          p = "oikos/umbrel-app.yml"
+          t = open(p).read()
+          t = re.sub(r"^releaseNotes:.*$", "releaseNotes: " + json.dumps(body), t, count=1, flags=re.M)
+          open(p, "w").write(t)
+          PY
+
+          echo "--- updated ---"
+          grep -E '^(version|releaseNotes):' oikos/umbrel-app.yml
+          grep 'image:' oikos/docker-compose.yml
 
           if git diff --quiet -- oikos/; then
-            echo "Catalog already at v$V — nothing to do."
+            echo "Catalog already at v$VERSION — nothing to do."
             exit 0
           fi
 
           git add oikos/
-          git commit -m "oikos: update to v$V"
+          git commit -m "oikos: update to v$VERSION"
           git push --force origin "$BRANCH"
 
           EXISTING="$(gh pr list --repo "$UPSTREAM" --head "$OWNER:$BRANCH" --state open --json number -q '.[0].number' 2>/dev/null || true)"
           if [ -z "$EXISTING" ]; then
             gh pr create --repo "$UPSTREAM" --base master --head "$OWNER:$BRANCH" \
-              --title "oikos: update to v$V" \
-              --body "Automated update of Oikos to v$V (multi-arch image pinned by digest). Source: https://github.com/$OWNER/oikos/releases/tag/v$V"
+              --title "oikos: update to v$VERSION" \
+              --body "Automated update of Oikos to v$VERSION (multi-arch image pinned by digest). Source: https://github.com/$OWNER/oikos/releases/tag/v$VERSION"
           else
-            echo "PR #$EXISTING already open — force-push updated it to v$V."
-            gh pr edit "$EXISTING" --repo "$UPSTREAM" --title "oikos: update to v$V" || true
+            echo "PR #$EXISTING already open — force-push updated it to v$VERSION."
+            gh pr edit "$EXISTING" --repo "$UPSTREAM" --title "oikos: update to v$VERSION" || true
           fi

--- a/deploy/umbrel/README.md
+++ b/deploy/umbrel/README.md
@@ -1,41 +1,44 @@
 # Oikos — Umbrel App Store source
 
-This folder is the **tracked source** for Oikos in the official Umbrel App Store
-([`getumbrel/umbrel-apps`](https://github.com/getumbrel/umbrel-apps)). The files
-here (`umbrel-app.yml`, `docker-compose.yml`) are copied verbatim into
-`umbrel-apps/oikos/` when opening or updating the submission PR.
+This folder is the **tracked source** for the Oikos entry in the official Umbrel
+App Store ([`getumbrel/umbrel-apps`](https://github.com/getumbrel/umbrel-apps)).
+The initial submission was opened as `getumbrel/umbrel-apps#5732` (manifest +
+compose only — Umbrel's app folder holds no images).
 
 Unlike TrueNAS (whose `truenasbot` Renovate bot auto-bumps the catalog from the
-GHCR image), **Umbrel has no auto-update bot for third-party apps**. Every Oikos
-release that should reach Umbrel needs a **manual PR** to `getumbrel/umbrel-apps`
-that bumps `version`, fills `releaseNotes`, and updates the pinned image digest.
+GHCR image), **Umbrel has no auto-update bot for third-party apps**. We replace
+that with our own workflow.
 
-## Per-release update checklist
+## Releases are automated
 
-1. Get the new multi-arch index digest after the image is published:
-   ```bash
-   docker buildx imagetools inspect ghcr.io/ulsklyc/oikos:<version>
-   # use the top-level `Digest:` (the OCI image index), not a per-arch one
-   ```
-2. In `umbrel-app.yml`: bump `version`, write `releaseNotes`.
-3. In `docker-compose.yml`: update the `web.image` tag **and** `@sha256:` digest.
-4. Copy both files into a fork of `getumbrel/umbrel-apps` under `oikos/`, open a PR,
-   fill the testing checklist, and paste the PR URL back into `submission:`.
+`.github/workflows/umbrel-publish.yml` runs on `release: published`. It resolves
+the new multi-arch index digest and opens/updates a single rolling `oikos-update`
+PR to `getumbrel/umbrel-apps`, editing the maintainers' upstream files **in
+place** (`version`, `releaseNotes` from the release body, `@sha256` image digest)
+so any review tweaks (port, gallery, category) are preserved. It needs the
+`UMBREL_FORK_TOKEN` secret and stays dormant until #5732 is merged.
+
+Manual fallback (if you ever need it): run the workflow via `workflow_dispatch`,
+or get the digest with
+`docker buildx imagetools inspect ghcr.io/ulsklyc/oikos:<version>` (top-level
+`Digest:`) and bump `version`/`@sha256:` in a fork PR by hand.
 
 ## Config notes (why the compose looks like this)
 
 - **`app_proxy`** is mandatory. Oikos has its own login, so `PROXY_AUTH_ADD: "false"`
   prevents a double sign-in. `APP_PORT: 3000` is where Oikos listens inside the
-  container; the manifest `port:` (currently `8090`) is the external port Umbrel
-  assigns — reviewers may change it to avoid conflicts.
+  container; the manifest `port:` is `8181` — a free port (the linter rejects
+  collisions; 8090 was taken by Urbit). Reviewers may still reassign it.
 - **`SESSION_SECRET=${APP_SEED}`** — Umbrel provides a deterministic per-app secret,
   so no interactive installer step is needed.
 - **No `user:` override** — the image entrypoint runs as root only to chown the
   volumes, then drops to the unprivileged `node` user. The app never serves as root.
+  (The linter flags this as info-level only.)
 - **`SESSION_SECURE=false`** — Umbrel serves apps over plain HTTP on the LAN.
-- Assets still to add to the store PR: a 256×256 SVG icon (no rounded corners) and
-  3–5 gallery images at 1440×900 (`1.jpg`, `2.jpg`, `3.jpg`). The TrueNAS
-  screenshots can be reused after reformatting.
+- **`gallery` and icon:** the manifest `gallery` field must be **empty** for
+  submission — the Umbrel team populates it. The assets themselves (256×256 square
+  `icon.svg` + five 1440×900 screenshots in `gallery/`) were submitted to the
+  gallery repo as `getumbrel/umbrel-apps-gallery#90`.
 
 ## Local testing before submitting
 

--- a/deploy/umbrel/umbrel-app.yml
+++ b/deploy/umbrel/umbrel-app.yml
@@ -56,13 +56,10 @@ website: https://github.com/ulsklyc/oikos
 dependencies: []
 repo: https://github.com/ulsklyc/oikos
 support: https://github.com/ulsklyc/oikos/issues
-port: 8090
-gallery:
-  - 1.jpg
-  - 2.jpg
-  - 3.jpg
-  - 4.jpg
-  - 5.jpg
+port: 8181
+# Must stay empty for submission — the Umbrel team populates icon/gallery from
+# the assets in umbrel-apps-gallery (see deploy/umbrel/icon.svg + gallery/).
+gallery: []
 path: ""
 defaultUsername: ""
 defaultPassword: ""


### PR DESCRIPTION
Follow-up to #278 after the umbrel-apps linter ran on getumbrel/umbrel-apps#5732.

## Linter fixes (already applied to #5732, mirrored here)
- **Port 8090 → 8181** — 8090 collides with Urbit; 8181 is free (verified against all 356 manifest ports). Blocking error.
- **`gallery: []`** — the manifest gallery field must be empty for new submissions; the Umbrel team populates icon/gallery from `umbrel-apps-gallery` (assets submitted in umbrel-apps-gallery#90). Warning.
- Remaining linter notes (mount dirs absent, default user root) are info-level; the entrypoint already drops to `node` (uid 1000).

## Workflow correctness fix
`umbrel-publish.yml` previously **copied our source manifest over the upstream file**, which would clobber the maintainers' port/gallery/category on every update. Reworked to edit the upstream files **in place** (`version`, `releaseNotes`, `@sha256` digest only). Dropped the now-unneeded checkout + build steps; inputs passed via `env`. YAML validated.