### PR TITLE
Point community-health docs at ulsklyc/yuvomi

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -2,7 +2,7 @@
 
 Feature requests and planned extensions. Entries here will **not** be implemented until explicitly prioritized and moved into a release branch.
 
-New suggestion? → [Open an issue](https://github.com/ulsklyc/oikos/issues/new?template=feature_request.md) or add it here.
+New suggestion? → [Open an issue](https://github.com/ulsklyc/yuvomi/issues/new?template=feature_request.md) or add it here.
 
 ## Open Entries
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -45,7 +45,7 @@ an individual is officially representing the community in public spaces.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported via [GitHub Private Vulnerability Reporting](https://github.com/ulsklyc/oikos/security/advisories/new)
+reported via [GitHub Private Vulnerability Reporting](https://github.com/ulsklyc/yuvomi/security/advisories/new)
 or by opening a private issue on GitHub. All complaints will be reviewed and
 investigated promptly and fairly.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Thanks for your interest in contributing! Yuvomi is a small, opinionated project with deliberate architectural constraints. This guide covers what you need to know before submitting code.
 
-Have a question before diving in? Start a thread in [Discussions](https://github.com/ulsklyc/oikos/discussions).
+Have a question before diving in? Start a thread in [Discussions](https://github.com/ulsklyc/yuvomi/discussions).
 
 ---
 
@@ -31,8 +31,8 @@ Backend dependencies are evaluated case-by-case but must remain minimal. When in
 ### Getting started
 
 ```bash
-git clone https://github.com/ulsklyc/oikos.git
-cd oikos
+git clone https://github.com/ulsklyc/yuvomi.git
+cd yuvomi
 npm install
 cp .env.example .env
 # Set SESSION_SECRET - leave DB_ENCRYPTION_KEY empty (no SQLCipher needed locally)
@@ -117,15 +117,15 @@ docs/                  # Product spec, screenshots
 
 ### 1. Find or create an issue
 
-Before starting work, check the [existing issues](https://github.com/ulsklyc/oikos/issues). For anything beyond a trivial fix, open an issue first to discuss the approach. This avoids wasted effort on changes that conflict with the project's direction.
+Before starting work, check the [existing issues](https://github.com/ulsklyc/yuvomi/issues). For anything beyond a trivial fix, open an issue first to discuss the approach. This avoids wasted effort on changes that conflict with the project's direction.
 
 ### 2. Fork and branch
 
 ```bash
 # Fork on GitHub, then:
-git clone https://github.com/YOUR-USERNAME/oikos.git
-cd oikos
-git remote add upstream https://github.com/ulsklyc/oikos.git
+git clone https://github.com/YOUR-USERNAME/yuvomi.git
+cd yuvomi
+git remote add upstream https://github.com/ulsklyc/yuvomi.git
 git checkout -b feat/your-feature-name
 ```
 
@@ -248,7 +248,7 @@ Format: imperative mood, one line per change, user-oriented language.
 
 ### Bugs
 
-[Open an issue](https://github.com/ulsklyc/oikos/issues/new) with:
+[Open an issue](https://github.com/ulsklyc/yuvomi/issues/new) with:
 
 - What you expected vs. what happened
 - Steps to reproduce
@@ -263,13 +263,13 @@ Features that conflict with the project's [hard constraints](#hard-constraints) 
 
 ### Security vulnerabilities
 
-Do **not** open a public issue. Use [GitHub Private Vulnerability Reporting](https://github.com/ulsklyc/oikos/security/advisories/new) instead. See [`SECURITY.md`](SECURITY.md) for details.
+Do **not** open a public issue. Use [GitHub Private Vulnerability Reporting](https://github.com/ulsklyc/yuvomi/security/advisories/new) instead. See [`SECURITY.md`](SECURITY.md) for details.
 
 ---
 
 ## Questions?
 
-If something in this guide is unclear or you're unsure whether a contribution fits, open a thread in [Discussions](https://github.com/ulsklyc/oikos/discussions) or comment on the relevant issue. We're happy to help.
+If something in this guide is unclear or you're unsure whether a contribution fits, open a thread in [Discussions](https://github.com/ulsklyc/yuvomi/discussions) or comment on the relevant issue. We're happy to help.
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 If you discover a security vulnerability in Yuvomi, please report it responsibly. **Do not open a public issue.**
 
-Instead, use [GitHub Private Vulnerability Reporting](https://github.com/ulsklyc/oikos/security/advisories/new) to submit your report. This creates a private advisory visible only to you and the maintainers.
+Instead, use [GitHub Private Vulnerability Reporting](https://github.com/ulsklyc/yuvomi/security/advisories/new) to submit your report. This creates a private advisory visible only to you and the maintainers.
 
 Include:
 

--- a/deploy/truenas/README.md
+++ b/deploy/truenas/README.md
@@ -1,3 +1,3 @@
 # Yuvomi
 
-[Yuvomi](https://github.com/ulsklyc/oikos) is a self-hosted, privacy-focused family planner. It bundles a shared calendar, tasks, shopping lists, meal planning, notes, contacts and budgeting into a single fast PWA — no cloud, no tracking.
+[Yuvomi](https://github.com/ulsklyc/yuvomi) is a self-hosted, privacy-focused family planner. It bundles a shared calendar, tasks, shopping lists, meal planning, notes, contacts and budgeting into a single fast PWA — no cloud, no tracking.

--- a/deploy/truenas/questions.yaml
+++ b/deploy/truenas/questions.yaml
@@ -53,7 +53,7 @@ questions:
             private: true
         - variable: additional_envs
           label: Additional Environment Variables
-          description: See https://github.com/ulsklyc/oikos/blob/main/docs/installation.md#environment-variables for available environment variables.
+          description: See https://github.com/ulsklyc/yuvomi/blob/main/docs/installation.md#environment-variables for available environment variables.
           schema:
             type: list
             default: []


### PR DESCRIPTION
Audit follow-up — repo-slug URLs that the release-time docs-sync did not cover:

- `CONTRIBUTING.md` — clone/upstream/issues/discussions URLs + `cd oikos` → `cd yuvomi` clone dir
- `CODE_OF_CONDUCT.md`, `SECURITY.md` — private vulnerability reporting links
- `BACKLOG.md` — issue link
- `deploy/truenas/{README.md,questions.yaml}` — reference URLs

All moved `github.com/ulsklyc/oikos` → `ulsklyc/yuvomi` (previously worked only via the rename redirect). Historical docs (`docs/archive`, `docs/design`), the transitional `templates/oikos.xml`, and the deliberate old-link mentions in the README banner / CHANGELOG are left untouched.