### PR TITLE
fix: add touch-action pan-y to app-content to prevent Android PWA scroll freeze

### DIFF
--- a/public/styles/layout.css
+++ b/public/styles/layout.css
@@ -135,6 +135,7 @@
   overflow-y: auto;
   overflow-x: hidden;
   overscroll-behavior-y: contain;
+  touch-action: pan-y;
   -webkit-overflow-scrolling: touch;
   padding-top: var(--offline-banner-height, 0px);
   transition: padding-top 0.2s ease;


### PR DESCRIPTION
## Summary

- Adds `touch-action: pan-y` to `.app-content` in `layout.css` to explicitly declare vertical panning intent to Android Chrome
- Without this, a touch gesture starting on a non-scrollable element (card header, separator) could be propagated to the body and terminated by `overflow: hidden` + `overscroll-behavior: none`, locking the entire touch sequence
- `touch-action: pan-y` is already the established pattern in this codebase (used 6× in `dashboard.css`)

Closes #291

## Test plan

- [ ] All existing tests pass (`npm run test:mobile-scroll-layout`, `npm run test:frontend-audit`)
- [ ] Manual: open app as PWA on Android, scroll from card headers/separators — no freeze

🤖 Generated with [Claude Code](https://claude.com/claude-code)