### PR TITLE
feat: display assigned user avatars on dashboard calendar widget (fixes #284)

### DIFF
--- a/public/pages/dashboard.js
+++ b/public/pages/dashboard.js
@@ -461,6 +461,7 @@ function renderUpcomingEvents(events) {
             ${e.cal_name ? `<span class="event-item__cal">${esc(e.cal_name)}</span>` : ''}
           </div>
         </div>
+        ${renderAvatarStack(e.assigned_users ?? [], { size: 26 })}
       </div>
     `;
   }).join('');

--- a/public/styles/dashboard.css
+++ b/public/styles/dashboard.css
@@ -627,7 +627,7 @@
  * -------------------------------------------------------- */
 .event-item {
   display: flex;
-  align-items: stretch;
+  align-items: center;
   gap: var(--space-2);
   padding: var(--space-2) 0;
   border-bottom: 1px solid var(--color-border-subtle);
@@ -646,6 +646,7 @@
 
 .event-item__bar {
   width: 3px;
+  align-self: stretch;
   border-radius: var(--radius-full);
   flex-shrink: 0;
   background-color: var(--color-accent);
@@ -655,6 +656,12 @@
 .event-item__content {
   flex: 1;
   min-width: 0;
+}
+
+.event-item .avatar-stack {
+  flex-shrink: 0;
+  margin-left: auto;
+  padding-left: var(--space-1);
 }
 
 .event-item__title {

--- a/server/routes/dashboard.js
+++ b/server/routes/dashboard.js
@@ -60,7 +60,10 @@ router.get('/', (req, res) => {
   // sodass auch Termine erscheinen, deren Master-Start in der Vergangenheit liegt.
   try {
     result.upcomingEvents = getUpcomingEvents(d, { userId, limit: 5, fromToday: true })
-      .map(({ assigned_users_json, ...event }) => event);
+      .map(({ assigned_users_json, ...event }) => {
+        event.assigned_users = assigned_users_json ? JSON.parse(assigned_users_json) : [];
+        return event;
+      });
   } catch (err) {
     log.error('upcomingEvents error:', err.message);
     result.upcomingEvents = [];

--- a/server/services/calendar-events.js
+++ b/server/services/calendar-events.js
@@ -10,7 +10,8 @@ import { nextOccurrence } from './recurrence.js';
 // Zugewiesene Personen eines Events als JSON-Array (Multi-Assignment).
 const ASSIGNED_USERS_SQL = `(
   SELECT json_group_array(json_object(
-    'id', u.id, 'display_name', u.display_name, 'color', u.avatar_color
+    'id', u.id, 'display_name', u.display_name, 'color', u.avatar_color,
+    'avatar_data', u.avatar_data
   ))
   FROM event_assignments ea JOIN users u ON u.id = ea.user_id
   WHERE ea.event_id = e.id

--- a/test/test-dashboard.js
+++ b/test/test-dashboard.js
@@ -73,10 +73,14 @@ db.prepare(`INSERT INTO tasks (title, priority, status, due_date, created_by)
   VALUES ('Done Task', 'urgent', 'done', ?, ?)`).run(today, uid1);
 
 // Kalender-Events
-db.prepare(`INSERT INTO calendar_events (title, start_datetime, created_by, assigned_to, color)
+const evMeeting = db.prepare(`INSERT INTO calendar_events (title, start_datetime, created_by, assigned_to, color)
   VALUES ('Morgen-Meeting', ?, ?, ?, '#007AFF')`).run(inOneHour, uid1, uid2);
 db.prepare(`INSERT INTO calendar_events (title, start_datetime, created_by)
   VALUES ('Event in 3 Tagen', ?, ?)`).run(in72h + 'T10:00:00Z', uid1);
+
+// Multi-Assignments für Morgen-Meeting (uid1 + uid2 sind zugewiesen)
+db.prepare(`INSERT INTO event_assignments (event_id, user_id) VALUES (?, ?)`).run(evMeeting.lastInsertRowid, uid1);
+db.prepare(`INSERT INTO event_assignments (event_id, user_id) VALUES (?, ?)`).run(evMeeting.lastInsertRowid, uid2);
 
 // Mahlzeiten
 db.prepare(`INSERT INTO meals (date, meal_type, title, created_by)
@@ -188,6 +192,36 @@ test('Anstehende Termine: zukünftige Events, sortiert, max 5', () => {
   assert(events[0].assigned_color === '#34C759', 'assigned_color vom Join');
 });
 
+test('Anstehende Termine: Dashboard-Mapping erzeugt assigned_users Array (Issue #284)', () => {
+  // Testet die Mapping-Logik direkt mit Mock-Daten (ohne SQL).
+  const mockRaw = [
+    {
+      id: 1, title: 'Morgen-Meeting',
+      assigned_users_json: JSON.stringify([
+        { id: 1, display_name: 'Anna Admin', color: '#007AFF', avatar_data: null },
+        { id: 2, display_name: 'Max Muster', color: '#34C759', avatar_data: null },
+      ]),
+    },
+    { id: 2, title: 'Solo Event', assigned_users_json: null },
+  ];
+
+  const upcomingEvents = mockRaw.map(({ assigned_users_json, ...event }) => {
+    event.assigned_users = assigned_users_json ? JSON.parse(assigned_users_json) : [];
+    return event;
+  });
+
+  const meeting = upcomingEvents[0];
+  assert(!('assigned_users_json' in meeting), 'assigned_users_json darf nicht im Ergebnis sein');
+  assert(Array.isArray(meeting.assigned_users), 'assigned_users muss ein Array sein');
+  assert(meeting.assigned_users.length === 2, `Erwartet 2 Einträge, erhalten ${meeting.assigned_users.length}`);
+  assert(meeting.assigned_users[0].display_name === 'Anna Admin', 'Erster User ist Anna Admin');
+  assert('avatar_data' in meeting.assigned_users[0], 'avatar_data muss im User-Objekt enthalten sein');
+
+  const solo = upcomingEvents[1];
+  assert(Array.isArray(solo.assigned_users) && solo.assigned_users.length === 0,
+    'Event ohne Zuweisung hat leeres assigned_users Array');
+});
+
 // --------------------------------------------------------
 // Tests: Heutige Mahlzeiten
 // --------------------------------------------------------
@@ -294,7 +328,8 @@ cdb.exec(`
   CREATE TABLE users (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     username TEXT UNIQUE NOT NULL, display_name TEXT NOT NULL,
-    password_hash TEXT NOT NULL, avatar_color TEXT NOT NULL DEFAULT '#007AFF'
+    password_hash TEXT NOT NULL, avatar_color TEXT NOT NULL DEFAULT '#007AFF',
+    avatar_data TEXT
   );
   CREATE TABLE external_calendars (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -366,7 +401,10 @@ insertEvent({ title: 'Past one-off', start_datetime: isoIn(-2 * DAY), created_by
 insertEvent({ title: 'Morning Meeting Today', start_datetime: todayStartIso(), created_by: cuTheo });
 
 // Nicht-wiederkehrender Termin in der Zukunft -> erscheint.
-insertEvent({ title: 'Theodore Soccer Game', start_datetime: isoIn(3 * DAY), created_by: cuTheo });
+// Beiden Nutzern (Theo + Sofia) zugewiesen – für Issue #284 (assigned_users im Dashboard).
+const soccerId = insertEvent({ title: 'Theodore Soccer Game', start_datetime: isoIn(3 * DAY), created_by: cuTheo });
+cdb.prepare(`INSERT INTO event_assignments (event_id, user_id) VALUES (?, ?)`).run(soccerId, cuTheo);
+cdb.prepare(`INSERT INTO event_assignments (event_id, user_id) VALUES (?, ?)`).run(soccerId, cuSofia);
 
 test('getUpcomingEvents: wiederkehrender Termin mit Vergangenheits-Start erscheint (Issue #224)', () => {
   const events = getUpcomingEvents(cdb, { userId: cuTheo, limit: 10 });
@@ -398,6 +436,34 @@ test('getUpcomingEvents: zukünftige Termine sortiert und auf limit begrenzt', (
   }
   const limited = getUpcomingEvents(cdb, { userId: cuTheo, limit: 1 });
   assert(limited.length === 1, `limit=1 liefert genau 1 Event, erhalten ${limited.length}`);
+});
+
+test('getUpcomingEvents: assigned_users_json enthält avatar_data (Issue #284)', () => {
+  const events = getUpcomingEvents(cdb, { userId: cuTheo, limit: 10 });
+  const soccer = events.find((e) => e.title === 'Theodore Soccer Game');
+  assert(soccer, 'Theodore Soccer Game muss erscheinen');
+  assert('assigned_users_json' in soccer, 'assigned_users_json muss im rohen Event enthalten sein');
+  const users = JSON.parse(soccer.assigned_users_json);
+  assert(Array.isArray(users) && users.length === 2,
+    `Erwartet 2 zugewiesene User, erhalten ${users.length}`);
+  assert(users.every((u) => 'avatar_data' in u),
+    'Jeder User im assigned_users_json muss avatar_data enthalten');
+  const theo  = users.find((u) => u.display_name === 'Theodore');
+  const sofia = users.find((u) => u.display_name === 'Sofia');
+  assert(theo,  'Theodore muss in assigned_users sein');
+  assert(sofia, 'Sofia muss in assigned_users sein');
+});
+
+test('getUpcomingEvents: Event ohne Assignments hat leeres assigned_users_json Array (Issue #284)', () => {
+  const events = getUpcomingEvents(cdb, { userId: cuTheo, limit: 10 });
+  const morning = events.find((e) => e.title === 'Morning Meeting Today');
+  // Morning Meeting Today wurde ohne event_assignments eingefügt.
+  const mornEvents = getUpcomingEvents(cdb, { userId: cuTheo, limit: 10, fromToday: true });
+  const mm = mornEvents.find((e) => e.title === 'Morning Meeting Today');
+  assert(mm, 'Morning Meeting Today mit fromToday=true vorhanden');
+  const users = JSON.parse(mm.assigned_users_json ?? '[]');
+  assert(Array.isArray(users) && users.length === 0,
+    'Event ohne Zuweisung hat leeres assigned_users_json Array');
 });
 
 test('getUpcomingEvents: private ICS-Termine fremder User werden ausgeblendet', () => {


### PR DESCRIPTION
## Summary

Closes #284

Displays the assigned users' avatars on the **Upcoming Events** (Calendar) widget on the dashboard  consistent with the existing Tasks widget behaviour.

## Changes

### Backend
- **server/services/calendar-events.js**: Added avatar_data to the ASSIGNED_USERS_SQL subquery so avatar images are included in the event payload.
- **server/routes/dashboard.js**: Parse assigned_users_json into an assigned_users array (instead of discarding it) before sending events to the client.

### Frontend
- **public/pages/dashboard.js**: 
enderUpcomingEvents now calls 
enderAvatarStack(e.assigned_users ?? [], { size: 26 }) at the right-hand side of each event card  reusing the same component already used by the Tasks widget.
- **public/styles/dashboard.css**: Updated .event-item to align-items: center and added .event-item .avatar-stack alignment rules so the avatar stack is flush to the right edge.

### Tests
- **	test/test-dashboard.js**: 3 new tests covering Issue #284:
  - Dashboard mapping produces assigned_users array from JSON
  - getUpcomingEvents returns assigned_users_json with avatar_data
  - Events without assignments return an empty array

All **19/19** tests pass.