### PR TITLE
chore: replace emoji with SVG module icons in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,20 +141,20 @@ Each module is independent. Use what fits, skip what doesn't.
 
 | | Module | What it does |
 |:---:|---|---|
-| ✅ | **Tasks** | Shared tasks with deadlines, priorities, subtasks, recurring schedules, multi-member assignment, Kanban, and mobile bulk controls. Optional CalDAV import of Apple Reminders. |
-| 🛒 | **Shopping** | Collaborative lists organized by aisle. Touch-safe quick add, swipe gestures, and meal-plan import in one tap. Optional CalDAV import. |
-| 🍽️ | **Meals** | Weekly drag-and-drop planner with multiple items per slot. Direct export to shopping list. |
-| 📖 | **Recipes** | Create, duplicate, and scale recipes. Pre-fill meal slots or save any planned meal as a recipe. |
-| 📅 | **Calendar** | Google Calendar (OAuth) and CalDAV sync (iCloud, Nextcloud, Radicale). ICS subscriptions, recurring events, file attachments, month and agenda views. |
-| 📂 | **Documents** | Upload and organize family files. Folders, tags, per-document visibility controls, drag-and-drop. |
-| 💰 | **Budget** | Income, expenses, recurring entries, trend charts, CSV export. Split Expenses with automatic debt simplification. |
-| 🏠 | **Housekeeping** | Manage household staff — schedules, check-in/out, daily or hourly billing, chores, supply requests. |
-| 📝 | **Notes & Contacts** | Colored sticky notes with Markdown. Contact directory with CardDAV sync. |
-| 🎂 | **Birthdays** | Birthday tracker with automatic calendar events, age display, and custom reminders. |
-| 👪 | **Family** | Member profiles with roles, photos, phone, email, and birthday — synced to Contacts and Birthdays. |
-| 🔔 | **Reminders** | Time-based notifications on tasks and calendar events with in-app badge counter. |
-| 🔑 | **API Tokens** | Named Bearer / X-API-Key tokens for integrations. OpenAPI 3.0 spec included. |
-| 💾 | **Backup** | Manual and scheduled database backup and restore, with automatic pre-restore rollback. Optional WebDAV upload target (Nextcloud, ownCloud, Hetzner, etc.). |
+| <img src="docs/icons/tasks.svg" width="20"> | **Tasks** | Shared tasks with deadlines, priorities, subtasks, recurring schedules, multi-member assignment, Kanban, and mobile bulk controls. Optional CalDAV import of Apple Reminders. |
+| <img src="docs/icons/shopping.svg" width="20"> | **Shopping** | Collaborative lists organized by aisle. Touch-safe quick add, swipe gestures, and meal-plan import in one tap. Optional CalDAV import. |
+| <img src="docs/icons/meals.svg" width="20"> | **Meals** | Weekly drag-and-drop planner with multiple items per slot. Direct export to shopping list. |
+| <img src="docs/icons/recipes.svg" width="20"> | **Recipes** | Create, duplicate, and scale recipes. Pre-fill meal slots or save any planned meal as a recipe. |
+| <img src="docs/icons/calendar.svg" width="20"> | **Calendar** | Google Calendar (OAuth) and CalDAV sync (iCloud, Nextcloud, Radicale). ICS subscriptions, recurring events, file attachments, month and agenda views. |
+| <img src="docs/icons/documents.svg" width="20"> | **Documents** | Upload and organize family files. Folders, tags, per-document visibility controls, drag-and-drop. |
+| <img src="docs/icons/budget.svg" width="20"> | **Budget** | Income, expenses, recurring entries, trend charts, CSV export. Split Expenses with automatic debt simplification. |
+| <img src="docs/icons/housekeeping.svg" width="20"> | **Housekeeping** | Manage household staff — schedules, check-in/out, daily or hourly billing, chores, supply requests. |
+| <img src="docs/icons/notes.svg" width="20"> | **Notes & Contacts** | Colored sticky notes with Markdown. Contact directory with CardDAV sync. |
+| <img src="docs/icons/birthdays.svg" width="20"> | **Birthdays** | Birthday tracker with automatic calendar events, age display, and custom reminders. |
+| <img src="docs/icons/family.svg" width="20"> | **Family** | Member profiles with roles, photos, phone, email, and birthday — synced to Contacts and Birthdays. |
+| <img src="docs/icons/reminders.svg" width="20"> | **Reminders** | Time-based notifications on tasks and calendar events with in-app badge counter. |
+| <img src="docs/icons/api-tokens.svg" width="20"> | **API Tokens** | Named Bearer / X-API-Key tokens for integrations. OpenAPI 3.0 spec included. |
+| <img src="docs/icons/backup.svg" width="20"> | **Backup** | Manual and scheduled database backup and restore, with automatic pre-restore rollback. Optional WebDAV upload target (Nextcloud, ownCloud, Hetzner, etc.). |
 
 ---
 

--- a/docs/icons/api-tokens.svg
+++ b/docs/icons/api-tokens.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <style>svg{stroke:#57606a;stroke-width:1.8}@media(prefers-color-scheme:dark){svg{stroke:#8b949e}}</style>
+  <path d="M21 2l-2 2m-7.61 7.61a5.5 5.5 0 1 1-7.778 7.778 5.5 5.5 0 0 1 7.777-7.777zm0 0L15.5 7.5m0 0l3 3L22 7l-3-3m-3.5 3.5L19 4"/>
+</svg>

--- a/docs/icons/backup.svg
+++ b/docs/icons/backup.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <style>svg{stroke:#57606a;stroke-width:1.8}@media(prefers-color-scheme:dark){svg{stroke:#8b949e}}</style>
+  <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/>
+  <path d="m9 12 2 2 4-4"/>
+</svg>

--- a/docs/icons/birthdays.svg
+++ b/docs/icons/birthdays.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <style>svg{stroke:#57606a;stroke-width:1.8}@media(prefers-color-scheme:dark){svg{stroke:#8b949e}}</style>
+  <path d="M20 21v-8a2 2 0 0 0-2-2H6a2 2 0 0 0-2 2v8"/>
+  <path d="M4 16s.5-1 2-1 2.5 2 4 2 2.5-2 4-2 2.5 2 4 2 2-1 2-1"/>
+  <path d="M2 21h20"/>
+  <path d="M7 8v3M12 8v3M17 8v3M7 4h.01M12 3h.01M17 4h.01"/>
+</svg>

--- a/docs/icons/budget.svg
+++ b/docs/icons/budget.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <style>svg{stroke:#57606a;stroke-width:1.8}@media(prefers-color-scheme:dark){svg{stroke:#8b949e}}</style>
+  <line x1="12" y1="1" x2="12" y2="23"/>
+  <path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"/>
+</svg>

--- a/docs/icons/calendar.svg
+++ b/docs/icons/calendar.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <style>svg{stroke:#57606a;stroke-width:1.8}@media(prefers-color-scheme:dark){svg{stroke:#8b949e}}</style>
+  <rect x="3" y="4" width="18" height="18" rx="2"/>
+  <line x1="16" y1="2" x2="16" y2="6"/>
+  <line x1="8" y1="2" x2="8" y2="6"/>
+  <line x1="3" y1="10" x2="21" y2="10"/>
+</svg>

--- a/docs/icons/documents.svg
+++ b/docs/icons/documents.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <style>svg{stroke:#57606a;stroke-width:1.8}@media(prefers-color-scheme:dark){svg{stroke:#8b949e}}</style>
+  <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/>
+  <polyline points="14 2 14 8 20 8"/>
+</svg>

--- a/docs/icons/family.svg
+++ b/docs/icons/family.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <style>svg{stroke:#57606a;stroke-width:1.8}@media(prefers-color-scheme:dark){svg{stroke:#8b949e}}</style>
+  <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/>
+  <circle cx="9" cy="7" r="4"/>
+  <path d="M23 21v-2a4 4 0 0 0-3-3.87"/>
+  <path d="M16 3.13a4 4 0 0 1 0 7.75"/>
+</svg>

--- a/docs/icons/housekeeping.svg
+++ b/docs/icons/housekeeping.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <style>svg{stroke:#57606a;stroke-width:1.8}@media(prefers-color-scheme:dark){svg{stroke:#8b949e}}</style>
+  <path d="m19 11-8-8-8.6 8.6a2 2 0 0 0 0 2.8l5.2 5.2a2 2 0 0 0 2.8 0z"/>
+  <path d="m5 2 5 5"/>
+  <path d="M2 13h15"/>
+  <path d="M22 20a2 2 0 1 1-4 0c0-1.6 1.7-2.4 2-4 .3 1.6 2 2.4 2 4z"/>
+</svg>

--- a/docs/icons/meals.svg
+++ b/docs/icons/meals.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <style>svg{stroke:#57606a;stroke-width:1.8}@media(prefers-color-scheme:dark){svg{stroke:#8b949e}}</style>
+  <path d="M3 2v7c0 1.1.9 2 2 2h0a2 2 0 0 0 2-2V2"/>
+  <path d="M5 2v20"/>
+  <path d="M19 2v20"/>
+  <path d="M19 2a4 4 0 0 0-4 4v6h4"/>
+</svg>

--- a/docs/icons/notes.svg
+++ b/docs/icons/notes.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <style>svg{stroke:#57606a;stroke-width:1.8}@media(prefers-color-scheme:dark){svg{stroke:#8b949e}}</style>
+  <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/>
+  <path d="M18.5 2.5a2.12 2.12 0 0 1 3 3L12 15l-4 1 1-4z"/>
+</svg>

--- a/docs/icons/recipes.svg
+++ b/docs/icons/recipes.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <style>svg{stroke:#57606a;stroke-width:1.8}@media(prefers-color-scheme:dark){svg{stroke:#8b949e}}</style>
+  <path d="M12 2a7 7 0 0 0-7 7c0 2.4 1.2 4.5 3 5.7V17a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1v-2.3c1.8-1.2 3-3.3 3-5.7a7 7 0 0 0-7-7z"/>
+  <line x1="9" y1="22" x2="15" y2="22"/>
+</svg>

--- a/docs/icons/reminders.svg
+++ b/docs/icons/reminders.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <style>svg{stroke:#57606a;stroke-width:1.8}@media(prefers-color-scheme:dark){svg{stroke:#8b949e}}</style>
+  <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"/>
+  <path d="M13.73 21a2 2 0 0 1-3.46 0"/>
+</svg>

--- a/docs/icons/shopping.svg
+++ b/docs/icons/shopping.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <style>svg{stroke:#57606a;stroke-width:1.8}@media(prefers-color-scheme:dark){svg{stroke:#8b949e}}</style>
+  <circle cx="9" cy="21" r="1"/>
+  <circle cx="20" cy="21" r="1"/>
+  <path d="M1 1h4l2.68 13.39a2 2 0 0 0 2 1.61h9.72a2 2 0 0 0 2-1.61L23 6H6"/>
+</svg>

--- a/docs/icons/tasks.svg
+++ b/docs/icons/tasks.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <style>svg{stroke:#57606a;stroke-width:1.8}@media(prefers-color-scheme:dark){svg{stroke:#8b949e}}</style>
+  <polyline points="9 11 12 14 22 4"/>
+  <path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/>
+</svg>


### PR DESCRIPTION
## Summary

- Replaces all 14 emoji in the README Modules table with proper SVG icons that match the GitHub Pages landing page
- SVG files are stored in `docs/icons/` — one per module
- Icons support both light and dark mode via `prefers-color-scheme` media queries inside each SVG
- Icons are sourced from the GitHub Pages landing page (`docs/index.html`) for modules that appear there; Lucide-style SVGs are used for the remaining modules (Family, API Tokens)

## Test plan

- [ ] Verify the README renders correctly on GitHub (light mode)
- [ ] Verify the README renders correctly on GitHub (dark mode)
- [ ] Check all 14 icons are visible and correctly sized in the Modules table

🤖 Generated with [Claude Code](https://claude.com/claude-code)