### PR TITLE
fix: accept FREQ=YEARLY in rrule validation

### DIFF
--- a/server/middleware/validate.js
+++ b/server/middleware/validate.js
@@ -16,7 +16,7 @@ const TIME_RE     = /^\d{2}:\d{2}$/;
 const DATETIME_RE = /^\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}(:\d{2}(?:\.\d+)?)?(?:Z|[+-]\d{2}:?\d{2})?)?$/;
 const COLOR_RE    = /^#[0-9A-Fa-f]{6}$/;
 const MONTH_RE    = /^\d{4}-\d{2}$/;
-const RRULE_RE    = /^(FREQ=(DAILY|WEEKLY|MONTHLY)(;INTERVAL=\d{1,2})?(;BYDAY=[A-Z,]{2,}(,[A-Z]{2})*)?(;UNTIL=\d{8}(T\d{6}Z)?)?)?$/;
+const RRULE_RE    = /^(FREQ=(DAILY|WEEKLY|MONTHLY|YEARLY)(;INTERVAL=\d{1,2})?(;BYDAY=[A-Z,]{2,}(,[A-Z]{2})*)?(;UNTIL=\d{8}(T\d{6}Z)?)?)?$/;
 
 /**
  * Bereinigt und validiert einen Pflicht-String.
@@ -150,7 +150,7 @@ function rrule(val, field) {
   if (s.length > MAX_RRULE)
     return { value: null, error: `${field} may be at most ${MAX_RRULE} characters long.` };
   // Grundlegende Struktur: KEY=VALUE;KEY=VALUE
-  if (!/^FREQ=(DAILY|WEEKLY|MONTHLY)/.test(s))
+  if (!/^FREQ=(DAILY|WEEKLY|MONTHLY|YEARLY)/.test(s))
     return { value: null, error: `${field}: invalid recurrence rule.` };
   return { value: s, error: null };
 }


### PR DESCRIPTION
## Summary

- The `rrule()` validator in `server/middleware/validate.js` only accepted `DAILY`, `WEEKLY`, and `MONTHLY` frequency values
- `FREQ=YEARLY` was silently rejected with "invalid recurrence rule" — even though the frontend dropdown offered it and the recurrence service already handled it correctly
- Added `YEARLY` to both the `RRULE_RE` regex constant and the inline guard in `rrule()`

Fixes #306

## Test plan

- [ ] Create a task with "Yearly" recurrence — should save without error
- [ ] Create a calendar event with "Yearly" recurrence — should save without error
- [ ] Existing DAILY/WEEKLY/MONTHLY recurrence rules continue to work
- [ ] `npm run test:tasks` and `npm run test:calendar` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)