### PR TITLE
Point Claude agent/skill gh commands at ulsklyc/yuvomi

### DIFF
--- a/.claude/agents/pr-reviewer.md
+++ b/.claude/agents/pr-reviewer.md
@@ -11,7 +11,7 @@ You are reviewing a single PR for Yuvomi, a self-hosted family planner PWA. The 
 
 ## Inputs
 
-Expect the parent to pass the PR number. Start with `gh pr view <n> --repo ulsklyc/oikos --json title,body,headRefName,baseRefName,files,author,state` and `gh pr diff <n> --repo ulsklyc/oikos`.
+Expect the parent to pass the PR number. Start with `gh pr view <n> --repo ulsklyc/yuvomi --json title,body,headRefName,baseRefName,files,author,state` and `gh pr diff <n> --repo ulsklyc/yuvomi`.
 
 ## How to read
 

--- a/.claude/agents/repo-auditor.md
+++ b/.claude/agents/repo-auditor.md
@@ -14,10 +14,10 @@ You are auditing the Yuvomi repo. Report only — never push, never close, never
 
 Run all six and report each even if clean.
 
-1. **Stale issues** — `gh issue list --repo ulsklyc/oikos --state open --json number,title,updatedAt,labels`. Flag any open issue with `updatedAt` older than 90 days or labelled `needs-info` for >14 days.
+1. **Stale issues** — `gh issue list --repo ulsklyc/yuvomi --state open --json number,title,updatedAt,labels`. Flag any open issue with `updatedAt` older than 90 days or labelled `needs-info` for >14 days.
 2. **Dormant branches** — `git branch -r --format '%(refname:short) %(committerdate:iso)'`. Flag remote branches with no commits in 30+ days that aren't `main` or a protected branch.
 3. **Untracked TODOs** — `grep -rn "TODO\|FIXME\|XXX\|HACK" --include='*.js' --include='*.css' --include='*.md' --exclude-dir=node_modules`. Cross-reference with open issues. Flag TODOs that don't link to an issue number.
-4. **Outdated deps** — `npm outdated --json` inside `oikos/`. Flag anything with a major upgrade available and anything with a known CVE (check `gh api /repos/ulsklyc/oikos/dependabot/alerts` if dependabot is on).
+4. **Outdated deps** — `npm outdated --json` inside `oikos/`. Flag anything with a major upgrade available and anything with a known CVE (check `gh api /repos/ulsklyc/yuvomi/dependabot/alerts` if dependabot is on).
 5. **Dead test files** — list all `test-*.js` in `oikos/test/`, cross-check against `package.json` scripts. Flag any `test-*.js` not wired into a `test:*` script. Flag any `test:*` script pointing at a missing file.
 6. **Un-released commits** — `git log v<latest-tag>..main --oneline`. If there are commits on `main` beyond the latest tag AND `## [Unreleased]` in `CHANGELOG.md` has bullets, recommend running `/release-prep`.
 

--- a/.claude/skills/docs-sync/SKILL.md
+++ b/.claude/skills/docs-sync/SKILL.md
@@ -59,8 +59,8 @@ sync targets below and update **only** what the change actually affects.
 | `tools/installer/README.md` | Installer steps, requirements, endpoints, localization, design |
 | `docs/index.html` | Version badge (hero + footer), feature showcase/grid, social-proof counts. **EN + DE i18n in lockstep** |
 | `docs/install.html` | Install options/cards, optional-integration cards. **EN + DE i18n in lockstep** |
-| `docs/awesome-selfhosted/oikos.yml` | `description` + `tags` reflect current modules |
-| `docs/awesome-selfhosted/issue-addition.md` | Directory-submission blurb matches `oikos.yml` |
+| `docs/awesome-selfhosted/yuvomi.yml` | `description` + `tags` reflect current modules |
+| `docs/awesome-selfhosted/issue-addition.md` | Directory-submission blurb matches `yuvomi.yml` |
 | `CONTRIBUTING.md` | Only when commit format, conventions, or test workflow changed |
 | `SECURITY.md` | Only when the security model or supported-version policy changed |
 | `CLAUDE.md` | **Only two sections:** the `## Commands` test-script list (keep in lockstep with the `test:*` scripts in `package.json`) and the `## Environment` env-var list (keep in lockstep with `.env.example`). Never touch any other part — architecture, hard constraints, key locations, conventions belong to the separate CLAUDE.md maintenance process |

--- a/.claude/skills/fix-issue/SKILL.md
+++ b/.claude/skills/fix-issue/SKILL.md
@@ -22,7 +22,7 @@ allowed-tools:
 
 Run from inside `oikos/`. `$1` is the issue number.
 
-1. **Load context** — `gh issue view $1 --repo ulsklyc/oikos --comments`. Read linked PRs, commits, related issues. Stop and report if the issue is already closed or duplicated.
+1. **Load context** — `gh issue view $1 --repo ulsklyc/yuvomi --comments`. Read linked PRs, commits, related issues. Stop and report if the issue is already closed or duplicated.
 2. **Triage before coding** — classify: bug, enhancement, question, invalid. If reproduction steps are missing or scope is unclear, post a question via `gh issue comment $1 --body "..."` and stop. Do not guess intent.
 3. **Branch + implement** — `git checkout -b fix/$1`. Make the minimal change that solves the reported problem. Respect the Hard Constraints from CLAUDE.md. Add or extend a `test-<module>.js` suite that would have caught the bug. Run `npm test` — all suites must pass before moving on.
 4. **Ship** — `git add` only the files actually changed by this fix, commit with a Conventional Commit subject (`fix: <short summary> (#$1)`), push `git push -u origin fix/$1`, then `gh pr create --fill --base main` with a body that closes the issue (`Closes #$1`) and summarises root cause + fix.

--- a/.claude/skills/issue-triage/SKILL.md
+++ b/.claude/skills/issue-triage/SKILL.md
@@ -13,15 +13,15 @@ allowed-tools:
 
 Run from inside `oikos/`. `$1` is a specific issue number or the literal `all` (default: `all` → every open issue without labels).
 
-1. **Load** — for a single issue: `gh issue view $1 --repo ulsklyc/oikos --comments`. For `all`: `gh issue list --repo ulsklyc/oikos --state open --label '' --json number,title,body,author,createdAt`.
-2. **Classify** — for each issue, pick ONE primary class and apply labels via `gh issue edit <n> --repo ulsklyc/oikos --add-label "<labels>"`:
+1. **Load** — for a single issue: `gh issue view $1 --repo ulsklyc/yuvomi --comments`. For `all`: `gh issue list --repo ulsklyc/yuvomi --state open --label '' --json number,title,body,author,createdAt`.
+2. **Classify** — for each issue, pick ONE primary class and apply labels via `gh issue edit <n> --repo ulsklyc/yuvomi --add-label "<labels>"`:
    - `bug` — reproduction + expected vs. actual behaviour present and plausible against current code
    - `enhancement` — new feature or UX improvement, no existing regression
    - `question` — user needs help using Yuvomi, not a code change
    - `invalid` — spam, duplicate, or out of scope (self-hosted family planner)
    Add area labels where obvious: `calendar`, `tasks`, `shopping`, `meals`, `budget`, `notes`, `contacts`, `reminders`, `i18n`, `pwa`, `security`, `docs`.
 3. **Request missing info** — if reproduction steps, expected behaviour, Yuvomi version, or browser are missing on a `bug`, post a single comment asking for exactly what's missing. Apply label `needs-info`.
-4. **Close spam/duplicates** — `gh issue close <n> --repo ulsklyc/oikos --reason "not planned" --comment "<english explanation>"`. Always leave a reason.
+4. **Close spam/duplicates** — `gh issue close <n> --repo ulsklyc/yuvomi --reason "not planned" --comment "<english explanation>"`. Always leave a reason.
 
 ## Guardrails
 

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -17,7 +17,7 @@ allowed-tools:
 
 Run from inside `oikos/`. `$1` is the PR number.
 
-1. **Fetch** — `gh pr view $1 --repo ulsklyc/oikos`, `gh pr diff $1 --repo ulsklyc/oikos`, `gh pr checks $1 --repo ulsklyc/oikos`. Note failing checks. Delegate the deep read to the `pr-reviewer` subagent (`Agent({ subagent_type: "pr-reviewer", ... })`) so main-thread context stays free.
+1. **Fetch** — `gh pr view $1 --repo ulsklyc/yuvomi`, `gh pr diff $1 --repo ulsklyc/yuvomi`, `gh pr checks $1 --repo ulsklyc/yuvomi`. Note failing checks. Delegate the deep read to the `pr-reviewer` subagent (`Agent({ subagent_type: "pr-reviewer", ... })`) so main-thread context stays free.
 2. **Constraint check** — walk the diff against CLAUDE.md Hard Constraints:
    - No frontend frameworks / bundlers / CSS libraries added
    - No `require`, only `import`/`export`


### PR DESCRIPTION
Post-rename cleanup of the Claude-specific config (`.claude/`).

- `pr-reviewer`, `repo-auditor` agents and the `pr-review`, `fix-issue`, `issue-triage` skills: `gh --repo ulsklyc/oikos` → `ulsklyc/yuvomi` (these only worked via GitHub's rename redirect).
- `docs-sync` sync-target table: renamed `awesome-selfhosted/oikos.yml` → `yuvomi.yml`.

Intentionally left as-is: local working-folder path prefixes (`oikos/...` — the checkout folder is still named oikos), the `oikos-` web-component prefix (§3c, later migration phase), `oikos.db`/localStorage/`window.oikos` (data continuity), and the transitional `ghcr.io/ulsklyc/oikos` image references (still accurate while the parallel push runs).