### PR TITLE
feat: public & school holidays calendar layer

### DIFF
--- a/public/locales/ar.json
+++ b/public/locales/ar.json
@@ -531,7 +531,9 @@
     "attachmentDocumentName": "{{title}} - {{name}}",
     "attachmentDocumentDescription": "مرفق تم رفعه لحدث التقويم \"{{title}}\".",
     "agendaEmpty": "لا توجد مواعيد في الفترة المحددة",
-    "taskChipAriaLabel": "مهمة: {{title}}"
+    "taskChipAriaLabel": "مهمة: {{title}}",
+    "toggleHolidays": "Public Holidays",
+    "toggleSchool": "School Holidays"
   },
   "notes": {
     "title": "لوحة الملاحظات",
@@ -1193,7 +1195,27 @@
     "weatherSwitchHint": "سيتم تفعيل Open-Meteo عند الحفظ وسيتم تجاهل OWM.",
     "weatherLocateBtn": "تحديد الموقع",
     "weatherLocateSuccess": "تم تحديد الموقع بنجاح.",
-    "weatherLocateUnsupported": "المتصفح لا يدعم تحديد الموقع الجغرافي."
+    "weatherLocateUnsupported": "المتصفح لا يدعم تحديد الموقع الجغرافي.",
+    "sectionHolidays": "Public & School Holidays",
+    "holidayTitle": "OpenHolidays API (free, no API key)",
+    "holidayDescription": "Display official public holidays and school vacations in your calendar.",
+    "holidayCountryLabel": "Country",
+    "holidayCountryPlaceholder": "Select a country…",
+    "holidaySubdivisionLabel": "State / Region",
+    "holidaySubdivisionNone": "Entire country",
+    "holidaySubdivisionPlaceholder": "Select a state…",
+    "holidayPublicLabel": "Show public holidays",
+    "holidaySchoolLabel": "Show school holidays",
+    "holidayPublicColor": "Public holiday color",
+    "holidaySchoolColor": "School holiday color",
+    "holidaySaveBtn": "Save",
+    "holidaySaved": "Calendar settings saved.",
+    "holidaySyncBtn": "Sync now",
+    "holidaySynced": "Holidays synced.",
+    "holidaySyncError": "Sync failed.",
+    "holidayLastSync": "Last sync: {{date}}",
+    "holidayNeverSynced": "Not yet synced",
+    "holidayCountryRequired": "Please select a country first."
   },
   "login": {
     "tagline": "تخطيط عائلي. آمن. يحترم الخصوصية. مفتوح المصدر.",

--- a/public/locales/cs.json
+++ b/public/locales/cs.json
@@ -531,7 +531,9 @@
     "attachmentDocumentName": "{{title}} - {{name}}",
     "attachmentDocumentDescription": "Příloha nahraná ke kalendářní události \"{{title}}\".",
     "agendaEmpty": "V vybraném rozsahu nejsou žádné události",
-    "taskChipAriaLabel": "Úkol: {{title}}"
+    "taskChipAriaLabel": "Úkol: {{title}}",
+    "toggleHolidays": "Public Holidays",
+    "toggleSchool": "School Holidays"
   },
   "notes": {
     "title": "Nástěnka",
@@ -1193,7 +1195,27 @@
     "weatherSwitchHint": "Open-Meteo bude aktivován při uložení a OWM bude ignorován.",
     "weatherLocateBtn": "Zjistit polohu",
     "weatherLocateSuccess": "Poloha úspěšně zjištěna.",
-    "weatherLocateUnsupported": "Geolokalizace není vaším prohlížečem podporována."
+    "weatherLocateUnsupported": "Geolokalizace není vaším prohlížečem podporována.",
+    "sectionHolidays": "Public & School Holidays",
+    "holidayTitle": "OpenHolidays API (free, no API key)",
+    "holidayDescription": "Display official public holidays and school vacations in your calendar.",
+    "holidayCountryLabel": "Country",
+    "holidayCountryPlaceholder": "Select a country…",
+    "holidaySubdivisionLabel": "State / Region",
+    "holidaySubdivisionNone": "Entire country",
+    "holidaySubdivisionPlaceholder": "Select a state…",
+    "holidayPublicLabel": "Show public holidays",
+    "holidaySchoolLabel": "Show school holidays",
+    "holidayPublicColor": "Public holiday color",
+    "holidaySchoolColor": "School holiday color",
+    "holidaySaveBtn": "Save",
+    "holidaySaved": "Calendar settings saved.",
+    "holidaySyncBtn": "Sync now",
+    "holidaySynced": "Holidays synced.",
+    "holidaySyncError": "Sync failed.",
+    "holidayLastSync": "Last sync: {{date}}",
+    "holidayNeverSynced": "Not yet synced",
+    "holidayCountryRequired": "Please select a country first."
   },
   "login": {
     "tagline": "Rodinné plánování. Bezpečné. Soukromé. Open Source.",

--- a/public/locales/de.json
+++ b/public/locales/de.json
@@ -537,7 +537,9 @@
     "attachmentDocumentName": "{{title}} - {{name}}",
     "attachmentDocumentDescription": "Anhang für Kalendereintrag \"{{title}}\" hochgeladen.",
     "agendaEmpty": "Keine Termine im ausgewählten Zeitraum",
-    "taskChipAriaLabel": "Aufgabe: {{title}}"
+    "taskChipAriaLabel": "Aufgabe: {{title}}",
+    "toggleHolidays": "Feiertage",
+    "toggleSchool": "Schulferien"
   },
   "notes": {
     "title": "Notizen",
@@ -1199,7 +1201,27 @@
     "weatherSwitchHint": "Open-Meteo wird beim Speichern automatisch aktiviert und OWM ignoriert.",
     "weatherLocateBtn": "Standort ermitteln",
     "weatherLocateSuccess": "Standort erfolgreich ermittelt.",
-    "weatherLocateUnsupported": "Geolokalisierung wird von Ihrem Browser nicht unterstützt."
+    "weatherLocateUnsupported": "Geolokalisierung wird von Ihrem Browser nicht unterstützt.",
+    "sectionHolidays": "Feiertage & Schulferien",
+    "holidayTitle": "OpenHolidays API (kostenlos, kein API-Key)",
+    "holidayDescription": "Offizielle Feiertage und Schulferien im Kalender anzeigen.",
+    "holidayCountryLabel": "Land",
+    "holidayCountryPlaceholder": "Land auswählen…",
+    "holidaySubdivisionLabel": "Bundesland / Region",
+    "holidaySubdivisionNone": "Gesamtes Land",
+    "holidaySubdivisionPlaceholder": "Bundesland auswählen…",
+    "holidayPublicLabel": "Feiertage anzeigen",
+    "holidaySchoolLabel": "Schulferien anzeigen",
+    "holidayPublicColor": "Farbe Feiertage",
+    "holidaySchoolColor": "Farbe Schulferien",
+    "holidaySaveBtn": "Speichern",
+    "holidaySaved": "Kalendereinstellungen gespeichert.",
+    "holidaySyncBtn": "Jetzt synchronisieren",
+    "holidaySynced": "Feiertage synchronisiert.",
+    "holidaySyncError": "Synchronisierung fehlgeschlagen.",
+    "holidayLastSync": "Zuletzt: {{date}}",
+    "holidayNeverSynced": "Noch nicht synchronisiert",
+    "holidayCountryRequired": "Bitte zuerst ein Land auswählen."
   },
   "login": {
     "tagline": "Familienplanung. Sicher. Datenschutzfreundlich. Open Source.",

--- a/public/locales/el.json
+++ b/public/locales/el.json
@@ -531,7 +531,9 @@
     "attachmentDocumentName": "{{title}} - {{name}}",
     "attachmentDocumentDescription": "Συνημμένο που ανέβηκε για το συμβάν ημερολογίου \"{{title}}\".",
     "agendaEmpty": "Δεν υπάρχουν ραντεβού στο επιλεγμένο διάστημα",
-    "taskChipAriaLabel": "Εργασία: {{title}}"
+    "taskChipAriaLabel": "Εργασία: {{title}}",
+    "toggleHolidays": "Public Holidays",
+    "toggleSchool": "School Holidays"
   },
   "notes": {
     "title": "Σημειώσεις",
@@ -1193,7 +1195,27 @@
     "weatherSwitchHint": "Το Open-Meteo θα ενεργοποιηθεί κατά την αποθήκευση και το OWM θα αγνοηθεί.",
     "weatherLocateBtn": "Εντοπισμός τοποθεσίας",
     "weatherLocateSuccess": "Τοποθεσία εντοπίστηκε.",
-    "weatherLocateUnsupported": "Ο εντοπισμός γεωγραφικής θέσης δεν υποστηρίζεται από τον περιηγητή σας."
+    "weatherLocateUnsupported": "Ο εντοπισμός γεωγραφικής θέσης δεν υποστηρίζεται από τον περιηγητή σας.",
+    "sectionHolidays": "Public & School Holidays",
+    "holidayTitle": "OpenHolidays API (free, no API key)",
+    "holidayDescription": "Display official public holidays and school vacations in your calendar.",
+    "holidayCountryLabel": "Country",
+    "holidayCountryPlaceholder": "Select a country…",
+    "holidaySubdivisionLabel": "State / Region",
+    "holidaySubdivisionNone": "Entire country",
+    "holidaySubdivisionPlaceholder": "Select a state…",
+    "holidayPublicLabel": "Show public holidays",
+    "holidaySchoolLabel": "Show school holidays",
+    "holidayPublicColor": "Public holiday color",
+    "holidaySchoolColor": "School holiday color",
+    "holidaySaveBtn": "Save",
+    "holidaySaved": "Calendar settings saved.",
+    "holidaySyncBtn": "Sync now",
+    "holidaySynced": "Holidays synced.",
+    "holidaySyncError": "Sync failed.",
+    "holidayLastSync": "Last sync: {{date}}",
+    "holidayNeverSynced": "Not yet synced",
+    "holidayCountryRequired": "Please select a country first."
   },
   "login": {
     "tagline": "Οικογενειακός προγραμματισμός. Ασφαλής. Φιλικός προς την ιδιωτικότητα. Ανοιχτός κώδικας.",

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -531,7 +531,9 @@
     "attachmentDocumentName": "{{title}} - {{name}}",
     "attachmentDocumentDescription": "Attachment uploaded for calendar event \"{{title}}\".",
     "agendaEmpty": "No events in the selected range",
-    "taskChipAriaLabel": "Task: {{title}}"
+    "taskChipAriaLabel": "Task: {{title}}",
+    "toggleHolidays": "Public Holidays",
+    "toggleSchool": "School Holidays"
   },
   "notes": {
     "title": "Board",
@@ -1193,7 +1195,27 @@
     "weatherSwitchHint": "Open-Meteo will be activated on save and OWM will be ignored.",
     "weatherLocateBtn": "Detect location",
     "weatherLocateSuccess": "Location detected.",
-    "weatherLocateUnsupported": "Geolocation is not supported by your browser."
+    "weatherLocateUnsupported": "Geolocation is not supported by your browser.",
+    "sectionHolidays": "Public & School Holidays",
+    "holidayTitle": "OpenHolidays API (free, no API key)",
+    "holidayDescription": "Display official public holidays and school vacations in your calendar.",
+    "holidayCountryLabel": "Country",
+    "holidayCountryPlaceholder": "Select a country…",
+    "holidaySubdivisionLabel": "State / Region",
+    "holidaySubdivisionNone": "Entire country",
+    "holidaySubdivisionPlaceholder": "Select a state…",
+    "holidayPublicLabel": "Show public holidays",
+    "holidaySchoolLabel": "Show school holidays",
+    "holidayPublicColor": "Public holiday color",
+    "holidaySchoolColor": "School holiday color",
+    "holidaySaveBtn": "Save",
+    "holidaySaved": "Calendar settings saved.",
+    "holidaySyncBtn": "Sync now",
+    "holidaySynced": "Holidays synced.",
+    "holidaySyncError": "Sync failed.",
+    "holidayLastSync": "Last sync: {{date}}",
+    "holidayNeverSynced": "Not yet synced",
+    "holidayCountryRequired": "Please select a country first."
   },
   "login": {
     "tagline": "Family planning. Secure. Privacy-friendly. Open source.",

--- a/public/locales/es.json
+++ b/public/locales/es.json
@@ -531,7 +531,9 @@
     "attachmentDocumentName": "{{title}} - {{name}}",
     "attachmentDocumentDescription": "Archivo adjunto subido para el evento de calendario \"{{title}}\".",
     "agendaEmpty": "No hay eventos en el período seleccionado",
-    "taskChipAriaLabel": "Tarea: {{title}}"
+    "taskChipAriaLabel": "Tarea: {{title}}",
+    "toggleHolidays": "Festivos",
+    "toggleSchool": "Vacaciones escolares"
   },
   "notes": {
     "title": "Notas",
@@ -1193,7 +1195,27 @@
     "weatherSwitchHint": "Open-Meteo se activará al guardar y se ignorará OWM.",
     "weatherLocateBtn": "Detectar ubicación",
     "weatherLocateSuccess": "Ubicación detectada.",
-    "weatherLocateUnsupported": "La geolocalización no es compatible con su navegador."
+    "weatherLocateUnsupported": "La geolocalización no es compatible con su navegador.",
+    "sectionHolidays": "Festivos y Vacaciones escolares",
+    "holidayTitle": "OpenHolidays API (gratis, sin clave API)",
+    "holidayDescription": "Muestra los festivos oficiales y las vacaciones escolares en tu calendario.",
+    "holidayCountryLabel": "País",
+    "holidayCountryPlaceholder": "Seleccionar un país…",
+    "holidaySubdivisionLabel": "Comunidad / Región",
+    "holidaySubdivisionNone": "Todo el país",
+    "holidaySubdivisionPlaceholder": "Seleccionar una región…",
+    "holidayPublicLabel": "Mostrar festivos",
+    "holidaySchoolLabel": "Mostrar vacaciones escolares",
+    "holidayPublicColor": "Color de festivos",
+    "holidaySchoolColor": "Color de vacaciones escolares",
+    "holidaySaveBtn": "Guardar",
+    "holidaySaved": "Configuración del calendario guardada.",
+    "holidaySyncBtn": "Sincronizar ahora",
+    "holidaySynced": "Festivos sincronizados.",
+    "holidaySyncError": "Error en la sincronización.",
+    "holidayLastSync": "Última sincronización: {{date}}",
+    "holidayNeverSynced": "Nunca sincronizado",
+    "holidayCountryRequired": "Selecciona primero un país."
   },
   "login": {
     "tagline": "Planificación familiar. Segura. Privada. Código abierto.",

--- a/public/locales/fr.json
+++ b/public/locales/fr.json
@@ -531,7 +531,9 @@
     "attachmentDocumentName": "{{title}} - {{name}}",
     "attachmentDocumentDescription": "Pièce jointe téléversée pour l’événement \"{{title}}\".",
     "agendaEmpty": "Aucun événement dans la période sélectionnée",
-    "taskChipAriaLabel": "Tâche : {{title}}"
+    "taskChipAriaLabel": "Tâche : {{title}}",
+    "toggleHolidays": "Jours fériés",
+    "toggleSchool": "Vacances scolaires"
   },
   "notes": {
     "title": "Notes",
@@ -1193,7 +1195,27 @@
     "weatherSwitchHint": "Open-Meteo sera activé à l'enregistrement et OWM ignoré.",
     "weatherLocateBtn": "Détecter ma position",
     "weatherLocateSuccess": "Position détectée.",
-    "weatherLocateUnsupported": "La géolocalisation n'est pas prise en charge par votre navigateur."
+    "weatherLocateUnsupported": "La géolocalisation n'est pas prise en charge par votre navigateur.",
+    "sectionHolidays": "Jours fériés & Vacances scolaires",
+    "holidayTitle": "OpenHolidays API (gratuit, sans clé API)",
+    "holidayDescription": "Affichez les jours fériés officiels et les vacances scolaires dans votre calendrier.",
+    "holidayCountryLabel": "Pays",
+    "holidayCountryPlaceholder": "Sélectionner un pays…",
+    "holidaySubdivisionLabel": "Région / Département",
+    "holidaySubdivisionNone": "Tout le pays",
+    "holidaySubdivisionPlaceholder": "Sélectionner une région…",
+    "holidayPublicLabel": "Afficher les jours fériés",
+    "holidaySchoolLabel": "Afficher les vacances scolaires",
+    "holidayPublicColor": "Couleur des jours fériés",
+    "holidaySchoolColor": "Couleur des vacances scolaires",
+    "holidaySaveBtn": "Enregistrer",
+    "holidaySaved": "Paramètres du calendrier enregistrés.",
+    "holidaySyncBtn": "Synchroniser maintenant",
+    "holidaySynced": "Jours fériés synchronisés.",
+    "holidaySyncError": "La synchronisation a échoué.",
+    "holidayLastSync": "Dernière synchronisation : {{date}}",
+    "holidayNeverSynced": "Jamais synchronisé",
+    "holidayCountryRequired": "Veuillez d'abord sélectionner un pays."
   },
   "login": {
     "tagline": "Planification familiale. Sécurisée. Respectueuse de la vie privée. Open source.",

--- a/public/locales/hi.json
+++ b/public/locales/hi.json
@@ -531,7 +531,9 @@
     "attachmentDocumentName": "{{title}} - {{name}}",
     "attachmentDocumentDescription": "कैलेंडर इवेंट \"{{title}}\" के लिए अपलोड किया गया अटैचमेंट।",
     "agendaEmpty": "चुनी गई अवधि में कोई कार्यक्रम नहीं",
-    "taskChipAriaLabel": "कार्य: {{title}}"
+    "taskChipAriaLabel": "कार्य: {{title}}",
+    "toggleHolidays": "Public Holidays",
+    "toggleSchool": "School Holidays"
   },
   "notes": {
     "title": "नोट बोर्ड",
@@ -1193,7 +1195,27 @@
     "weatherSwitchHint": "सहेजने पर Open-Meteo सक्रिय हो जाएगा और OWM अनदेखा किया जाएगा।",
     "weatherLocateBtn": "स्थान पता करें",
     "weatherLocateSuccess": "स्थान सफलतापूर्वक पता चला।",
-    "weatherLocateUnsupported": "आपका ब्राउज़र जियोलोकेशन का समर्थन नहीं करता।"
+    "weatherLocateUnsupported": "आपका ब्राउज़र जियोलोकेशन का समर्थन नहीं करता।",
+    "sectionHolidays": "Public & School Holidays",
+    "holidayTitle": "OpenHolidays API (free, no API key)",
+    "holidayDescription": "Display official public holidays and school vacations in your calendar.",
+    "holidayCountryLabel": "Country",
+    "holidayCountryPlaceholder": "Select a country…",
+    "holidaySubdivisionLabel": "State / Region",
+    "holidaySubdivisionNone": "Entire country",
+    "holidaySubdivisionPlaceholder": "Select a state…",
+    "holidayPublicLabel": "Show public holidays",
+    "holidaySchoolLabel": "Show school holidays",
+    "holidayPublicColor": "Public holiday color",
+    "holidaySchoolColor": "School holiday color",
+    "holidaySaveBtn": "Save",
+    "holidaySaved": "Calendar settings saved.",
+    "holidaySyncBtn": "Sync now",
+    "holidaySynced": "Holidays synced.",
+    "holidaySyncError": "Sync failed.",
+    "holidayLastSync": "Last sync: {{date}}",
+    "holidayNeverSynced": "Not yet synced",
+    "holidayCountryRequired": "Please select a country first."
   },
   "login": {
     "tagline": "पारिवारिक योजना। सुरक्षित। गोपनीयता-अनुकूल। ओपन सोर्स।",

--- a/public/locales/it.json
+++ b/public/locales/it.json
@@ -531,7 +531,9 @@
     "attachmentDocumentName": "{{title}} - {{name}}",
     "attachmentDocumentDescription": "Allegato caricato per l’evento calendario \"{{title}}\".",
     "agendaEmpty": "Nessun evento nell'intervallo selezionato",
-    "taskChipAriaLabel": "Attività: {{title}}"
+    "taskChipAriaLabel": "Attività: {{title}}",
+    "toggleHolidays": "Festività",
+    "toggleSchool": "Vacanze scolastiche"
   },
   "notes": {
     "title": "Bacheca",
@@ -1193,7 +1195,27 @@
     "weatherSwitchHint": "Open-Meteo sarà attivato al salvataggio e OWM ignorato.",
     "weatherLocateBtn": "Rileva posizione",
     "weatherLocateSuccess": "Posizione rilevata.",
-    "weatherLocateUnsupported": "La geolocalizzazione non è supportata dal browser."
+    "weatherLocateUnsupported": "La geolocalizzazione non è supportata dal browser.",
+    "sectionHolidays": "Festività e Vacanze scolastiche",
+    "holidayTitle": "OpenHolidays API (gratuito, senza chiave API)",
+    "holidayDescription": "Visualizza le festività ufficiali e le vacanze scolastiche nel tuo calendario.",
+    "holidayCountryLabel": "Paese",
+    "holidayCountryPlaceholder": "Seleziona un paese…",
+    "holidaySubdivisionLabel": "Regione / Provincia",
+    "holidaySubdivisionNone": "Tutto il paese",
+    "holidaySubdivisionPlaceholder": "Seleziona una regione…",
+    "holidayPublicLabel": "Mostra festività",
+    "holidaySchoolLabel": "Mostra vacanze scolastiche",
+    "holidayPublicColor": "Colore festività",
+    "holidaySchoolColor": "Colore vacanze scolastiche",
+    "holidaySaveBtn": "Salva",
+    "holidaySaved": "Impostazioni calendario salvate.",
+    "holidaySyncBtn": "Sincronizza ora",
+    "holidaySynced": "Festività sincronizzate.",
+    "holidaySyncError": "Sincronizzazione non riuscita.",
+    "holidayLastSync": "Ultima sincronizzazione: {{date}}",
+    "holidayNeverSynced": "Mai sincronizzato",
+    "holidayCountryRequired": "Seleziona prima un paese."
   },
   "login": {
     "tagline": "Pianificazione familiare. Sicura. Rispettosa della privacy. Open source.",

--- a/public/locales/ja.json
+++ b/public/locales/ja.json
@@ -531,7 +531,9 @@
     "attachmentDocumentName": "{{title}} - {{name}}",
     "attachmentDocumentDescription": "カレンダー予定「{{title}}」にアップロードされた添付ファイル。",
     "agendaEmpty": "選択した期間に予定はありません",
-    "taskChipAriaLabel": "タスク: {{title}}"
+    "taskChipAriaLabel": "タスク: {{title}}",
+    "toggleHolidays": "Public Holidays",
+    "toggleSchool": "School Holidays"
   },
   "notes": {
     "title": "メモボード",
@@ -1193,7 +1195,27 @@
     "weatherSwitchHint": "保存するとOpen-Meteoが有効化され、OWMは無視されます。",
     "weatherLocateBtn": "現在地を取得",
     "weatherLocateSuccess": "現在地を取得しました。",
-    "weatherLocateUnsupported": "お使いのブラウザは位置情報に対応していません。"
+    "weatherLocateUnsupported": "お使いのブラウザは位置情報に対応していません。",
+    "sectionHolidays": "Public & School Holidays",
+    "holidayTitle": "OpenHolidays API (free, no API key)",
+    "holidayDescription": "Display official public holidays and school vacations in your calendar.",
+    "holidayCountryLabel": "Country",
+    "holidayCountryPlaceholder": "Select a country…",
+    "holidaySubdivisionLabel": "State / Region",
+    "holidaySubdivisionNone": "Entire country",
+    "holidaySubdivisionPlaceholder": "Select a state…",
+    "holidayPublicLabel": "Show public holidays",
+    "holidaySchoolLabel": "Show school holidays",
+    "holidayPublicColor": "Public holiday color",
+    "holidaySchoolColor": "School holiday color",
+    "holidaySaveBtn": "Save",
+    "holidaySaved": "Calendar settings saved.",
+    "holidaySyncBtn": "Sync now",
+    "holidaySynced": "Holidays synced.",
+    "holidaySyncError": "Sync failed.",
+    "holidayLastSync": "Last sync: {{date}}",
+    "holidayNeverSynced": "Not yet synced",
+    "holidayCountryRequired": "Please select a country first."
   },
   "login": {
     "tagline": "家族計画。安全。プライバシー重視。オープンソース。",

--- a/public/locales/nl.json
+++ b/public/locales/nl.json
@@ -531,7 +531,9 @@
     "attachmentDocumentName": "{{title}} - {{name}}",
     "attachmentDocumentDescription": "Bijlage geüpload voor agendagebeurtenis \"{{title}}\".",
     "agendaEmpty": "Geen evenementen in het geselecteerde bereik",
-    "taskChipAriaLabel": "Taak: {{title}}"
+    "taskChipAriaLabel": "Taak: {{title}}",
+    "toggleHolidays": "Feestdagen",
+    "toggleSchool": "Schoolvakanties"
   },
   "notes": {
     "title": "Bord",
@@ -1193,7 +1195,27 @@
     "weatherSwitchHint": "Open-Meteo wordt geactiveerd bij opslaan en OWM genegeerd.",
     "weatherLocateBtn": "Locatie detecteren",
     "weatherLocateSuccess": "Locatie gedetecteerd.",
-    "weatherLocateUnsupported": "Geolocatie wordt niet ondersteund door uw browser."
+    "weatherLocateUnsupported": "Geolocatie wordt niet ondersteund door uw browser.",
+    "sectionHolidays": "Feestdagen & Schoolvakanties",
+    "holidayTitle": "OpenHolidays API (gratis, geen API-sleutel)",
+    "holidayDescription": "Officiële feestdagen en schoolvakanties weergeven in uw agenda.",
+    "holidayCountryLabel": "Land",
+    "holidayCountryPlaceholder": "Selecteer een land…",
+    "holidaySubdivisionLabel": "Provincie / Regio",
+    "holidaySubdivisionNone": "Heel het land",
+    "holidaySubdivisionPlaceholder": "Selecteer een provincie…",
+    "holidayPublicLabel": "Feestdagen weergeven",
+    "holidaySchoolLabel": "Schoolvakanties weergeven",
+    "holidayPublicColor": "Kleur feestdagen",
+    "holidaySchoolColor": "Kleur schoolvakanties",
+    "holidaySaveBtn": "Opslaan",
+    "holidaySaved": "Kalenderinstellingen opgeslagen.",
+    "holidaySyncBtn": "Nu synchroniseren",
+    "holidaySynced": "Feestdagen gesynchroniseerd.",
+    "holidaySyncError": "Synchronisatie mislukt.",
+    "holidayLastSync": "Laatste synchronisatie: {{date}}",
+    "holidayNeverSynced": "Nog niet gesynchroniseerd",
+    "holidayCountryRequired": "Selecteer eerst een land."
   },
   "login": {
     "tagline": "Gezinsplanning. Veilig. Privacyvriendelijk. Open source.",

--- a/public/locales/pl.json
+++ b/public/locales/pl.json
@@ -537,7 +537,9 @@
     "attachmentDocumentName": "{{title}} - {{name}}",
     "attachmentDocumentDescription": "Załącznik do wpisu kalendarza \"{{title}}\" przesłany.",
     "agendaEmpty": "Brak wydarzeń w wybranym zakresie",
-    "taskChipAriaLabel": "Zadanie: {{title}}"
+    "taskChipAriaLabel": "Zadanie: {{title}}",
+    "toggleHolidays": "Public Holidays",
+    "toggleSchool": "School Holidays"
   },
   "notes": {
     "title": "Notatki",
@@ -1199,7 +1201,27 @@
     "weatherSwitchHint": "Open-Meteo zostanie aktywowany po zapisaniu i OWM zostanie zignorowany.",
     "weatherLocateBtn": "Wykryj lokalizację",
     "weatherLocateSuccess": "Lokalizacja wykryta.",
-    "weatherLocateUnsupported": "Przeglądarka nie obsługuje geolokalizacji."
+    "weatherLocateUnsupported": "Przeglądarka nie obsługuje geolokalizacji.",
+    "sectionHolidays": "Public & School Holidays",
+    "holidayTitle": "OpenHolidays API (free, no API key)",
+    "holidayDescription": "Display official public holidays and school vacations in your calendar.",
+    "holidayCountryLabel": "Country",
+    "holidayCountryPlaceholder": "Select a country…",
+    "holidaySubdivisionLabel": "State / Region",
+    "holidaySubdivisionNone": "Entire country",
+    "holidaySubdivisionPlaceholder": "Select a state…",
+    "holidayPublicLabel": "Show public holidays",
+    "holidaySchoolLabel": "Show school holidays",
+    "holidayPublicColor": "Public holiday color",
+    "holidaySchoolColor": "School holiday color",
+    "holidaySaveBtn": "Save",
+    "holidaySaved": "Calendar settings saved.",
+    "holidaySyncBtn": "Sync now",
+    "holidaySynced": "Holidays synced.",
+    "holidaySyncError": "Sync failed.",
+    "holidayLastSync": "Last sync: {{date}}",
+    "holidayNeverSynced": "Not yet synced",
+    "holidayCountryRequired": "Please select a country first."
   },
   "login": {
     "tagline": "Planowanie rodziny. Bezpieczne. Chroniące prywatność. Open Source.",

--- a/public/locales/pt.json
+++ b/public/locales/pt.json
@@ -531,7 +531,9 @@
     "attachmentDocumentName": "{{title}} - {{name}}",
     "attachmentDocumentDescription": "Anexo enviado para o evento \"{{title}}\" do calendário.",
     "agendaEmpty": "Nenhum evento no período selecionado",
-    "taskChipAriaLabel": "Tarefa: {{title}}"
+    "taskChipAriaLabel": "Tarefa: {{title}}",
+    "toggleHolidays": "Feriados",
+    "toggleSchool": "Férias escolares"
   },
   "notes": {
     "title": "Quadro de notas",
@@ -1193,7 +1195,27 @@
     "weatherSwitchHint": "Open-Meteo será ativado ao guardar e OWM ignorado.",
     "weatherLocateBtn": "Detectar localização",
     "weatherLocateSuccess": "Localização detectada.",
-    "weatherLocateUnsupported": "A geolocalização não é suportada pelo seu navegador."
+    "weatherLocateUnsupported": "A geolocalização não é suportada pelo seu navegador.",
+    "sectionHolidays": "Feriados e Férias escolares",
+    "holidayTitle": "OpenHolidays API (gratuito, sem chave de API)",
+    "holidayDescription": "Exiba feriados oficiais e férias escolares no seu calendário.",
+    "holidayCountryLabel": "País",
+    "holidayCountryPlaceholder": "Selecionar um país…",
+    "holidaySubdivisionLabel": "Estado / Região",
+    "holidaySubdivisionNone": "Todo o país",
+    "holidaySubdivisionPlaceholder": "Selecionar um estado…",
+    "holidayPublicLabel": "Mostrar feriados",
+    "holidaySchoolLabel": "Mostrar férias escolares",
+    "holidayPublicColor": "Cor dos feriados",
+    "holidaySchoolColor": "Cor das férias escolares",
+    "holidaySaveBtn": "Guardar",
+    "holidaySaved": "Configurações do calendário guardadas.",
+    "holidaySyncBtn": "Sincronizar agora",
+    "holidaySynced": "Feriados sincronizados.",
+    "holidaySyncError": "Falha na sincronização.",
+    "holidayLastSync": "Última sincronização: {{date}}",
+    "holidayNeverSynced": "Nunca sincronizado",
+    "holidayCountryRequired": "Selecione primeiro um país."
   },
   "login": {
     "tagline": "Planejamento familiar. Seguro. Privado. Código aberto.",

--- a/public/locales/ru.json
+++ b/public/locales/ru.json
@@ -531,7 +531,9 @@
     "attachmentDocumentName": "{{title}} - {{name}}",
     "attachmentDocumentDescription": "Вложение загружено для события календаря «{{title}}».",
     "agendaEmpty": "Нет событий в выбранном периоде",
-    "taskChipAriaLabel": "Задача: {{title}}"
+    "taskChipAriaLabel": "Задача: {{title}}",
+    "toggleHolidays": "Public Holidays",
+    "toggleSchool": "School Holidays"
   },
   "notes": {
     "title": "Заметки",
@@ -1193,7 +1195,27 @@
     "weatherSwitchHint": "Open-Meteo будет активирован при сохранении, OWM будет проигнорирован.",
     "weatherLocateBtn": "Определить местоположение",
     "weatherLocateSuccess": "Местоположение успешно определено.",
-    "weatherLocateUnsupported": "Ваш браузер не поддерживает геолокацию."
+    "weatherLocateUnsupported": "Ваш браузер не поддерживает геолокацию.",
+    "sectionHolidays": "Public & School Holidays",
+    "holidayTitle": "OpenHolidays API (free, no API key)",
+    "holidayDescription": "Display official public holidays and school vacations in your calendar.",
+    "holidayCountryLabel": "Country",
+    "holidayCountryPlaceholder": "Select a country…",
+    "holidaySubdivisionLabel": "State / Region",
+    "holidaySubdivisionNone": "Entire country",
+    "holidaySubdivisionPlaceholder": "Select a state…",
+    "holidayPublicLabel": "Show public holidays",
+    "holidaySchoolLabel": "Show school holidays",
+    "holidayPublicColor": "Public holiday color",
+    "holidaySchoolColor": "School holiday color",
+    "holidaySaveBtn": "Save",
+    "holidaySaved": "Calendar settings saved.",
+    "holidaySyncBtn": "Sync now",
+    "holidaySynced": "Holidays synced.",
+    "holidaySyncError": "Sync failed.",
+    "holidayLastSync": "Last sync: {{date}}",
+    "holidayNeverSynced": "Not yet synced",
+    "holidayCountryRequired": "Please select a country first."
   },
   "login": {
     "tagline": "Семейное планирование. Безопасно. С уважением к приватности. Открытый исходный код.",

--- a/public/locales/sv.json
+++ b/public/locales/sv.json
@@ -531,7 +531,9 @@
     "attachmentDocumentName": "{{title}} - {{name}}",
     "attachmentDocumentDescription": "Bilaga uppladdad för kalenderhändelsen \"{{title}}\".",
     "agendaEmpty": "Inga händelser under vald period",
-    "taskChipAriaLabel": "Uppgift: {{title}}"
+    "taskChipAriaLabel": "Uppgift: {{title}}",
+    "toggleHolidays": "Helgdagar",
+    "toggleSchool": "Skollov"
   },
   "notes": {
     "title": "Anteckningar",
@@ -1193,7 +1195,27 @@
     "weatherSwitchHint": "Open-Meteo aktiveras vid sparning och OWM ignoreras.",
     "weatherLocateBtn": "Identifiera plats",
     "weatherLocateSuccess": "Plats identifierad.",
-    "weatherLocateUnsupported": "Geolokalisering stöds inte av din webbläsare."
+    "weatherLocateUnsupported": "Geolokalisering stöds inte av din webbläsare.",
+    "sectionHolidays": "Helgdagar & Skollov",
+    "holidayTitle": "OpenHolidays API (gratis, ingen API-nyckel)",
+    "holidayDescription": "Visa officiella helgdagar och skollov i din kalender.",
+    "holidayCountryLabel": "Land",
+    "holidayCountryPlaceholder": "Välj ett land…",
+    "holidaySubdivisionLabel": "Län / Region",
+    "holidaySubdivisionNone": "Hela landet",
+    "holidaySubdivisionPlaceholder": "Välj ett län…",
+    "holidayPublicLabel": "Visa helgdagar",
+    "holidaySchoolLabel": "Visa skollov",
+    "holidayPublicColor": "Färg helgdagar",
+    "holidaySchoolColor": "Färg skollov",
+    "holidaySaveBtn": "Spara",
+    "holidaySaved": "Kalenderinställningar sparade.",
+    "holidaySyncBtn": "Synkronisera nu",
+    "holidaySynced": "Helgdagar synkroniserade.",
+    "holidaySyncError": "Synkronisering misslyckades.",
+    "holidayLastSync": "Senast synkroniserad: {{date}}",
+    "holidayNeverSynced": "Aldrig synkroniserad",
+    "holidayCountryRequired": "Välj ett land först."
   },
   "login": {
     "tagline": "Familjeplanering. Säker. Sekretessvänlig. Öppen källkod.",

--- a/public/locales/tr.json
+++ b/public/locales/tr.json
@@ -531,7 +531,9 @@
     "attachmentDocumentName": "{{title}} - {{name}}",
     "attachmentDocumentDescription": "\"{{title}}\" takvim etkinliği için ek yüklendi.",
     "agendaEmpty": "Seçilen aralıkta etkinlik yok",
-    "taskChipAriaLabel": "Görev: {{title}}"
+    "taskChipAriaLabel": "Görev: {{title}}",
+    "toggleHolidays": "Public Holidays",
+    "toggleSchool": "School Holidays"
   },
   "notes": {
     "title": "Notlar",
@@ -1193,7 +1195,27 @@
     "weatherSwitchHint": "Open-Meteo kaydedildiğinde etkinleştirilecek ve OWM yoksayılacak.",
     "weatherLocateBtn": "Konumu tespit et",
     "weatherLocateSuccess": "Konum tespit edildi.",
-    "weatherLocateUnsupported": "Tarayıcınız coğrafi konum belirlemeyi desteklemiyor."
+    "weatherLocateUnsupported": "Tarayıcınız coğrafi konum belirlemeyi desteklemiyor.",
+    "sectionHolidays": "Public & School Holidays",
+    "holidayTitle": "OpenHolidays API (free, no API key)",
+    "holidayDescription": "Display official public holidays and school vacations in your calendar.",
+    "holidayCountryLabel": "Country",
+    "holidayCountryPlaceholder": "Select a country…",
+    "holidaySubdivisionLabel": "State / Region",
+    "holidaySubdivisionNone": "Entire country",
+    "holidaySubdivisionPlaceholder": "Select a state…",
+    "holidayPublicLabel": "Show public holidays",
+    "holidaySchoolLabel": "Show school holidays",
+    "holidayPublicColor": "Public holiday color",
+    "holidaySchoolColor": "School holiday color",
+    "holidaySaveBtn": "Save",
+    "holidaySaved": "Calendar settings saved.",
+    "holidaySyncBtn": "Sync now",
+    "holidaySynced": "Holidays synced.",
+    "holidaySyncError": "Sync failed.",
+    "holidayLastSync": "Last sync: {{date}}",
+    "holidayNeverSynced": "Not yet synced",
+    "holidayCountryRequired": "Please select a country first."
   },
   "login": {
     "tagline": "Aile planlaması. Güvenli. Gizlilik dostu. Açık kaynak.",

--- a/public/locales/uk.json
+++ b/public/locales/uk.json
@@ -531,7 +531,9 @@
     "attachmentDocumentName": "{{title}} - {{name}}",
     "attachmentDocumentDescription": "Вкладення завантажено для події календаря «{{title}}».",
     "agendaEmpty": "Немає подій у вибраному періоді",
-    "taskChipAriaLabel": "Завдання: {{title}}"
+    "taskChipAriaLabel": "Завдання: {{title}}",
+    "toggleHolidays": "Public Holidays",
+    "toggleSchool": "School Holidays"
   },
   "notes": {
     "title": "Нотатки",
@@ -1193,7 +1195,27 @@
     "weatherSwitchHint": "Open-Meteo буде активовано при збереженні, OWM ігноруватиметься.",
     "weatherLocateBtn": "Визначити місцезнаходження",
     "weatherLocateSuccess": "Місцезнаходження успішно визначено.",
-    "weatherLocateUnsupported": "Ваш браузер не підтримує геолокацію."
+    "weatherLocateUnsupported": "Ваш браузер не підтримує геолокацію.",
+    "sectionHolidays": "Public & School Holidays",
+    "holidayTitle": "OpenHolidays API (free, no API key)",
+    "holidayDescription": "Display official public holidays and school vacations in your calendar.",
+    "holidayCountryLabel": "Country",
+    "holidayCountryPlaceholder": "Select a country…",
+    "holidaySubdivisionLabel": "State / Region",
+    "holidaySubdivisionNone": "Entire country",
+    "holidaySubdivisionPlaceholder": "Select a state…",
+    "holidayPublicLabel": "Show public holidays",
+    "holidaySchoolLabel": "Show school holidays",
+    "holidayPublicColor": "Public holiday color",
+    "holidaySchoolColor": "School holiday color",
+    "holidaySaveBtn": "Save",
+    "holidaySaved": "Calendar settings saved.",
+    "holidaySyncBtn": "Sync now",
+    "holidaySynced": "Holidays synced.",
+    "holidaySyncError": "Sync failed.",
+    "holidayLastSync": "Last sync: {{date}}",
+    "holidayNeverSynced": "Not yet synced",
+    "holidayCountryRequired": "Please select a country first."
   },
   "login": {
     "tagline": "Планування для родини. Безпечно. Конфіденційно. Відкритий код.",

--- a/public/locales/zh.json
+++ b/public/locales/zh.json
@@ -531,7 +531,9 @@
     "attachmentDocumentName": "{{title}} - {{name}}",
     "attachmentDocumentDescription": "为日历事件“{{title}}”上传的附件。",
     "agendaEmpty": "所选时间范围内没有日程",
-    "taskChipAriaLabel": "任务：{{title}}"
+    "taskChipAriaLabel": "任务：{{title}}",
+    "toggleHolidays": "Public Holidays",
+    "toggleSchool": "School Holidays"
   },
   "notes": {
     "title": "便签板",
@@ -1193,7 +1195,27 @@
     "weatherSwitchHint": "保存后将激活Open-Meteo并忽略OWM。",
     "weatherLocateBtn": "获取当前位置",
     "weatherLocateSuccess": "位置获取成功。",
-    "weatherLocateUnsupported": "您的浏览器不支持地理定位。"
+    "weatherLocateUnsupported": "您的浏览器不支持地理定位。",
+    "sectionHolidays": "Public & School Holidays",
+    "holidayTitle": "OpenHolidays API (free, no API key)",
+    "holidayDescription": "Display official public holidays and school vacations in your calendar.",
+    "holidayCountryLabel": "Country",
+    "holidayCountryPlaceholder": "Select a country…",
+    "holidaySubdivisionLabel": "State / Region",
+    "holidaySubdivisionNone": "Entire country",
+    "holidaySubdivisionPlaceholder": "Select a state…",
+    "holidayPublicLabel": "Show public holidays",
+    "holidaySchoolLabel": "Show school holidays",
+    "holidayPublicColor": "Public holiday color",
+    "holidaySchoolColor": "School holiday color",
+    "holidaySaveBtn": "Save",
+    "holidaySaved": "Calendar settings saved.",
+    "holidaySyncBtn": "Sync now",
+    "holidaySynced": "Holidays synced.",
+    "holidaySyncError": "Sync failed.",
+    "holidayLastSync": "Last sync: {{date}}",
+    "holidayNeverSynced": "Not yet synced",
+    "holidayCountryRequired": "Please select a country first."
   },
   "login": {
     "tagline": "家庭规划。安全。注重隐私。开源。",

--- a/public/pages/calendar.js
+++ b/public/pages/calendar.js
@@ -573,9 +573,15 @@ function getMonthRange(dateStr) {
   const d     = new Date(dateStr + 'T00:00:00');
   const year  = d.getFullYear();
   const month = d.getMonth();
-  const from  = `${year}-${pad(month + 1)}-01`;
-  // Extra Tage für Kalenderraster (6 Wochen × 7 = 42 Tage)
-  const to    = addDays(from, 41);
+  // Start des Monats, dann bis auf den Montag zurückgehen (Kalenderraster)
+  const firstOfMonth = new Date(year, month, 1);
+  let startOffset = firstOfMonth.getDay() - 1; // Montag = 0
+  if (startOffset < 0) startOffset = 6;        // Sonntag → 6
+  const gridStart = new Date(firstOfMonth);
+  gridStart.setDate(gridStart.getDate() - startOffset);
+  const from = isoDate(gridStart);
+  // 42 Tage (6 Wochen) abdecken
+  const to   = addDays(from, 41);
   return { from, to };
 }
 
@@ -736,6 +742,7 @@ async function loadRange(from, to) {
     state.events   = evRes.data;
     state.tasks    = filterTasksForCalendar(taskRes.data ?? []);
     state.holidays = holRes.data ?? [];
+    console.debug('[Calendar] holidays loaded:', state.holidays.length, state.holidays);
   } catch (err) {
     console.error('[Calendar] loadRange Fehler:', err);
     state.events   = [];

--- a/public/pages/calendar.js
+++ b/public/pages/calendar.js
@@ -210,6 +210,8 @@ const MAX_ATTACHMENT_BYTES = 5 * 1024 * 1024;
 const ATTACHMENT_IMAGE_MIME = new Set(['image/png', 'image/jpeg', 'image/webp', 'image/gif']);
 const CALENDAR_VIEW_STORAGE_KEY = 'oikos:calendar:view';
 const LEGACY_CALENDAR_VIEW_STORAGE_KEY = 'oikos-calendar-view';
+const LAYER_HOLIDAYS_KEY = 'oikos:calendar:layer:holidays';
+const LAYER_SCHOOL_KEY   = 'oikos:calendar:layer:school';
 
 const HOUR_HEIGHT = 56; // px pro Stunde in Wochen-/Tagesansicht
 
@@ -326,14 +328,18 @@ function getContrastColor(hex) {
 // --------------------------------------------------------
 
 let state = {
-  view:        'month',
-  today:       '',
-  cursor:      null,     // aktuell angezeigte Referenz-Datum (YYYY-MM-DD)
-  events:      [],
-  tasks:       [],       // Aufgaben mit due_date für Kalender-Anzeige
-  users:       [],
-  rangeFrom:   '',
-  rangeTo:     '',
+  view:          'month',
+  today:         '',
+  cursor:        null,     // aktuell angezeigte Referenz-Datum (YYYY-MM-DD)
+  events:        [],
+  tasks:         [],       // Aufgaben mit due_date für Kalender-Anzeige
+  users:         [],
+  rangeFrom:     '',
+  rangeTo:       '',
+  holidays:      [],       // cached entries from holiday_cache
+  holidayPrefs:  {},       // subset of /preferences
+  layerHolidays: true,     // toggle for public holiday layer
+  layerSchool:   true,     // toggle for school holiday layer
 };
 let _container = null;
 
@@ -686,6 +692,17 @@ function tasksOnDay(dateStr) {
   return state.tasks.filter((t) => t.due_date === dateStr);
 }
 
+/** Holiday entries that overlap a given date (respects layer toggles). */
+function holidaysOnDay(dateStr) {
+  if (!state.holidays?.length) return [];
+  return state.holidays.filter((h) => {
+    if (h.start_date > dateStr || h.end_date < dateStr) return false;
+    if (h.type === 'public' && !state.layerHolidays) return false;
+    if (h.type === 'school' && !state.layerSchool)   return false;
+    return true;
+  });
+}
+
 /** Rendert einen read-only Task-Chip für Kalenderansichten. */
 function renderTaskChip(task) {
   const priority = task.priority || 'none';
@@ -708,19 +725,22 @@ function renderTaskChip(task) {
 
 async function loadRange(from, to) {
   try {
-    const [evRes, taskRes] = await Promise.all([
+    const [evRes, taskRes, holRes] = await Promise.all([
       api.get(`/calendar?from=${from}&to=${to}`),
       api.get('/tasks?include_future=1').catch((err) => {
         console.warn('[Calendar] Tasks-Fetch fehlgeschlagen:', err);
         return { data: [] };
       }),
+      api.get(`/calendar/holidays?from=${from}&to=${to}`).catch(() => ({ data: [] })),
     ]);
-    state.events = evRes.data;
-    state.tasks  = filterTasksForCalendar(taskRes.data ?? []);
+    state.events   = evRes.data;
+    state.tasks    = filterTasksForCalendar(taskRes.data ?? []);
+    state.holidays = holRes.data ?? [];
   } catch (err) {
     console.error('[Calendar] loadRange Fehler:', err);
-    state.events = [];
-    state.tasks  = [];
+    state.events   = [];
+    state.tasks    = [];
+    state.holidays = [];
     window.oikos?.showToast(t('calendar.loadError'), 'danger');
   }
   state.rangeFrom = from;
@@ -758,7 +778,14 @@ export async function render(container, { user }) {
   `);
 
   const { from, to } = getRangeForView(state.view, state.cursor);
-  await Promise.all([loadRange(from, to), loadUsers()]);
+  const [,, prefsRes] = await Promise.all([
+    loadRange(from, to),
+    loadUsers(),
+    api.get('/preferences').catch(() => ({ data: {} })),
+  ]);
+  state.holidayPrefs  = prefsRes.data ?? {};
+  state.layerHolidays = localStorage.getItem(LAYER_HOLIDAYS_KEY) !== 'false';
+  state.layerSchool   = localStorage.getItem(LAYER_SCHOOL_KEY)   !== 'false';
 
   renderToolbar();
   renderView();
@@ -786,6 +813,33 @@ function renderToolbar() {
   const bar = _container.querySelector('#cal-toolbar');
   if (!bar) return;
 
+  const hp = state.holidayPrefs ?? {};
+  const showHolidayToggle = hp.holiday_show_public;
+  const showSchoolToggle  = hp.holiday_show_school;
+
+  const holidayToggleHtml = (showHolidayToggle || showSchoolToggle) ? `
+    <div class="cal-toolbar__layers">
+      ${showHolidayToggle ? `
+        <button class="cal-toolbar__layer-btn ${state.layerHolidays ? 'cal-toolbar__layer-btn--active' : ''}"
+                id="cal-layer-holidays" data-layer="holidays"
+                title="${t('calendar.toggleHolidays')}"
+                style="--layer-color:${esc(hp.holiday_public_color ?? '#FF3B30')}">
+          <span class="cal-toolbar__layer-dot"></span>
+          <span>${t('calendar.toggleHolidays')}</span>
+        </button>
+      ` : ''}
+      ${showSchoolToggle ? `
+        <button class="cal-toolbar__layer-btn ${state.layerSchool ? 'cal-toolbar__layer-btn--active' : ''}"
+                id="cal-layer-school" data-layer="school"
+                title="${t('calendar.toggleSchool')}"
+                style="--layer-color:${esc(hp.holiday_school_color ?? '#34C759')}">
+          <span class="cal-toolbar__layer-dot"></span>
+          <span>${t('calendar.toggleSchool')}</span>
+        </button>
+      ` : ''}
+    </div>
+  ` : '';
+
   bar.replaceChildren();
   bar.insertAdjacentHTML('beforeend', `
     <h1 class="sr-only">${t('calendar.title')}</h1>
@@ -796,6 +850,7 @@ function renderToolbar() {
     </div>
     <button class="cal-toolbar__today" id="cal-today">${t('calendar.today')}</button>
     <span class="cal-toolbar__label" id="cal-label"></span>
+    ${holidayToggleHtml}
     <div class="cal-toolbar__views">
       ${VIEWS.map((v) => `
         <button class="cal-toolbar__view-btn ${v === state.view ? 'cal-toolbar__view-btn--active' : ''}"
@@ -821,6 +876,22 @@ function renderToolbar() {
   bar.querySelector('#cal-next').addEventListener('click', () => navigate(1));
   bar.querySelector('#cal-today').addEventListener('click', goToday);
   bar.querySelector('#cal-add').addEventListener('click', () => openEventModal({ mode: 'create' }));
+
+  bar.querySelectorAll('[data-layer]').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      const layer = btn.dataset.layer;
+      if (layer === 'holidays') {
+        state.layerHolidays = !state.layerHolidays;
+        localStorage.setItem(LAYER_HOLIDAYS_KEY, state.layerHolidays);
+        btn.classList.toggle('cal-toolbar__layer-btn--active', state.layerHolidays);
+      } else if (layer === 'school') {
+        state.layerSchool = !state.layerSchool;
+        localStorage.setItem(LAYER_SCHOOL_KEY, state.layerSchool);
+        btn.classList.toggle('cal-toolbar__layer-btn--active', state.layerSchool);
+      }
+      renderView();
+    });
+  });
 
   bar.querySelectorAll('[data-view]').forEach((btn) => {
     btn.addEventListener('click', async () => {
@@ -982,6 +1053,7 @@ function renderMonthView(container) {
 function renderMonthDay(date, inMonth) {
   const evs      = eventsOnDay(date);
   const dayTasks = tasksOnDay(date);
+  const dayHols  = holidaysOnDay(date);
   const isToday  = date === state.today;
   const classes  = [
     'month-day',
@@ -1008,9 +1080,16 @@ function renderMonthDay(date, inMonth) {
   const MAX_TASK_SHOW = 2;
   const taskHtml = dayTasks.slice(0, MAX_TASK_SHOW).map(renderTaskChip).join('');
 
+  const holHtml = dayHols.map((h) => `
+    <div class="month-day__holiday" style="--holi-color:${esc(h.color)}" title="${esc(h.name)}">
+      <span>${esc(h.name)}</span>
+    </div>
+  `).join('');
+
   return `
     <div class="${classes}" data-date="${date}">
       <div class="month-day__number">${new Date(date + 'T00:00:00').getDate()}</div>
+      ${holHtml}
       ${evHtml}
       ${extra > 0 ? `<div class="month-day__more">${t('calendar.moreEvents', { count: extra })}</div>` : ''}
       ${taskHtml}
@@ -1060,6 +1139,11 @@ function renderWeekView(container) {
         <div class="calendar-all-day-label">${t('calendar.allDayShort')}</div>
         ${days.map((d, i) => `
           <div class="allday-cell">
+            ${holidaysOnDay(d).map((h) => `
+              <div class="allday-holiday" style="--holi-color:${esc(h.color)}" title="${esc(h.name)}">
+                <span>${esc(h.name)}</span>
+              </div>
+            `).join('')}
             ${alldayEvs[i].map((ev) => `
               <div class="allday-event" data-id="${ev.id}"
                    style="${ev.color || ev.cal_color ? `background-color:${esc(ev.color || ev.cal_color)};` : ''}${getContrastColor(ev.color || ev.cal_color) ? `color:${getContrastColor(ev.color || ev.cal_color)};` : ''}"
@@ -1240,10 +1324,15 @@ function renderDayView(container) {
       <div class="day-view__header">
         <div class="day-view__date-label">${formatDate(state.cursor, { weekday: true, long: true })}</div>
       </div>
-      ${(allday.length || tasksOnDay(state.cursor).length) ? `
+      ${(allday.length || tasksOnDay(state.cursor).length || holidaysOnDay(state.cursor).length) ? `
       <div class="allday-row" style="display:grid;grid-template-columns:var(--space-12) 1fr;">
         <div class="calendar-all-day-label">${t('calendar.allDayShort')}</div>
         <div class="allday-cell">
+          ${holidaysOnDay(state.cursor).map((h) => `
+            <div class="allday-holiday" style="--holi-color:${esc(h.color)}" title="${esc(h.name)}">
+              <span>${esc(h.name)}</span>
+            </div>
+          `).join('')}
           ${allday.map((ev) => `
             <div class="allday-event" data-id="${ev.id}"
                  style="${ev.color || ev.cal_color ? `background-color:${esc(ev.color || ev.cal_color)};` : ''}${getContrastColor(ev.color || ev.cal_color) ? `color:${getContrastColor(ev.color || ev.cal_color)};` : ''}"
@@ -1311,20 +1400,25 @@ function renderAgendaView(container) {
   const days = Array.from({ length: 31 }, (_, i) => addDays(from, i));
 
   const groups = days
-    .map((d) => ({ date: d, events: eventsOnDay(d), tasks: tasksOnDay(d) }))
-    .filter((g) => g.events.length > 0 || g.tasks.length > 0);
+    .map((d) => ({ date: d, events: eventsOnDay(d), tasks: tasksOnDay(d), holidays: holidaysOnDay(d) }))
+    .filter((g) => g.events.length > 0 || g.tasks.length > 0 || g.holidays.length > 0);
 
   container.replaceChildren();
   container.insertAdjacentHTML('beforeend', `
     <div class="agenda-view" id="agenda-view">
       ${groups.length === 0
         ? `<div class="agenda-empty">${t('calendar.agendaEmpty')}</div>`
-        : groups.map(({ date, events, tasks }) => `
+        : groups.map(({ date, events, tasks, holidays }) => `
           <div class="agenda-day">
             <div class="agenda-day__header ${date === state.today ? 'agenda-day__header--today' : ''}">
               <span class="agenda-day__date">${formatDate(date)}</span>
               <span class="agenda-day__weekday">${DAY_NAMES_LONG()[new Date(date + 'T00:00:00').getDay()]}</span>
             </div>
+            ${holidays.length ? `<div class="agenda-holidays">${holidays.map((h) => `
+              <div class="agenda-holiday" style="--holi-color:${esc(h.color)}">
+                <span class="agenda-holiday__dot"></span>
+                <span>${esc(h.name)}</span>
+              </div>`).join('')}</div>` : ''}
             ${events.map((ev) => renderAgendaEvent(ev, date)).join('')}
             ${tasks.length ? `<div class="agenda-tasks">${tasks.map(renderTaskChip).join('')}</div>` : ''}
           </div>

--- a/public/pages/settings.js
+++ b/public/pages/settings.js
@@ -2053,6 +2053,25 @@ function bindEvents(container, user, users, categories, icsSubscriptions, apiTok
       }
       syncBtn.disabled = true;
       try {
+        // Einstellungen zuerst speichern, damit sync() die aktuellen Werte liest.
+        // Wenn noch kein Toggle aktiviert ist, Public Holidays automatisch einschalten.
+        const showPublicCbEl  = container.querySelector('#holiday-show-public');
+        const showSchoolCbEl  = container.querySelector('#holiday-show-school');
+        const noneEnabled = !showPublicCbEl?.checked && !showSchoolCbEl?.checked;
+        if (noneEnabled && showPublicCbEl) {
+          showPublicCbEl.checked = true;
+          const pubGrp = container.querySelector('#holiday-public-color-group');
+          if (pubGrp) pubGrp.hidden = false;
+        }
+        await api.put('/preferences', {
+          holiday_country:      countrySelect.value || null,
+          holiday_subdivision:  subdivisionSelect.value || null,
+          holiday_show_public:  container.querySelector('#holiday-show-public')?.checked ?? false,
+          holiday_show_school:  container.querySelector('#holiday-show-school')?.checked ?? false,
+          holiday_public_color: container.querySelector('#holiday-public-color')?.value ?? '#FF3B30',
+          holiday_school_color: container.querySelector('#holiday-school-color')?.value ?? '#34C759',
+        });
+
         const res = await api.post('/preferences/holidays/sync', {});
         const lastSyncLabel = container.querySelector('#holiday-last-sync-label');
         if (lastSyncLabel && res.data?.last_sync) {

--- a/public/pages/settings.js
+++ b/public/pages/settings.js
@@ -264,7 +264,7 @@ export async function render(container, { user }) {
       : t('settings.notConnected');
 
   const allowedTabs = [
-    'general', 'meals', 'budget', 'shopping', 'sync',
+    'general', 'meals', 'budget', 'shopping', 'calendar', 'sync',
     ...(user?.role === 'admin' ? ['family', 'api-tokens'] : []),
     'account',
     ...(user?.role === 'admin' ? ['backup'] : []),
@@ -542,6 +542,76 @@ export async function render(container, { user }) {
             </form>
           </div>
         </section>
+      </div>
+
+      <!-- Panel: Kalender -->
+      <div class="settings-tab-panel" data-panel="calendar" role="tabpanel"
+        data-holiday-country="${esc(prefs.holiday_country ?? '')}"
+        data-holiday-subdivision="${esc(prefs.holiday_subdivision ?? '')}"
+        ${panelHidden('calendar')}>
+        ${user?.role === 'admin' ? `
+        <section class="settings-section">
+          <h2 class="settings-section__title">${t('settings.sectionHolidays')}</h2>
+          <div class="settings-card" id="holidays-card">
+            <h3 class="settings-card__title">${t('settings.holidayTitle')}</h3>
+            <p class="settings-card-description">${t('settings.holidayDescription')}</p>
+
+            <form class="settings-form settings-form--compact" id="holidays-form" novalidate autocomplete="off">
+              <div class="form-group">
+                <label class="form-label" for="holiday-country">${t('settings.holidayCountryLabel')}</label>
+                <select class="form-input" id="holiday-country">
+                  <option value="">${t('settings.holidayCountryPlaceholder')}</option>
+                </select>
+              </div>
+              <div class="form-group">
+                <label class="form-label" for="holiday-subdivision">${t('settings.holidaySubdivisionLabel')}</label>
+                <select class="form-input" id="holiday-subdivision" disabled>
+                  <option value="">${t('settings.holidaySubdivisionNone')}</option>
+                </select>
+              </div>
+              <div class="form-group">
+                <label class="toggle-row">
+                  <input type="checkbox" id="holiday-show-public" ${prefs.holiday_show_public ? 'checked' : ''}>
+                  <span>${t('settings.holidayPublicLabel')}</span>
+                </label>
+              </div>
+              <div class="form-group" id="holiday-public-color-group" ${!prefs.holiday_show_public ? 'hidden' : ''}>
+                <label class="form-label" for="holiday-public-color">${t('settings.holidayPublicColor')}</label>
+                <input class="form-input" type="color" id="holiday-public-color"
+                  value="${esc(prefs.holiday_public_color ?? '#FF3B30')}" />
+              </div>
+              <div class="form-group">
+                <label class="toggle-row">
+                  <input type="checkbox" id="holiday-show-school" ${prefs.holiday_show_school ? 'checked' : ''}>
+                  <span>${t('settings.holidaySchoolLabel')}</span>
+                </label>
+              </div>
+              <div class="form-group" id="holiday-school-color-group" ${!prefs.holiday_show_school ? 'hidden' : ''}>
+                <label class="form-label" for="holiday-school-color">${t('settings.holidaySchoolColor')}</label>
+                <input class="form-input" type="color" id="holiday-school-color"
+                  value="${esc(prefs.holiday_school_color ?? '#34C759')}" />
+              </div>
+              <div id="holidays-form-error" class="form-error" hidden></div>
+              <div class="settings-form-actions">
+                <button type="submit" class="btn btn--primary">${t('settings.holidaySaveBtn')}</button>
+              </div>
+            </form>
+
+            <div class="settings-sync-info" style="margin-top:var(--space-4)">
+              <span class="form-label" id="holiday-last-sync-label">
+                ${prefs.holiday_last_sync
+                  ? t('settings.holidayLastSync', { date: new Date(prefs.holiday_last_sync).toLocaleString() })
+                  : t('settings.holidayNeverSynced')}
+              </span>
+              <button type="button" class="btn btn--secondary btn--sm" id="holiday-sync-btn"
+                ${!prefs.holiday_country ? 'disabled title="' + t('settings.holidayCountryRequired') + '"' : ''}>
+                <i data-lucide="refresh-cw" aria-hidden="true"></i>
+                ${t('settings.holidaySyncBtn')}
+              </button>
+            </div>
+          </div>
+        </section>
+        ` : '<p class="form-hint" style="padding:var(--space-4)">' + t('settings.adminOnly') + '</p>'}
       </div>
 
       <!-- Panel: Synchronisation -->
@@ -1383,6 +1453,7 @@ function buildSettingsTabs(user) {
     { id: 'meals',      label: t('settings.tabMeals'),      icon: 'utensils'       },
     { id: 'budget',     label: t('settings.tabBudget'),     icon: 'wallet'         },
     { id: 'shopping',   label: t('settings.tabShopping'),   icon: 'shopping-cart'  },
+    { id: 'calendar',   label: t('settings.tabCalendar'),   icon: 'calendar'       },
     { id: 'sync',       label: t('settings.tabSync'),       icon: 'refresh-cw',    separatorBefore: true },
     { id: 'account',    label: t('settings.tabAccount'),    icon: 'user',          separatorBefore: true },
   ];
@@ -1876,6 +1947,126 @@ function bindEvents(container, user, users, categories, icsSubscriptions, apiTok
         );
       });
     }
+  }
+
+  // ── Holiday config (admin) ────────────────────────────────────────────────
+  const holidaysForm = container.querySelector('#holidays-form');
+  if (holidaysForm) {
+    // Populate countries dropdown
+    const countrySelect = container.querySelector('#holiday-country');
+    const subdivisionSelect = container.querySelector('#holiday-subdivision');
+    const syncBtn = container.querySelector('#holiday-sync-btn');
+    const errEl = container.querySelector('#holidays-form-error');
+
+    (async () => {
+      try {
+        const res = await api.get('/preferences/holidays/countries');
+        const panel = container.querySelector('[data-panel="calendar"]');
+        const savedCode = panel?.dataset.holidayCountry ?? '';
+        for (const c of (res.data ?? [])) {
+          const opt = document.createElement('option');
+          opt.value = c.isoCode;
+          opt.textContent = c.name;
+          if (c.isoCode === savedCode) opt.selected = true;
+          countrySelect.appendChild(opt);
+        }
+        // After populating country list, load subdivisions for saved country
+        if (savedCode) {
+          const savedSub = panel?.dataset.holidaySubdivision ?? '';
+          await loadSubdivisions(savedCode, savedSub);
+        }
+      } catch { /* silently ignore if API unavailable */ }
+    })();
+
+    // Load subdivisions for a given country code
+    async function loadSubdivisions(countryCode, selectedCode) {
+      subdivisionSelect.innerHTML = `<option value="">${t('settings.holidaySubdivisionNone')}</option>`;
+      subdivisionSelect.disabled = true;
+      if (!countryCode) return;
+      try {
+        const res = await api.get(`/preferences/holidays/subdivisions/${countryCode}`);
+        for (const s of (res.data ?? [])) {
+          const opt = document.createElement('option');
+          opt.value = s.isoCode;
+          opt.textContent = s.name;
+          if (s.isoCode === selectedCode) opt.selected = true;
+          subdivisionSelect.appendChild(opt);
+        }
+        if ((res.data ?? []).length > 0) subdivisionSelect.disabled = false;
+      } catch { /* ignore */ }
+    }
+
+    // Set sync button initial state
+    if (syncBtn) {
+      const panel = container.querySelector('[data-panel="calendar"]');
+      const savedCode = panel?.dataset.holidayCountry ?? '';
+      syncBtn.disabled = !savedCode;
+      if (!savedCode) syncBtn.title = t('settings.holidayCountryRequired');
+    }
+
+    countrySelect.addEventListener('change', () => {
+      const code = countrySelect.value;
+      loadSubdivisions(code, '');
+      if (syncBtn) {
+        syncBtn.disabled = !code;
+        syncBtn.title = code ? '' : t('settings.holidayCountryRequired');
+      }
+    });
+
+    // Show/hide color pickers based on toggles
+    const showPublicCb  = container.querySelector('#holiday-show-public');
+    const showSchoolCb  = container.querySelector('#holiday-show-school');
+    const publicColorGr = container.querySelector('#holiday-public-color-group');
+    const schoolColorGr = container.querySelector('#holiday-school-color-group');
+    showPublicCb?.addEventListener('change', () => { if (publicColorGr) publicColorGr.hidden = !showPublicCb.checked; });
+    showSchoolCb?.addEventListener('change', () => { if (schoolColorGr) schoolColorGr.hidden = !showSchoolCb.checked; });
+
+    holidaysForm.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      errEl.hidden = true;
+      const country     = countrySelect.value || null;
+      const subdivision = subdivisionSelect.value || null;
+      const showPublic  = container.querySelector('#holiday-show-public').checked;
+      const showSchool  = container.querySelector('#holiday-show-school').checked;
+      const publicColor = container.querySelector('#holiday-public-color').value;
+      const schoolColor = container.querySelector('#holiday-school-color').value;
+      try {
+        await api.put('/preferences', {
+          holiday_country:      country,
+          holiday_subdivision:  subdivision,
+          holiday_show_public:  showPublic,
+          holiday_show_school:  showSchool,
+          holiday_public_color: publicColor,
+          holiday_school_color: schoolColor,
+        });
+        window.oikos?.showToast(t('settings.holidaySaved'), 'success');
+      } catch (err) {
+        errEl.textContent = err.message ?? t('common.errorGeneric');
+        errEl.hidden = false;
+      }
+    });
+
+    syncBtn?.addEventListener('click', async () => {
+      if (!countrySelect.value) {
+        window.oikos?.showToast(t('settings.holidayCountryRequired'), 'warning');
+        return;
+      }
+      syncBtn.disabled = true;
+      try {
+        const res = await api.post('/preferences/holidays/sync', {});
+        const lastSyncLabel = container.querySelector('#holiday-last-sync-label');
+        if (lastSyncLabel && res.data?.last_sync) {
+          lastSyncLabel.textContent = t('settings.holidayLastSync', {
+            date: new Date(res.data.last_sync).toLocaleString(),
+          });
+        }
+        window.oikos?.showToast(t('settings.holidaySynced'), 'success');
+      } catch (err) {
+        window.oikos?.showToast(err.message ?? t('settings.holidaySyncError'), 'danger');
+      } finally {
+        syncBtn.disabled = !countrySelect.value;
+      }
+    });
   }
 
   const appNameForm = container.querySelector('#app-name-form');

--- a/public/styles/calendar.css
+++ b/public/styles/calendar.css
@@ -1201,7 +1201,7 @@
 .agenda-holiday {
   display: inline-flex;
   align-items: center;
-  gap: var(--space-1h);
+  gap: var(--space-2);
   font-size: var(--text-xs);
   font-weight: var(--font-weight-medium);
   color: var(--color-text-primary);
@@ -1232,7 +1232,7 @@
 .cal-toolbar__layer-btn {
   display: inline-flex;
   align-items: center;
-  gap: var(--space-1h);
+  gap: var(--space-2);
   padding: var(--space-1) var(--space-2);
   border-radius: var(--radius-full);
   border: 1px solid color-mix(in srgb, var(--layer-color) 40%, transparent);

--- a/public/styles/calendar.css
+++ b/public/styles/calendar.css
@@ -1131,3 +1131,154 @@
 .agenda-tasks .cal-task-chip {
   margin-bottom: 0;
 }
+
+/* --------------------------------------------------------
+ * Holiday layer – month, week/day all-day row, agenda
+ * -------------------------------------------------------- */
+
+/* Month view: slim colored band below day number */
+.month-day__holiday {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  font-size: var(--text-xs);
+  font-weight: var(--font-weight-medium);
+  padding: 1px var(--space-1);
+  border-radius: var(--radius-xs);
+  margin-bottom: 2px;
+  color: #fff;
+  background: color-mix(in srgb, var(--holi-color) 90%, transparent);
+  border-left: 3px solid var(--holi-color);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  pointer-events: none;
+  user-select: none;
+}
+
+.month-day__holiday span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+
+/* Week/Day view: holiday chip in the all-day row */
+.allday-holiday {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  font-size: var(--text-xs);
+  font-weight: var(--font-weight-medium);
+  padding: var(--space-px) var(--space-1);
+  border-radius: var(--radius-xs);
+  color: #fff;
+  background: color-mix(in srgb, var(--holi-color) 88%, transparent);
+  border-left: 3px solid var(--holi-color);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin-bottom: var(--space-0h);
+  pointer-events: none;
+  user-select: none;
+}
+
+.allday-holiday span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+
+/* Agenda view: compact holiday row before events */
+.agenda-holidays {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-1);
+  padding: var(--space-1) var(--space-3);
+}
+
+.agenda-holiday {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1h);
+  font-size: var(--text-xs);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text-primary);
+  padding: 2px var(--space-2);
+  border-radius: var(--radius-full);
+  background: color-mix(in srgb, var(--holi-color) 15%, var(--color-surface));
+  border: 1px solid color-mix(in srgb, var(--holi-color) 40%, transparent);
+}
+
+.agenda-holiday__dot {
+  width: 8px;
+  height: 8px;
+  border-radius: var(--radius-full);
+  background: var(--holi-color);
+  flex-shrink: 0;
+}
+
+/* --------------------------------------------------------
+ * Toolbar holiday layer toggle buttons
+ * -------------------------------------------------------- */
+.cal-toolbar__layers {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  flex-shrink: 0;
+}
+
+.cal-toolbar__layer-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1h);
+  padding: var(--space-1) var(--space-2);
+  border-radius: var(--radius-full);
+  border: 1px solid color-mix(in srgb, var(--layer-color) 40%, transparent);
+  background: transparent;
+  color: var(--color-text-secondary);
+  font-size: var(--text-xs);
+  font-weight: var(--font-weight-medium);
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+  white-space: nowrap;
+}
+
+.cal-toolbar__layer-btn:hover {
+  background: color-mix(in srgb, var(--layer-color) 12%, transparent);
+  color: var(--color-text-primary);
+}
+
+.cal-toolbar__layer-btn--active {
+  background: color-mix(in srgb, var(--layer-color) 18%, var(--color-surface));
+  color: var(--color-text-primary);
+  border-color: color-mix(in srgb, var(--layer-color) 60%, transparent);
+}
+
+.cal-toolbar__layer-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: var(--radius-full);
+  background: var(--layer-color);
+  flex-shrink: 0;
+  opacity: 0.5;
+  transition: opacity 0.15s;
+}
+
+.cal-toolbar__layer-btn--active .cal-toolbar__layer-dot {
+  opacity: 1;
+}
+
+@media (max-width: 639px) {
+  .cal-toolbar__layer-btn span:not(.cal-toolbar__layer-dot) {
+    display: none;
+  }
+  .cal-toolbar__layer-btn {
+    padding: var(--space-1);
+    border-radius: var(--radius-full);
+    width: 28px;
+    height: 28px;
+    justify-content: center;
+  }
+}

--- a/server/db.js
+++ b/server/db.js
@@ -1798,6 +1798,27 @@ const MIGRATIONS = [
       ALTER TABLE housekeeping_work_sessions ADD COLUMN minutes_worked INTEGER;
     `,
   },
+  {
+    version: 49,
+    description: 'Holiday cache for public holidays and school holidays',
+    up: `
+      CREATE TABLE IF NOT EXISTS holiday_cache (
+        id          INTEGER PRIMARY KEY AUTOINCREMENT,
+        type        TEXT    NOT NULL CHECK(type IN ('public', 'school')),
+        country     TEXT    NOT NULL,
+        subdivision TEXT,
+        start_date  TEXT    NOT NULL,
+        end_date    TEXT    NOT NULL,
+        name        TEXT    NOT NULL,
+        year        INTEGER NOT NULL
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_holiday_cache_dates
+        ON holiday_cache(start_date, end_date);
+      CREATE INDEX IF NOT EXISTS idx_holiday_cache_lookup
+        ON holiday_cache(type, country, subdivision, year);
+    `,
+  },
 ];
 
 /**

--- a/server/index.js
+++ b/server/index.js
@@ -19,6 +19,7 @@ import * as googleCalendar from './services/google-calendar.js';
 import * as appleCalendar from './services/apple-calendar.js';
 import * as icsSubscription from './services/ics-subscription.js';
 import * as caldavReminders from './services/caldav-reminders-sync.js';
+import * as holidays from './services/holidays.js';
 import { startScheduler as startBackupScheduler } from './services/backup-scheduler.js';
 import { startScheduler as startSplitExpenseScheduler } from './services/split-expenses-scheduler.js';
 import dashboardRouter from './routes/dashboard.js';
@@ -374,6 +375,9 @@ async function runSync() {
   // CalDAV Reminders (VTODO → Tasks/Shopping): kein Guard nötig — sync() kehrt sofort
   // zurück, wenn keine aktivierten Reminder-Listen konfiguriert sind.
   caldavReminders.sync().catch((e) => logSync.error('CalDAV reminders error:', e.message));
+
+  // Holidays: kein Guard nötig — sync() kehrt sofort zurück, wenn kein Land konfiguriert ist.
+  holidays.sync().catch((e) => logSync.error('Holidays error:', e.message));
 }
 
 // --------------------------------------------------------

--- a/server/routes/calendar.js
+++ b/server/routes/calendar.js
@@ -621,6 +621,24 @@ router.post('/subscriptions/:id/sync', async (req, res) => {
   }
 });
 
+// ---------------------------------------------------------------------------
+// GET /api/v1/calendar/holidays?from=YYYY-MM-DD&to=YYYY-MM-DD
+// Muss VOR /:id stehen, damit "holidays" nicht als ID-Parameter interpretiert wird.
+// ---------------------------------------------------------------------------
+router.get('/holidays', (req, res) => {
+  try {
+    const { from, to } = req.query;
+    if (!from || !to || !/^\d{4}-\d{2}-\d{2}$/.test(from) || !/^\d{4}-\d{2}-\d{2}$/.test(to)) {
+      return res.status(400).json({ error: 'Query params from and to (YYYY-MM-DD) required.', code: 400 });
+    }
+    const data = holidays.getForRange(from, to);
+    res.json({ data });
+  } catch (err) {
+    log.error('GET /holidays', err);
+    res.status(500).json({ error: 'Interner Fehler.', code: 500 });
+  }
+});
+
 // --------------------------------------------------------
 // GET /api/v1/calendar/:id
 // Einzelnen Termin abrufen.
@@ -1086,23 +1104,4 @@ router.get('/caldav/reminders/status', (req, res) => {
 });
 
 export const __test = { googleTarget };
-
-// ---------------------------------------------------------------------------
-// GET /api/v1/calendar/holidays?from=YYYY-MM-DD&to=YYYY-MM-DD
-// Returns holiday entries from the local cache for the configured country.
-// ---------------------------------------------------------------------------
-router.get('/holidays', (req, res) => {
-  try {
-    const { from, to } = req.query;
-    if (!from || !to || !/^\d{4}-\d{2}-\d{2}$/.test(from) || !/^\d{4}-\d{2}-\d{2}$/.test(to)) {
-      return res.status(400).json({ error: 'Query params from and to (YYYY-MM-DD) required.', code: 400 });
-    }
-    const data = holidays.getForRange(from, to);
-    res.json({ data });
-  } catch (err) {
-    log.error('GET /holidays', err);
-    res.status(500).json({ error: 'Interner Fehler.', code: 500 });
-  }
-});
-
 export default router;

--- a/server/routes/calendar.js
+++ b/server/routes/calendar.js
@@ -13,6 +13,7 @@ import * as appleCalendar from '../services/apple-calendar.js';
 import * as icsSubscription from '../services/ics-subscription.js';
 import * as caldavSync from '../services/caldav-sync.js';
 import * as caldavReminders from '../services/caldav-reminders-sync.js';
+import * as holidays from '../services/holidays.js';
 import { requireAdmin } from '../auth.js';
 import { str, color, datetime, rrule, collectErrors, MAX_TITLE, MAX_TEXT, DATE_RE, DATETIME_RE } from '../middleware/validate.js';
 import { expandRecurringEvents, getUpcomingEvents } from '../services/calendar-events.js';
@@ -1085,4 +1086,23 @@ router.get('/caldav/reminders/status', (req, res) => {
 });
 
 export const __test = { googleTarget };
+
+// ---------------------------------------------------------------------------
+// GET /api/v1/calendar/holidays?from=YYYY-MM-DD&to=YYYY-MM-DD
+// Returns holiday entries from the local cache for the configured country.
+// ---------------------------------------------------------------------------
+router.get('/holidays', (req, res) => {
+  try {
+    const { from, to } = req.query;
+    if (!from || !to || !/^\d{4}-\d{2}-\d{2}$/.test(from) || !/^\d{4}-\d{2}-\d{2}$/.test(to)) {
+      return res.status(400).json({ error: 'Query params from and to (YYYY-MM-DD) required.', code: 400 });
+    }
+    const data = holidays.getForRange(from, to);
+    res.json({ data });
+  } catch (err) {
+    log.error('GET /holidays', err);
+    res.status(500).json({ error: 'Interner Fehler.', code: 500 });
+  }
+});
+
 export default router;

--- a/server/routes/preferences.js
+++ b/server/routes/preferences.js
@@ -7,6 +7,7 @@
 import { createLogger } from '../logger.js';
 import express from 'express';
 import * as db from '../db.js';
+import * as holidays from '../services/holidays.js';
 import { str, MAX_SHORT } from '../middleware/validate.js';
 
 const log = createLogger('Preferences');
@@ -27,6 +28,10 @@ const DEFAULT_TIME_FORMAT = '24h';
 
 const VALID_WEATHER_PROVIDERS = ['open-meteo', 'openweathermap'];
 const VALID_WEATHER_UNITS = ['metric', 'imperial'];
+
+const HEX_COLOR_RE = /^#[0-9a-fA-F]{6}$/;
+const COUNTRY_ISO_RE = /^[A-Z]{2}$/;
+const SUBDIVISION_RE = /^[A-Z]{2}-[A-Z0-9-]{1,10}$/;
 
 const VALID_WIDGET_IDS = ['tasks', 'calendar', 'weather', 'meals', 'shopping', 'birthdays', 'budget', 'family', 'notes'];
 const VALID_WIDGET_SIZES = ['1x1', '1x2', '1x3', '1x4', '2x1', '2x2', '2x3', '2x4', '3x1', '3x2', '3x3', '3x4', '4x1', '4x2', '4x3', '4x4'];
@@ -182,6 +187,13 @@ router.get('/', (req, res) => {
         weather_lon:      cfgGet('weather_lon')      ?? null,
         weather_city:     cfgGet('weather_city')     ?? '',
         weather_units:    cfgGet('weather_units')    ?? 'metric',
+        holiday_country:       cfgGet('holiday_country')       ?? null,
+        holiday_subdivision:   cfgGet('holiday_subdivision')   ?? null,
+        holiday_show_public:   cfgGet('holiday_show_public')   === '1',
+        holiday_show_school:   cfgGet('holiday_show_school')   === '1',
+        holiday_public_color:  cfgGet('holiday_public_color')  ?? '#FF3B30',
+        holiday_school_color:  cfgGet('holiday_school_color')  ?? '#34C759',
+        holiday_last_sync:     cfgGet('holiday_last_sync')     ?? null,
       },
     });
   } catch (err) {
@@ -199,7 +211,7 @@ router.get('/', (req, res) => {
 
 router.put('/', (req, res) => {
   try {
-    const { visible_meal_types, currency, date_format, time_format, app_name, dashboard_widgets, disabled_modules, module_order, housekeeping_payment_tasks, weather_provider, weather_lat, weather_lon, weather_city, weather_units } = req.body;
+    const { visible_meal_types, currency, date_format, time_format, app_name, dashboard_widgets, disabled_modules, module_order, housekeeping_payment_tasks, weather_provider, weather_lat, weather_lon, weather_city, weather_units, holiday_country, holiday_subdivision, holiday_show_public, holiday_show_school, holiday_public_color, holiday_school_color } = req.body;
 
     if (visible_meal_types !== undefined) {
       if (!Array.isArray(visible_meal_types)) {
@@ -321,6 +333,62 @@ router.put('/', (req, res) => {
       }
     }
 
+    // Holiday configuration — admin only
+    if (
+      holiday_country      !== undefined ||
+      holiday_subdivision  !== undefined ||
+      holiday_show_public  !== undefined ||
+      holiday_show_school  !== undefined ||
+      holiday_public_color !== undefined ||
+      holiday_school_color !== undefined
+    ) {
+      if (req.authRole !== 'admin') {
+        return res.status(403).json({ error: 'Admin access required.', code: 403 });
+      }
+      if (holiday_country !== undefined) {
+        if (holiday_country !== null && !COUNTRY_ISO_RE.test(holiday_country)) {
+          return res.status(400).json({ error: 'Ungültiger Ländercode (2 Großbuchstaben, z. B. DE).', code: 400 });
+        }
+        if (holiday_country === null) {
+          cfgDelete('holiday_country');
+          cfgDelete('holiday_subdivision');
+        } else {
+          cfgSet('holiday_country', holiday_country);
+        }
+      }
+      if (holiday_subdivision !== undefined) {
+        if (holiday_subdivision !== null && !SUBDIVISION_RE.test(holiday_subdivision)) {
+          return res.status(400).json({ error: 'Ungültiger Regionscode (z. B. DE-BY).', code: 400 });
+        }
+        if (holiday_subdivision === null) cfgDelete('holiday_subdivision');
+        else cfgSet('holiday_subdivision', holiday_subdivision);
+      }
+      if (holiday_show_public !== undefined) {
+        if (typeof holiday_show_public !== 'boolean') {
+          return res.status(400).json({ error: 'holiday_show_public must be a boolean.', code: 400 });
+        }
+        cfgSet('holiday_show_public', holiday_show_public ? '1' : '0');
+      }
+      if (holiday_show_school !== undefined) {
+        if (typeof holiday_show_school !== 'boolean') {
+          return res.status(400).json({ error: 'holiday_show_school must be a boolean.', code: 400 });
+        }
+        cfgSet('holiday_show_school', holiday_show_school ? '1' : '0');
+      }
+      if (holiday_public_color !== undefined) {
+        if (!HEX_COLOR_RE.test(holiday_public_color)) {
+          return res.status(400).json({ error: 'holiday_public_color muss ein gültiger Hex-Farbwert sein (z. B. #FF3B30).', code: 400 });
+        }
+        cfgSet('holiday_public_color', holiday_public_color);
+      }
+      if (holiday_school_color !== undefined) {
+        if (!HEX_COLOR_RE.test(holiday_school_color)) {
+          return res.status(400).json({ error: 'holiday_school_color muss ein gültiger Hex-Farbwert sein (z. B. #34C759).', code: 400 });
+        }
+        cfgSet('holiday_school_color', holiday_school_color);
+      }
+    }
+
     const rawMealTypes = cfgGet('visible_meal_types') ?? DEFAULT_MEAL_TYPES;
     const savedMealTypes = rawMealTypes.split(',').filter((t) => VALID_MEAL_TYPES.includes(t));
     const savedCurrency = cfgGet('currency') ?? DEFAULT_CURRENCY;
@@ -348,11 +416,58 @@ router.put('/', (req, res) => {
         weather_lon:      cfgGet('weather_lon')      ?? null,
         weather_city:     cfgGet('weather_city')     ?? '',
         weather_units:    cfgGet('weather_units')    ?? 'metric',
+        holiday_country:       cfgGet('holiday_country')       ?? null,
+        holiday_subdivision:   cfgGet('holiday_subdivision')   ?? null,
+        holiday_show_public:   cfgGet('holiday_show_public')   === '1',
+        holiday_show_school:   cfgGet('holiday_show_school')   === '1',
+        holiday_public_color:  cfgGet('holiday_public_color')  ?? '#FF3B30',
+        holiday_school_color:  cfgGet('holiday_school_color')  ?? '#34C759',
+        holiday_last_sync:     cfgGet('holiday_last_sync')     ?? null,
       },
     });
   } catch (err) {
     log.error('PUT /', err);
     res.status(500).json({ error: 'Interner Fehler', code: 500 });
+  }
+});
+
+// GET /api/v1/preferences/holidays/countries
+router.get('/holidays/countries', async (_req, res) => {
+  try {
+    const countries = await holidays.getCountries();
+    res.json({ data: countries });
+  } catch (err) {
+    log.error('GET /holidays/countries', err);
+    res.status(502).json({ error: 'Fehler beim Abrufen der Länderliste.', code: 502 });
+  }
+});
+
+// GET /api/v1/preferences/holidays/subdivisions/:countryCode
+router.get('/holidays/subdivisions/:countryCode', async (req, res) => {
+  const { countryCode } = req.params;
+  if (!COUNTRY_ISO_RE.test(countryCode)) {
+    return res.status(400).json({ error: 'Ungültiger Ländercode.', code: 400 });
+  }
+  try {
+    const subdivisions = await holidays.getSubdivisions(countryCode);
+    res.json({ data: subdivisions });
+  } catch (err) {
+    log.error('GET /holidays/subdivisions/:countryCode', err);
+    res.status(502).json({ error: 'Fehler beim Abrufen der Regionsliste.', code: 502 });
+  }
+});
+
+// POST /api/v1/preferences/holidays/sync  (admin only)
+router.post('/holidays/sync', async (req, res) => {
+  if (req.authRole !== 'admin') {
+    return res.status(403).json({ error: 'Admin access required.', code: 403 });
+  }
+  try {
+    await holidays.sync();
+    res.json({ data: { last_sync: cfgGet('holiday_last_sync') ?? null } });
+  } catch (err) {
+    log.error('POST /holidays/sync', err);
+    res.status(502).json({ error: 'Fehler bei der Feiertags-Synchronisierung: ' + err.message, code: 502 });
   }
 });
 

--- a/server/services/holidays.js
+++ b/server/services/holidays.js
@@ -38,19 +38,27 @@ async function apiFetch(path) {
 
 /**
  * Alle verfügbaren Länder abrufen.
- * @returns {Promise<Array<{isoCode, name}>>}
+ * @returns {Promise<Array<{isoCode: string, name: string}>>}
  */
 async function getCountries() {
-  return apiFetch('/Countries');
+  const raw = await apiFetch('/Countries');
+  return (raw ?? []).map((c) => ({
+    isoCode: c.isoCode,
+    name: resolveName(c.name),
+  })).sort((a, b) => a.name.localeCompare(b.name));
 }
 
 /**
  * Unterteilungen (Bundesländer etc.) für ein Land abrufen.
  * @param {string} countryIsoCode z.B. 'DE'
- * @returns {Promise<Array<{code, shortName, name}>>}
+ * @returns {Promise<Array<{isoCode: string, name: string}>>}
  */
 async function getSubdivisions(countryIsoCode) {
-  return apiFetch(`/Subdivisions?countryIsoCode=${encodeURIComponent(countryIsoCode)}`);
+  const raw = await apiFetch(`/Subdivisions?countryIsoCode=${encodeURIComponent(countryIsoCode)}`);
+  return (raw ?? []).map((s) => ({
+    isoCode: s.isoCode ?? s.code,
+    name: resolveName(s.name) || s.shortName || s.isoCode || s.code,
+  })).sort((a, b) => a.name.localeCompare(b.name));
 }
 
 /**
@@ -116,8 +124,13 @@ async function sync() {
   const showPublic  = db.get().prepare("SELECT value FROM sync_config WHERE key='holiday_show_public'").get()?.value === '1';
   const showSchool  = db.get().prepare("SELECT value FROM sync_config WHERE key='holiday_show_school'").get()?.value === '1';
 
-  if (!country || (!showPublic && !showSchool)) {
-    log.info('No holiday country configured or both layers disabled – skipping sync.');
+  if (!country) {
+    log.info('No holiday country configured – skipping sync.');
+    return { synced: 0 };
+  }
+
+  if (!showPublic && !showSchool) {
+    log.info('Both holiday layers disabled – skipping sync.');
     return { synced: 0 };
   }
 

--- a/server/services/holidays.js
+++ b/server/services/holidays.js
@@ -1,0 +1,196 @@
+/**
+ * Modul: Feiertage & Schulferien (Holidays)
+ * Zweck: Fetch von der OpenHolidays API, Caching in holiday_cache-Tabelle,
+ *        periodischer Sync. Kein API-Key erforderlich.
+ * Quelle: https://openholidaysapi.org (open source, kostenlos)
+ * Abhängigkeiten: node-fetch, server/db.js
+ */
+
+import fetch from 'node-fetch';
+import { createLogger } from '../logger.js';
+import * as db from '../db.js';
+
+const log = createLogger('Holidays');
+
+const BASE_URL          = 'https://openholidaysapi.org';
+const FETCH_TIMEOUT_MS  = 15_000;
+const SYNC_YEARS_BACK   = 1;
+const SYNC_YEARS_AHEAD  = 2;
+
+// --------------------------------------------------------
+// API-Abfragen
+// --------------------------------------------------------
+
+async function apiFetch(path) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const res = await fetch(`${BASE_URL}${path}`, {
+      signal: controller.signal,
+      headers: { Accept: 'application/json' },
+    });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    return await res.json();
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Alle verfügbaren Länder abrufen.
+ * @returns {Promise<Array<{isoCode, name}>>}
+ */
+async function getCountries() {
+  return apiFetch('/Countries');
+}
+
+/**
+ * Unterteilungen (Bundesländer etc.) für ein Land abrufen.
+ * @param {string} countryIsoCode z.B. 'DE'
+ * @returns {Promise<Array<{code, shortName, name}>>}
+ */
+async function getSubdivisions(countryIsoCode) {
+  return apiFetch(`/Subdivisions?countryIsoCode=${encodeURIComponent(countryIsoCode)}`);
+}
+
+/**
+ * Gibt den Anzeigenamen aus dem name-Array zurück (bevorzugt EN, sonst erstes).
+ * @param {Array<{language, text}>} nameArr
+ * @param {string} [preferLang='EN']
+ */
+function resolveName(nameArr, preferLang = 'EN') {
+  if (!Array.isArray(nameArr) || nameArr.length === 0) return '';
+  const preferred = nameArr.find((n) => n.language === preferLang);
+  return (preferred ?? nameArr[0]).text ?? '';
+}
+
+// --------------------------------------------------------
+// Sync-Logik
+// --------------------------------------------------------
+
+async function syncYearAndType(country, subdivision, year, type, langCode) {
+  const from = `${year}-01-01`;
+  const to   = `${year}-12-31`;
+  const endpoint = type === 'public' ? 'PublicHolidays' : 'SchoolHolidays';
+
+  let params = `countryIsoCode=${encodeURIComponent(country)}&languageIsoCode=${encodeURIComponent(langCode)}&validFrom=${from}&validTo=${to}`;
+  if (subdivision) params += `&subdivisionCode=${encodeURIComponent(subdivision)}`;
+
+  let holidays;
+  try {
+    holidays = await apiFetch(`/${endpoint}?${params}`);
+  } catch (err) {
+    log.warn(`Fetch ${endpoint} ${country}/${subdivision ?? '-'}/${year}: ${err.message}`);
+    return 0;
+  }
+
+  if (!Array.isArray(holidays) || holidays.length === 0) return 0;
+
+  const insert = db.get().prepare(`
+    INSERT INTO holiday_cache (type, country, subdivision, start_date, end_date, name, year)
+    VALUES (?, ?, ?, ?, ?, ?, ?)
+  `);
+
+  const insertAll = db.get().transaction((rows) => {
+    for (const h of rows) {
+      insert.run(type, country, subdivision ?? null, h.startDate, h.endDate, resolveName(h.name, langCode.toUpperCase()), year);
+    }
+  });
+
+  // Alte Einträge für diesen Scope löschen, dann neu einfügen
+  db.get().prepare(
+    'DELETE FROM holiday_cache WHERE type = ? AND country = ? AND (subdivision IS ? OR subdivision = ?) AND year = ?'
+  ).run(type, country, subdivision ?? null, subdivision ?? '', year);
+
+  insertAll(holidays);
+  return holidays.length;
+}
+
+/**
+ * Sync Feiertage und/oder Schulferien für das konfigurierte Land/Region.
+ * Wird vom Auto-Scheduler und manuell aus den Settings aufgerufen.
+ */
+async function sync() {
+  const country     = db.get().prepare("SELECT value FROM sync_config WHERE key='holiday_country'").get()?.value;
+  const subdivision = db.get().prepare("SELECT value FROM sync_config WHERE key='holiday_subdivision'").get()?.value ?? null;
+  const showPublic  = db.get().prepare("SELECT value FROM sync_config WHERE key='holiday_show_public'").get()?.value === '1';
+  const showSchool  = db.get().prepare("SELECT value FROM sync_config WHERE key='holiday_show_school'").get()?.value === '1';
+
+  if (!country || (!showPublic && !showSchool)) {
+    log.info('No holiday country configured or both layers disabled – skipping sync.');
+    return { synced: 0 };
+  }
+
+  // Sprache aus Land ableiten (Fallback EN)
+  const langMap = {
+    DE: 'DE', AT: 'DE', CH: 'DE', FR: 'FR', ES: 'ES', IT: 'IT',
+    NL: 'NL', PL: 'PL', PT: 'PT', RU: 'RU', TR: 'TR', CZ: 'CS',
+    SE: 'SV', NO: 'NO', DK: 'DA', FI: 'FI', HU: 'HU', RO: 'RO',
+    GR: 'EL', SK: 'SK', HR: 'HR', BG: 'BG', RS: 'SR', SI: 'SL',
+  };
+  const langCode = langMap[country] ?? 'EN';
+
+  const currentYear = new Date().getFullYear();
+  const years = [];
+  for (let y = currentYear - SYNC_YEARS_BACK; y <= currentYear + SYNC_YEARS_AHEAD; y++) {
+    years.push(y);
+  }
+
+  let total = 0;
+  for (const year of years) {
+    if (showPublic) total += await syncYearAndType(country, subdivision, year, 'public', langCode);
+    if (showSchool) total += await syncYearAndType(country, subdivision, year, 'school', langCode);
+  }
+
+  const now = new Date().toISOString();
+  db.get().prepare(`
+    INSERT INTO sync_config (key, value)
+    VALUES ('holiday_last_sync', ?)
+    ON CONFLICT(key) DO UPDATE SET value = excluded.value,
+                                   updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
+  `).run(now);
+
+  log.info(`Holiday sync complete: ${total} entries for ${country}${subdivision ? '/' + subdivision : ''}`);
+  return { synced: total, lastSync: now };
+}
+
+/**
+ * Feiertage/Ferien für einen Datumsbereich aus dem Cache lesen.
+ * @param {string} from YYYY-MM-DD
+ * @param {string} to   YYYY-MM-DD
+ * @returns {Array<{id, type, start_date, end_date, name}>}
+ */
+function getForRange(from, to) {
+  const country     = db.get().prepare("SELECT value FROM sync_config WHERE key='holiday_country'").get()?.value;
+  const subdivision = db.get().prepare("SELECT value FROM sync_config WHERE key='holiday_subdivision'").get()?.value ?? null;
+  const showPublic  = db.get().prepare("SELECT value FROM sync_config WHERE key='holiday_show_public'").get()?.value === '1';
+  const showSchool  = db.get().prepare("SELECT value FROM sync_config WHERE key='holiday_show_school'").get()?.value === '1';
+  const pubColor    = db.get().prepare("SELECT value FROM sync_config WHERE key='holiday_public_color'").get()?.value ?? '#FF3B30';
+  const schColor    = db.get().prepare("SELECT value FROM sync_config WHERE key='holiday_school_color'").get()?.value ?? '#34C759';
+
+  if (!country || (!showPublic && !showSchool)) return [];
+
+  const types = [];
+  if (showPublic) types.push('public');
+  if (showSchool) types.push('school');
+
+  const placeholders = types.map(() => '?').join(', ');
+
+  const rows = db.get().prepare(`
+    SELECT id, type, start_date, end_date, name
+    FROM holiday_cache
+    WHERE country = ?
+      AND (subdivision IS NULL OR subdivision = ? OR subdivision = '')
+      AND type IN (${placeholders})
+      AND start_date <= ?
+      AND end_date   >= ?
+    ORDER BY start_date ASC
+  `).all(country, subdivision ?? '', ...types, to, from);
+
+  return rows.map((r) => ({
+    ...r,
+    color: r.type === 'public' ? pubColor : schColor,
+  }));
+}
+
+export { sync, getCountries, getSubdivisions, getForRange };


### PR DESCRIPTION
## Summary

Adds a public holidays and school vacations layer to the calendar using the free [OpenHolidays API](https://openholidaysapi.org) (no API key required).

## Changes

### Backend
- **DB migration v49**: holiday_cache table + indexes
- **server/services/holidays.js** (new): sync() fetches & caches; getForRange() reads from cache; getCountries() / getSubdivisions() for settings dropdowns
- **server/routes/preferences.js**: holiday_* fields in GET/PUT /preferences; sub-routes for countries, subdivisions, manual sync
- **server/routes/calendar.js**: GET /api/v1/calendar/holidays?from=&to=
- **server/index.js**: holidays.sync() wired into auto-sync scheduler

### Frontend
- **Settings  Calendar tab** (admin-only): country + subdivision dropdowns, show-public/show-school toggles, color pickers, save + sync button, last-sync timestamp
- **Calendar toolbar**: conditional layer-toggle buttons (only shown when a layer is configured)
- **All 4 views**: holiday bands in month view, chips in week/day all-day row, pills in agenda view

### i18n
All 18 locale files updated with 	oggleHolidays, 	oggleSchool and full sectionHolidays settings keys.