### PR TITLE
Point absolute URLs at yuvomi.cloud (domain step, part 1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 > - The Docker image moved to `ghcr.io/ulsklyc/yuvomi`; the old `ghcr.io/ulsklyc/oikos` keeps working for now — please update at your convenience.
 > - Your existing data and settings are fully preserved on upgrade.
 >
-> New home: **https://ulsklyc.github.io/yuvomi/** · Questions? Open a [discussion](https://github.com/ulsklyc/yuvomi/discussions).
+> New home: **https://yuvomi.cloud/** · Questions? Open a [discussion](https://github.com/ulsklyc/yuvomi/discussions).
 
 <div align="center">
   <img src="docs/logo.svg" alt="Yuvomi" width="92" />
@@ -27,7 +27,7 @@
 
   <p>
     <a href="docs/installation.md"><strong>→ Install</strong></a> &nbsp;·&nbsp;
-    <a href="https://ulsklyc.github.io/oikos/"><strong>Website & screenshots</strong></a> &nbsp;·&nbsp;
+    <a href="https://yuvomi.cloud/"><strong>Website & screenshots</strong></a> &nbsp;·&nbsp;
     <a href="docs/SPEC.md"><strong>Docs</strong></a> &nbsp;·&nbsp;
     <a href="CHANGELOG.md"><strong>Changelog</strong></a>
   </p>
@@ -74,7 +74,7 @@
       </td>
     </tr>
   </table>
-  <sub>Switch GitHub to dark mode to preview the dark theme &nbsp;·&nbsp; <a href="https://ulsklyc.github.io/oikos/">See all screenshots →</a></sub>
+  <sub>Switch GitHub to dark mode to preview the dark theme &nbsp;·&nbsp; <a href="https://yuvomi.cloud/">See all screenshots →</a></sub>
 </div>
 
 <br>
@@ -144,7 +144,7 @@ Each module is independent. Use what fits, skip what doesn't.
       </td>
     </tr>
   </table>
-  <a href="https://ulsklyc.github.io/oikos/">View all screenshots →</a>
+  <a href="https://yuvomi.cloud/">View all screenshots →</a>
 </div>
 
 ---

--- a/docs/awesome-selfhosted/issue-addition.md
+++ b/docs/awesome-selfhosted/issue-addition.md
@@ -14,7 +14,7 @@ Please fill out information below (all fields are mandatory unless noted otherwi
 # software name
 name: "Yuvomi"
 # URL of the software project's homepage
-website_url: "https://ulsklyc.github.io/oikos/"
+website_url: "https://yuvomi.cloud/"
 # URL where the full source code of the program can be downloaded
 source_code_url: "https://github.com/ulsklyc/yuvomi"
 # description of what the software does, shorter than 250 characters, sentence case

--- a/docs/awesome-selfhosted/yuvomi.yml
+++ b/docs/awesome-selfhosted/yuvomi.yml
@@ -1,5 +1,5 @@
 name: Yuvomi
-website_url: "https://ulsklyc.github.io/oikos/"
+website_url: "https://yuvomi.cloud/"
 source_code_url: "https://github.com/ulsklyc/yuvomi"
 description: "Family planner with shared tasks, shopping lists, meal planning, calendar sync (Google Calendar, CalDAV/CardDAV), budget tracking, split expenses, notes, contacts, and housekeeping. PWA with offline support."
 licenses:

--- a/docs/index.html
+++ b/docs/index.html
@@ -10,11 +10,11 @@
   <meta property="og:type" content="website">
   <meta property="og:title" content="Yuvomi — The Self-Hosted Family Planner">
   <meta property="og:description" content="Tasks, shopping, meals, calendar, budget — all self-hosted, no cloud dependency.">
-  <meta property="og:image" content="https://ulsklyc.github.io/oikos/og-image.png">
-  <meta property="og:url" content="https://ulsklyc.github.io/oikos/">
+  <meta property="og:image" content="https://yuvomi.cloud/og-image.png">
+  <meta property="og:url" content="https://yuvomi.cloud/">
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:image" content="https://ulsklyc.github.io/oikos/twitter-image.png">
-  <link rel="canonical" href="https://ulsklyc.github.io/oikos/">
+  <meta name="twitter:image" content="https://yuvomi.cloud/twitter-image.png">
+  <link rel="canonical" href="https://yuvomi.cloud/">
   <link rel="icon" type="image/svg+xml" href="logo.svg">
 
   <style>

--- a/docs/install.html
+++ b/docs/install.html
@@ -7,7 +7,7 @@
   <meta name="description" content="Step-by-step installation guide for Yuvomi. Docker, Podman, TrueNAS, Umbrel or Unraid — get your self-hosted family planner running in minutes.">
   <meta name="theme-color" content="#fafaf8" media="(prefers-color-scheme: light)">
   <meta name="theme-color" content="#1a1a18" media="(prefers-color-scheme: dark)">
-  <link rel="canonical" href="https://ulsklyc.github.io/oikos/install.html">
+  <link rel="canonical" href="https://yuvomi.cloud/install.html">
   <link rel="icon" type="image/svg+xml" href="logo.svg">
 
   <style>


### PR DESCRIPTION
Domain step, part 1 of 2. Migrates all absolute `ulsklyc.github.io` URLs (og/twitter meta, canonical, README banner + screenshot links, awesome-selfhosted website_url) to `https://yuvomi.cloud/`.

`docs/CNAME` and the GitHub Pages custom-domain switch are deliberately held back (part 2) until the yuvomi.cloud DNS records point at GitHub Pages, so the Pages site is not taken offline in the meantime. Until then these URLs resolve once DNS + CNAME are in place.