### PR TITLE
Set Pages custom domain to yuvomi.cloud (domain step, part 2)

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+yuvomi.cloud


### PR DESCRIPTION
Final part of the domain switch. Adds `docs/CNAME` = `yuvomi.cloud` so GitHub Pages serves the site at the custom domain (DNS A/AAAA records are in place). After merge + Pages rebuild, enable **Enforce HTTPS** in Settings → Pages once the certificate is provisioned.

Completes the Oikos → Yuvomi rebrand domain step (part 1 migrated the absolute URLs in #319).