### PR TITLE
Catalog rename: Umbrel id, Unraid template, awesome-selfhosted

### DIFF
--- a/ca_profile.xml
+++ b/ca_profile.xml
@@ -8,10 +8,10 @@ A private, offline-capable web app that keeps your household organized — tasks
 
 This repository ships the official Docker template for Yuvomi. The image is published to GitHub Container Registry at `ghcr.io/ulsklyc/yuvomi`.
 
-**Support:** open an issue at https://github.com/ulsklyc/oikos/issues
+**Support:** open an issue at https://github.com/ulsklyc/yuvomi/issues
   </Profile>
   <!-- Repository icon -->
-  <Icon>https://raw.githubusercontent.com/ulsklyc/oikos/main/icon.svg</Icon>
+  <Icon>https://raw.githubusercontent.com/ulsklyc/yuvomi/main/icon.svg</Icon>
   <!-- Project web page -->
-  <WebPage>https://github.com/ulsklyc/oikos</WebPage>
+  <WebPage>https://github.com/ulsklyc/yuvomi</WebPage>
 </CommunityApplications>

--- a/deploy/umbrel/README.md
+++ b/deploy/umbrel/README.md
@@ -12,7 +12,7 @@ that with our own workflow.
 ## Releases are automated
 
 `.github/workflows/umbrel-publish.yml` runs on `release: published`. It resolves
-the new multi-arch index digest and opens/updates a single rolling `oikos-update`
+the new multi-arch index digest and opens/updates a single rolling `yuvomi-update`
 PR to `getumbrel/umbrel-apps`, editing the maintainers' upstream files **in
 place** (`version`, `releaseNotes` from the release body, `@sha256` image digest)
 so any review tweaks (port, gallery, category) are preserved. It needs the
@@ -63,9 +63,9 @@ merged** via a temporary Community App Store:
 
 1. Create a throwaway public git repo with this layout:
    ```
-   umbrel-app-store.yml      # id: oikos-test, name: Yuvomi Test
-   oikos/umbrel-app.yml      # copy of this folder's manifest
-   oikos/docker-compose.yml  # copy of this folder's compose
+   umbrel-app-store.yml       # id: yuvomi-test, name: Yuvomi Test
+   yuvomi/umbrel-app.yml      # copy of this folder's manifest
+   yuvomi/docker-compose.yml  # copy of this folder's compose
    ```
 2. In umbrelOS → App Store → "Community App Stores", add the repo URL.
 3. Install Yuvomi, create the first account, then **restart the app** and confirm the

--- a/deploy/umbrel/docker-compose.yml
+++ b/deploy/umbrel/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.7"
 services:
   app_proxy:
     environment:
-      APP_HOST: oikos_web_1
+      APP_HOST: yuvomi_web_1
       APP_PORT: 3000
       # Yuvomi ships its own session-based login, so Umbrel's proxy auth is
       # disabled to avoid a double sign-in (same pattern as Immich).
@@ -13,7 +13,7 @@ services:
       PROXY_AUTH_ADD: "false"
 
   web:
-    image: ghcr.io/ulsklyc/yuvomi:0.65.1@sha256:ad9fa6cfd5844629220774963877e0b91d828144de341de5ec4377fd9253b06b
+    image: ghcr.io/ulsklyc/yuvomi:0.66.0@sha256:0de09531d39d16e13281100b8a55dd3307f1db9a2a07ef5fbfd928894e639cbf
     restart: on-failure
     stop_grace_period: 1m
     # No `user:` override: the image entrypoint starts as root only to chown the

--- a/deploy/umbrel/umbrel-app.yml
+++ b/deploy/umbrel/umbrel-app.yml
@@ -1,8 +1,8 @@
 manifestVersion: 1
-id: oikos
+id: yuvomi
 category: files
 name: Yuvomi
-version: "0.65.1"
+version: "0.66.0"
 tagline: Self-hosted family planner — calendar, tasks, shopping, meals & budget
 description: >-
   Yuvomi is a self-hosted, privacy-focused family planner that bundles everything
@@ -52,10 +52,10 @@ description: >-
   account becomes the family admin and can invite the rest of the household.
 releaseNotes: ""
 developer: Ulas Kalayci
-website: https://github.com/ulsklyc/oikos
+website: https://github.com/ulsklyc/yuvomi
 dependencies: []
-repo: https://github.com/ulsklyc/oikos
-support: https://github.com/ulsklyc/oikos/issues
+repo: https://github.com/ulsklyc/yuvomi
+support: https://github.com/ulsklyc/yuvomi/issues
 port: 8181
 # Must stay empty for submission — the Umbrel team populates icon/gallery from
 # the assets in umbrel-apps-gallery (see deploy/umbrel/icon.svg + gallery/).

--- a/docs/awesome-selfhosted/issue-addition.md
+++ b/docs/awesome-selfhosted/issue-addition.md
@@ -1,7 +1,7 @@
 ---
 name: Addition
 about: Add new software to the list.
-title: Add Oikos
+title: Add Yuvomi
 labels: addition, reviewers wanted
 assignees: ''
 ---
@@ -12,11 +12,11 @@ Please fill out information below (all fields are mandatory unless noted otherwi
 
 ```yaml
 # software name
-name: "Oikos"
+name: "Yuvomi"
 # URL of the software project's homepage
 website_url: "https://ulsklyc.github.io/oikos/"
 # URL where the full source code of the program can be downloaded
-source_code_url: "https://github.com/ulsklyc/oikos"
+source_code_url: "https://github.com/ulsklyc/yuvomi"
 # description of what the software does, shorter than 250 characters, sentence case
 description: "Family planner with shared tasks, shopping lists, meal planning, calendar sync (Google & iCloud), budget tracking, notes, and contacts. PWA with offline support."
 # list of license identifiers, see https://github.com/awesome-selfhosted/awesome-selfhosted-data/blob/master/licenses.yml for the full list of licenses

--- a/docs/awesome-selfhosted/yuvomi.yml
+++ b/docs/awesome-selfhosted/yuvomi.yml
@@ -1,6 +1,6 @@
-name: Oikos
+name: Yuvomi
 website_url: "https://ulsklyc.github.io/oikos/"
-source_code_url: "https://github.com/ulsklyc/oikos"
+source_code_url: "https://github.com/ulsklyc/yuvomi"
 description: "Family planner with shared tasks, shopping lists, meal planning, calendar sync (Google Calendar, CalDAV/CardDAV), budget tracking, split expenses, notes, contacts, and housekeeping. PWA with offline support."
 licenses:
   - MIT

--- a/templates/yuvomi.xml
+++ b/templates/yuvomi.xml
@@ -1,0 +1,127 @@
+<?xml version="1.0"?>
+<Container version="2">
+  <Name>Yuvomi</Name>
+  <Repository>ghcr.io/ulsklyc/yuvomi:latest</Repository>
+  <Registry>https://github.com/ulsklyc/yuvomi/pkgs/container/yuvomi</Registry>
+  <Network>bridge</Network>
+  <MyIP/>
+  <Shell>sh</Shell>
+  <Privileged>false</Privileged>
+  <WebUI>http://[IP]:[PORT:3000]</WebUI>
+  <TemplateURL>https://raw.githubusercontent.com/ulsklyc/yuvomi/main/templates/yuvomi.xml</TemplateURL>
+  <Icon>https://raw.githubusercontent.com/ulsklyc/yuvomi/main/icon.svg</Icon>
+
+  <Overview>Yuvomi is a private, self-hosted family planner — one calm home for everything your household needs to stay organized. No cloud accounts, no subscriptions, no tracking: your data lives on your server and nowhere else.
+
+Independent modules — turn on what fits, ignore the rest:
+
+- Dashboard — today's tasks, events, meals and reminders at a glance
+- Tasks — shared to-dos with priorities, due dates and assignees
+- Shopping — collaborative grocery lists, auto-sorted by category
+- Meals &amp; Recipes — weekly meal planner with a built-in recipe book
+- Calendar — family calendar with recurring events and reminders
+- Budget — shared expenses, split costs and a spending overview
+- Housekeeping — chores, supplies and staff/session tracking
+- Documents — store and find important household files
+- Notes, Contacts &amp; Birthdays — everything else in one tidy place
+
+Why Yuvomi:
+
+- Mobile-first PWA — install it on any phone, works offline
+- Light &amp; dark mode, fast and polished (no bloated frameworks, no build step)
+- Optional sync — CalDAV / CardDAV, Apple and Google Calendar
+- OIDC single sign-on for households that already run an identity provider
+- Encrypted-at-rest storage (SQLCipher) with automated, scheduled backups
+- Multi-language, fully self-contained and MIT-licensed
+
+— Setup —
+
+REQUIRED: Set a long random SESSION_SECRET.
+RECOMMENDED: Set a strong DB_ENCRYPTION_KEY to encrypt the database at rest — without it the database and any synced calendar/contact credentials are stored unencrypted.
+Generate either secret with: openssl rand -base64 48
+
+After the container starts, open the WebUI — the first visit guides you through creating your admin account. (Headless setups can alternatively run node setup.js in the container console.) Then log in — pick the modules you want and invite your family.</Overview>
+
+  <!-- Either Support or Project is required -->
+  <Support>https://github.com/ulsklyc/yuvomi/issues</Support>
+  <Project>https://github.com/ulsklyc/yuvomi</Project>
+  <ReadMe>https://raw.githubusercontent.com/ulsklyc/yuvomi/main/README.md</ReadMe>
+
+  <Category>Productivity: HomeAutomation: Tools:</Category>
+  <License>MIT</License>
+  <ExtraSearchTerms>family planner household organizer tasks groceries shopping meals recipes calendar budget chores notes contacts birthdays caldav carddav pwa selfhosted</ExtraSearchTerms>
+
+  <!-- Combined desktop + mobile dark-mode composites (see docs/screenshots/build-unraid-composites.mjs) -->
+  <Screenshot>https://raw.githubusercontent.com/ulsklyc/yuvomi/main/docs/screenshots/unraid/dashboard-combined-dark.png</Screenshot>
+  <Screenshot>https://raw.githubusercontent.com/ulsklyc/yuvomi/main/docs/screenshots/unraid/calendar-combined-dark.png</Screenshot>
+  <Screenshot>https://raw.githubusercontent.com/ulsklyc/yuvomi/main/docs/screenshots/unraid/meals-combined-dark.png</Screenshot>
+  <Screenshot>https://raw.githubusercontent.com/ulsklyc/yuvomi/main/docs/screenshots/unraid/shopping-combined-dark.png</Screenshot>
+  <Screenshot>https://raw.githubusercontent.com/ulsklyc/yuvomi/main/docs/screenshots/unraid/budget-combined-dark.png</Screenshot>
+
+  <!-- WebUI port (container always listens on 3000) -->
+  <Config Name="WebUI Port" Target="3000" Default="3000" Mode="tcp" Description="Host port for the Yuvomi web interface." Type="Port" Display="always" Required="true" Mask="false">3000</Config>
+
+  <!-- Persistent data -->
+  <Config Name="Data" Target="/data" Default="/mnt/user/appdata/yuvomi/data" Mode="rw" Description="Database and stored app data (uploads, documents)." Type="Path" Display="always" Required="true" Mask="false">/mnt/user/appdata/yuvomi/data</Config>
+  <Config Name="Backups" Target="/backups" Default="/mnt/user/appdata/yuvomi/backups" Mode="rw" Description="Destination folder for scheduled and manual database backups." Type="Path" Display="always" Required="true" Mask="false">/mnt/user/appdata/yuvomi/backups</Config>
+  <Config Name="Modules (optional)" Target="/app/modules" Default="/mnt/user/appdata/yuvomi/modules" Mode="rw" Description="Optional: drop-in folder for additional Yuvomi modules. Leave default if unused." Type="Path" Display="advanced" Required="false" Mask="false">/mnt/user/appdata/yuvomi/modules</Config>
+
+  <!-- Required secret -->
+  <Config Name="SESSION_SECRET" Target="SESSION_SECRET" Default="" Mode="" Description="REQUIRED. A long random string used to sign sessions. Generate with: openssl rand -base64 48" Type="Variable" Display="always" Required="true" Mask="true"/>
+
+  <!-- Recommended secret -->
+  <Config Name="DB_ENCRYPTION_KEY" Target="DB_ENCRYPTION_KEY" Default="" Mode="" Description="RECOMMENDED. Strong key to encrypt the database at rest (SQLCipher). Leave empty for unencrypted SQLite. Cannot be changed later without re-encrypting. Generate with: openssl rand -base64 48" Type="Variable" Display="always" Required="false" Mask="true"/>
+
+  <!-- Timezone -->
+  <Config Name="Timezone" Target="TZ" Default="Europe/Berlin" Mode="" Description="Container timezone, e.g. Europe/Berlin. Affects scheduled backups and reminders." Type="Variable" Display="always" Required="false" Mask="false">Europe/Berlin</Config>
+
+  <!-- HTTPS / cookie security -->
+  <Config Name="SESSION_SECURE" Target="SESSION_SECURE" Default="false" Mode="" Description="Set to true only when serving Yuvomi over HTTPS behind a reverse proxy. Keep false for direct HTTP access on the LAN." Type="Variable" Display="advanced" Required="false" Mask="false">false</Config>
+  <Config Name="TRUST_PROXY" Target="TRUST_PROXY" Default="loopback" Mode="" Description="Use 1 behind one reverse proxy (Caddy/nginx/Traefik), or 'loopback' for direct (no proxy) access." Type="Variable" Display="advanced" Required="false" Mask="false">loopback</Config>
+
+  <!-- Database path (advanced; matches the /data mount) -->
+  <Config Name="DB_PATH" Target="DB_PATH" Default="/data/oikos.db" Mode="" Description="Path to the SQLite database inside the container. Keep default unless you know what you are doing." Type="Variable" Display="advanced" Required="false" Mask="false">/data/oikos.db</Config>
+
+  <!-- Weather (optional) — Open-Meteo (recommended, free, no API key) -->
+  <Config Name="WEATHER_LAT" Target="WEATHER_LAT" Default="" Mode="" Description="Optional. Latitude for the Open-Meteo weather widget (no API key required). Find coordinates on openstreetmap.org or Google Maps, e.g. 52.52." Type="Variable" Display="advanced" Required="false" Mask="false"/>
+  <Config Name="WEATHER_LON" Target="WEATHER_LON" Default="" Mode="" Description="Optional. Longitude for the Open-Meteo weather widget, e.g. 13.41." Type="Variable" Display="advanced" Required="false" Mask="false"/>
+  <Config Name="WEATHER_CITY" Target="WEATHER_CITY" Default="" Mode="" Description="Optional. Display name shown on the weather widget, e.g. Berlin." Type="Variable" Display="advanced" Required="false" Mask="false"/>
+  <Config Name="WEATHER_UNITS" Target="WEATHER_UNITS" Default="metric" Mode="" Description="Optional. Unit system for temperatures: metric (°C) or imperial (°F)." Type="Variable" Display="advanced" Required="false" Mask="false">metric</Config>
+  <!-- Weather (optional) — OpenWeatherMap (legacy; only if you already use it) -->
+  <Config Name="OPENWEATHER_API_KEY" Target="OPENWEATHER_API_KEY" Default="" Mode="" Description="Optional (legacy). OpenWeatherMap API key to enable the weather widget. Prefer the keyless Open-Meteo variables above." Type="Variable" Display="advanced" Required="false" Mask="true"/>
+  <Config Name="OPENWEATHER_CITY" Target="OPENWEATHER_CITY" Default="" Mode="" Description="Optional (legacy). City for the OpenWeatherMap weather widget, e.g. Berlin." Type="Variable" Display="advanced" Required="false" Mask="false"/>
+  <Config Name="OPENWEATHER_UNITS" Target="OPENWEATHER_UNITS" Default="metric" Mode="" Description="Optional (legacy). Unit system for temperatures: metric (°C) or imperial (°F)." Type="Variable" Display="advanced" Required="false" Mask="false">metric</Config>
+  <Config Name="OPENWEATHER_LANG" Target="OPENWEATHER_LANG" Default="en" Mode="" Description="Optional (legacy). Language code for OpenWeatherMap descriptions, e.g. en, de, fr." Type="Variable" Display="advanced" Required="false" Mask="false">en</Config>
+
+  <!-- Google Calendar (optional) -->
+  <Config Name="GOOGLE_CLIENT_ID" Target="GOOGLE_CLIENT_ID" Default="" Mode="" Description="Optional. Google OAuth 2.0 client ID for Google Calendar sync." Type="Variable" Display="advanced" Required="false" Mask="false"/>
+  <Config Name="GOOGLE_CLIENT_SECRET" Target="GOOGLE_CLIENT_SECRET" Default="" Mode="" Description="Optional. Google OAuth 2.0 client secret for Google Calendar sync." Type="Variable" Display="advanced" Required="false" Mask="true"/>
+  <Config Name="GOOGLE_REDIRECT_URI" Target="GOOGLE_REDIRECT_URI" Default="" Mode="" Description="Optional. OAuth callback URL, e.g. https://your-domain.com/api/v1/calendar/google/callback" Type="Variable" Display="advanced" Required="false" Mask="false"/>
+
+  <!-- OIDC / SSO (optional — all four values required to enable SSO) -->
+  <Config Name="OIDC_ISSUER" Target="OIDC_ISSUER" Default="" Mode="" Description="Optional. OIDC issuer URL, e.g. https://authentik.example.com/application/o/oikos/" Type="Variable" Display="advanced" Required="false" Mask="false"/>
+  <Config Name="OIDC_CLIENT_ID" Target="OIDC_CLIENT_ID" Default="" Mode="" Description="Optional. OIDC client ID from your identity provider." Type="Variable" Display="advanced" Required="false" Mask="false"/>
+  <Config Name="OIDC_CLIENT_SECRET" Target="OIDC_CLIENT_SECRET" Default="" Mode="" Description="Optional. OIDC client secret from your identity provider." Type="Variable" Display="advanced" Required="false" Mask="true"/>
+  <Config Name="OIDC_REDIRECT_URI" Target="OIDC_REDIRECT_URI" Default="" Mode="" Description="Optional. OIDC callback URL, e.g. https://your-domain.com/api/v1/auth/oidc/callback" Type="Variable" Display="advanced" Required="false" Mask="false"/>
+
+  <!-- Apple Calendar CalDAV (optional) -->
+  <Config Name="APPLE_CALDAV_URL" Target="APPLE_CALDAV_URL" Default="https://caldav.icloud.com" Mode="" Description="Optional. Apple CalDAV server URL (default: iCloud). Change only if using a custom CalDAV server." Type="Variable" Display="advanced" Required="false" Mask="false">https://caldav.icloud.com</Config>
+  <Config Name="APPLE_USERNAME" Target="APPLE_USERNAME" Default="" Mode="" Description="Optional. Apple ID (email) for iCloud Calendar sync." Type="Variable" Display="advanced" Required="false" Mask="false"/>
+  <Config Name="APPLE_APP_SPECIFIC_PASSWORD" Target="APPLE_APP_SPECIFIC_PASSWORD" Default="" Mode="" Description="Optional. Apple app-specific password for iCloud Calendar sync (generate at appleid.apple.com)." Type="Variable" Display="advanced" Required="false" Mask="true"/>
+
+  <!-- Calendar sync interval -->
+  <Config Name="SYNC_INTERVAL_MINUTES" Target="SYNC_INTERVAL_MINUTES" Default="15" Mode="" Description="Interval in minutes for calendar sync (Google, Apple, CalDAV). Default: 15." Type="Variable" Display="advanced" Required="false" Mask="false">15</Config>
+
+  <!-- Backups (optional) -->
+  <Config Name="BACKUP_ENABLED" Target="BACKUP_ENABLED" Default="true" Mode="" Description="Optional. Enable automated database backups (default: true)." Type="Variable" Display="advanced" Required="false" Mask="false">true</Config>
+  <Config Name="BACKUP_SCHEDULE" Target="BACKUP_SCHEDULE" Default="0 2 * * *" Mode="" Description="Optional. Cron schedule for automated backups (default: 2 AM daily)." Type="Variable" Display="advanced" Required="false" Mask="false">0 2 * * *</Config>
+  <Config Name="BACKUP_KEEP" Target="BACKUP_KEEP" Default="7" Mode="" Description="Optional. Number of backups to retain (default: 7)." Type="Variable" Display="advanced" Required="false" Mask="false">7</Config>
+
+  <!-- WebDAV backup target (optional) — upload each backup to Nextcloud, ownCloud, Hetzner Storage Box, etc. -->
+  <Config Name="WEBDAV_BACKUP_ENABLED" Target="WEBDAV_BACKUP_ENABLED" Default="" Mode="" Description="Optional. Set to true to enable automatic upload of backups to a WebDAV server after each local backup." Type="Variable" Display="advanced" Required="false" Mask="false"/>
+  <Config Name="WEBDAV_BACKUP_URL" Target="WEBDAV_BACKUP_URL" Default="" Mode="" Description="Optional. WebDAV server URL, e.g. https://cloud.example.com/remote.php/dav/files/username/" Type="Variable" Display="advanced" Required="false" Mask="false"/>
+  <Config Name="WEBDAV_BACKUP_USERNAME" Target="WEBDAV_BACKUP_USERNAME" Default="" Mode="" Description="Optional. WebDAV username for authentication." Type="Variable" Display="advanced" Required="false" Mask="false"/>
+  <Config Name="WEBDAV_BACKUP_PASSWORD" Target="WEBDAV_BACKUP_PASSWORD" Default="" Mode="" Description="Optional. WebDAV password for authentication." Type="Variable" Display="advanced" Required="false" Mask="true"/>
+  <Config Name="WEBDAV_BACKUP_PATH" Target="WEBDAV_BACKUP_PATH" Default="/oikos/backups/" Mode="" Description="Optional. Remote directory path where backup files are stored (default: /oikos/backups/)." Type="Variable" Display="advanced" Required="false" Mask="false">/oikos/backups/</Config>
+  <Config Name="WEBDAV_BACKUP_KEEP" Target="WEBDAV_BACKUP_KEEP" Default="7" Mode="" Description="Optional. Number of remote backup files to keep (default: 7)." Type="Variable" Display="advanced" Required="false" Mask="false">7</Config>
+</Container>


### PR DESCRIPTION
Catalog-identity follow-up to the Oikos → Yuvomi rebrand (in-repo source for the deploy catalogs). Runtime image refs already moved to `ghcr.io/ulsklyc/yuvomi` in the rebrand PR; this aligns the catalog **identity**.

## Changes
- **Umbrel** (`deploy/umbrel/`) — `umbrel-app.yml` id `oikos` → `yuvomi`, version 0.66.0 with the released digest, website/repo/support → ulsklyc/yuvomi; `docker-compose.yml` `APP_HOST: yuvomi_web_1` (proxy target follows the app id); README test-store/branch notes. The live submission PR (getumbrel/umbrel-apps#5732) has been renamed in place to match.
- **Unraid** — new `templates/yuvomi.xml` as the canonical CA template (identity URLs, `appdata/yuvomi` host paths, Registry → yuvomi). `ca_profile.xml` icon/webpage/support → yuvomi. The old `templates/oikos.xml` stays functional during the transition.
- **awesome-selfhosted** — renamed the (never-submitted) `oikos.yml` → `yuvomi.yml`, name + source_code_url → Yuvomi.

## Kept intentionally
- In-container DB filename `/data/oikos.db` and WebDAV `/oikos/backups/` (data continuity).
- `website_url` / `ulsklyc.github.io` Pages URLs and README TrueNAS/Unraid catalog badges — finalized in the domain step / once the new catalog entries are live.

## Not here
- TrueNAS catalog rename — coordinated with maintainers in truenas/apps#5135 (blocked on their asset hosting + approach); the upstream PR follows their response.