### PR TITLE
fix: use RRULE_RE for full rrule validation instead of unanchored prefix check

### DIFF
--- a/server/middleware/validate.js
+++ b/server/middleware/validate.js
@@ -149,8 +149,7 @@ function rrule(val, field) {
   const s = String(val).trim();
   if (s.length > MAX_RRULE)
     return { value: null, error: `${field} may be at most ${MAX_RRULE} characters long.` };
-  // Grundlegende Struktur: KEY=VALUE;KEY=VALUE
-  if (!/^FREQ=(DAILY|WEEKLY|MONTHLY|YEARLY)/.test(s))
+  if (!RRULE_RE.test(s))
     return { value: null, error: `${field}: invalid recurrence rule.` };
   return { value: s, error: null };
 }


### PR DESCRIPTION
## Summary

- The `rrule()` validator in `server/middleware/validate.js` used an unanchored prefix regex (`/^FREQ=(DAILY|WEEKLY|MONTHLY|YEARLY)/`) that accepted malformed rules like `FREQ=YEARLYX` or `FREQ=YEARLY;INTERVAL=abc`
- The `RRULE_RE` constant (defined at the top of the file) already covers the full anchored structure but was never used in `rrule()`
- Replaced the loose prefix check with `RRULE_RE.test(s)` for complete validation

Addresses feedback from Codex review on #307.

## Test plan

- [ ] `npm run test:tasks` passes
- [ ] `npm run test:calendar` passes
- [ ] `FREQ=YEARLYX` is rejected as invalid
- [ ] `FREQ=YEARLY;INTERVAL=abc` is rejected as invalid
- [ ] `FREQ=YEARLY`, `FREQ=YEARLY;INTERVAL=1` continue to be accepted

🤖 Generated with [Claude Code](https://claude.com/claude-code)