### PR TITLE
fix: restrict glass hover effect to bottom nav only

### DIFF
--- a/public/styles/glass.css
+++ b/public/styles/glass.css
@@ -40,9 +40,9 @@
   box-shadow: inset 0 1px 0 var(--glass-highlight-subtle);
 }
 
-/* Hover-State auf Desktop */
+/* Hover-State Bottom-Nav (nur sichtbar auf Mobile) */
 @media (hover: hover) {
-  .nav-item:hover:not([aria-current="page"]) {
+  .nav-bottom .nav-item:hover:not([aria-current="page"]) {
     background: color-mix(in srgb, var(--color-text-tertiary) 8%, transparent);
     border-radius: var(--radius-glass-chip);
   }


### PR DESCRIPTION
## Summary

- The `glass.css` hover rule `.nav-item:hover:not([aria-current="page"])` applied globally, including sidebar nav items on desktop
- It set `border-radius: var(--radius-glass-chip)` (= `border-radius: full`, pill shape) which overrode the sidebar's expected `--radius-sm` (8px)
- The `layout.css` sidebar hover rule had higher specificity and correctly overrode `background-color`, but did not reset `border-radius` — leaving sidebar items with an unintended pill shape on hover

**Fix:** narrow the `glass.css` selector from `.nav-item` to `.nav-bottom .nav-item`. Since `.nav-bottom` is hidden on desktop via `display: none` at ≥1024px, this selector never affected sidebar styling — the restriction is purely correct.

Fixes #286

## Test plan

- [ ] Hover over inactive sidebar nav items on desktop (≥1024px) — background highlight should be `var(--color-surface-3)` with `border-radius: 8px` (no pill shape)
- [ ] Hover over bottom nav items on mobile with a pointer device — glass semi-transparent background + pill shape still applies
- [ ] `npm run test:frontend-audit` passes (57/57)

🤖 Generated with [Claude Code](https://claude.com/claude-code)