### PR TITLE
fix: remove opacity from note-card footer to prevent avatar tinting

### DIFF
--- a/public/styles/notes.css
+++ b/public/styles/notes.css
@@ -185,7 +185,7 @@
   margin-top: var(--space-2);
   padding-top: var(--space-2);
   border-top: 1px solid currentColor;
-  opacity: 0.55;
+  color: color-mix(in srgb, currentColor 55%, transparent);
 }
 
 .note-card__creator {


### PR DESCRIPTION
## Summary

- Replaces `opacity: 0.55` on `.note-card__footer` with `color: color-mix(in srgb, currentColor 55%, transparent)`
- CSS opacity cascades to all descendants and cannot be overridden by children, causing avatar images and background-colors to appear tinted with the note card's background color
- Using `color-mix` on the `color` property mutes the border (`currentColor`) and text (`color: inherit`) without affecting the avatar's `background-color` or image opacity

Closes #287

## Test plan

- [ ] Open Notes module
- [ ] Create a note with a bright background color (yellow, green, red)
- [ ] Verify the creator avatar shows its actual color without background tinting
- [ ] Verify border and creator name still appear muted/subtle
- [ ] Verify delete button icon still appears muted

🤖 Generated with [Claude Code](https://claude.com/claude-code)