### PR TITLE
fix: randomize avatar color on user creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.65.31] - 2026-06-08
+
+### Fixed
+- New family members created via the admin panel, from a contact in split expenses, or as a split guest now receive a random color from the avatar palette instead of always defaulting to blue. The new-member form in Settings also pre-populates the color picker with a random palette color.
+
 ## [0.65.30] - 2026-06-08
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oikos",
-  "version": "0.65.30",
+  "version": "0.65.31",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oikos",
-      "version": "0.65.30",
+      "version": "0.65.31",
       "license": "MIT",
       "dependencies": {
         "bcrypt": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oikos",
-  "version": "0.65.30",
+  "version": "0.65.31",
   "description": "Self-hosted family planner - calendar, tasks, shopping, meal planning, budget and more. Private, open-source, no subscription.",
   "main": "server/index.js",
   "type": "module",

--- a/public/pages/settings.js
+++ b/public/pages/settings.js
@@ -18,6 +18,8 @@ const SETTINGS_TAB_KEY = 'oikos:settings:tab';
 const APP_NAME_STORAGE_KEY = 'oikos-app-name';
 const DEFAULT_APP_NAME = 'Oikos';
 const FAMILY_ROLES = ['dad', 'mom', 'parent', 'child', 'grandparent', 'relative', 'other'];
+const AVATAR_COLORS = ['#007AFF', '#34C759', '#FF9500', '#FF3B30', '#AF52DE', '#FF2D55'];
+const randomAvatarColor = () => AVATAR_COLORS[Math.floor(Math.random() * AVATAR_COLORS.length)];
 const MAX_AVATAR_DATA_LENGTH = 768 * 1024;
 const BUILT_IN_MODULES = [
   { id: 'dashboard', labelKey: 'nav.dashboard', icon: 'layout-dashboard', locked: true },
@@ -725,7 +727,7 @@ export async function render(container, { user }) {
                 </div>
                 <div class="form-group settings-color-field">
                   <label class="form-label" for="new-avatar-color">${t('settings.colorLabel')}</label>
-                  <input class="settings-color-button" type="color" id="new-avatar-color" value="#007AFF" />
+                  <input class="settings-color-button" type="color" id="new-avatar-color" value="${randomAvatarColor()}" />
                 </div>
               </div>
               <div class="form-group">

--- a/server/auth.js
+++ b/server/auth.js
@@ -853,7 +853,7 @@ router.post('/users', requireAuth, requireAdmin, csrfMiddleware, async (req, res
       username,
       display_name,
       password,
-      avatar_color = '#007AFF',
+      avatar_color = avatarColors[Math.floor(Math.random() * avatarColors.length)],
       avatar_data,
       family_role = 'other',
       system_admin = req.body.role === 'admin',

--- a/server/routes/split-expenses.js
+++ b/server/routes/split-expenses.js
@@ -15,6 +15,9 @@ import { syncBirthdayArtifacts } from '../services/birthdays.js';
 const log = createLogger('SplitExpenses');
 const router = express.Router();
 
+const avatarColors = ['#007AFF', '#34C759', '#FF9500', '#FF3B30', '#AF52DE', '#FF2D55'];
+const randomAvatarColor = () => avatarColors[Math.floor(Math.random() * avatarColors.length)];
+
 const GROUP_TYPES = ['household', 'couple', 'travel', 'event', 'shopping', 'general'];
 const GROUP_ROLES = ['owner', 'admin', 'guest'];
 const SPLIT_METHODS = ['equal', 'exact', 'percentage', 'shares'];
@@ -125,8 +128,8 @@ async function userFromContact(database, contactId, actorId) {
   const passwordHash = await bcrypt.hash(crypto.randomBytes(24).toString('base64url'), 12);
   const created = database.prepare(`
     INSERT INTO users (username, display_name, password_hash, avatar_color, role, family_role)
-    VALUES (?, ?, ?, '#2563EB', 'member', 'other')
-  `).run(username, contact.name, passwordHash);
+    VALUES (?, ?, ?, ?, 'member', 'other')
+  `).run(username, contact.name, passwordHash, randomAvatarColor());
   database.prepare('UPDATE contacts SET family_user_id = ? WHERE id = ?').run(created.lastInsertRowid, contact.id);
   if (contact.birthday) {
     syncGuestArtifacts(database, created.lastInsertRowid, {
@@ -584,8 +587,8 @@ router.post('/groups/:id/guests', async (req, res) => {
     const createdUserId = db.transaction(() => {
       const created = db.get().prepare(`
         INSERT INTO users (username, display_name, password_hash, avatar_color, role, family_role)
-        VALUES (?, ?, ?, '#2563EB', 'member', ?)
-      `).run(username, vDisplayName.value, hash, familyRole);
+        VALUES (?, ?, ?, ?, 'member', ?)
+      `).run(username, vDisplayName.value, hash, randomAvatarColor(), familyRole);
       syncGuestArtifacts(db.get(), created.lastInsertRowid, {
         displayName: vDisplayName.value,
         phone: vPhone.value,


### PR DESCRIPTION
## Summary

Closes #301

- `server/auth.js`: Admin creates user → default `avatar_color` is now a random pick from the existing palette instead of hardcoded `#007AFF`
- `server/routes/split-expenses.js`: User created from contact or as split guest → both `INSERT` statements now use a random palette color instead of hardcoded `#2563EB`
- `public/pages/settings.js`: New-member form pre-populates the color picker with a random palette color on each render

The `avatarColors` palette (`['#007AFF', '#34C759', '#FF9500', '#FF3B30', '#AF52DE', '#FF2D55']`) already existed in `server/auth.js` and was already used for OIDC logins and the initial setup — this change applies the same logic consistently to all remaining creation paths.

No breaking changes: existing users keep their stored color; admins can still override manually.

## Test plan

- [ ] Create a new family member in Settings → color picker shows a random palette color (not always blue)
- [ ] Create multiple members in a row → colors vary
- [ ] Split expenses: add a guest user → avatar appears with a random palette color
- [ ] Split expenses: add a user from a contact → avatar appears with a random palette color
- [ ] All existing tests pass (`npm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)