### PR TITLE
fix(navigation): align sidebar logo, icons, and highlight pill to resolve #314

### DIFF
--- a/public/router.js
+++ b/public/router.js
@@ -692,7 +692,7 @@ function renderAppShell(container) {
     if (!ind) return;
     const cr = sidebarItems.getBoundingClientRect();
     const ir = item.getBoundingClientRect();
-    ind.style.transform = `translateY(${ir.top - cr.top + sidebarItems.scrollTop}px)`;
+    ind.style.transform = `translateY(${ir.top - cr.top + sidebarItems.scrollTop + 2}px)`;
     ind.style.opacity = '0.5';
   });
   sidebarItems.addEventListener('mouseleave', () => positionSidebarIndicator());
@@ -1519,7 +1519,7 @@ function positionSidebarIndicator() {
   }
   const cr = container.getBoundingClientRect();
   const ar = active.getBoundingClientRect();
-  indicator.style.transform = `translateY(${ar.top - cr.top + container.scrollTop}px)`;
+  indicator.style.transform = `translateY(${ar.top - cr.top + container.scrollTop + 2}px)`;
   indicator.style.opacity = '';
 }
 

--- a/public/styles/layout.css
+++ b/public/styles/layout.css
@@ -786,7 +786,8 @@ html.fab-anim-done .page-fab {
     display: flex;
     justify-content: flex-start;
     align-items: center;
-    padding: var(--space-2) var(--space-5) var(--space-4) calc(var(--space-5) - 1px);
+    height: 56px;
+    padding: 0 var(--space-5) 0 14px;
     margin-bottom: var(--space-1);
     flex-shrink: 0;
     gap: var(--space-3);
@@ -835,7 +836,7 @@ html.fab-anim-done .page-fab {
     display: flex;
     flex-direction: column;
     gap: var(--space-0h);
-    padding: 0 var(--space-2);
+    padding: 0;
     flex: 1;
     overflow-y: auto;
     scrollbar-width: none;
@@ -849,7 +850,7 @@ html.fab-anim-done .page-fab {
     justify-content: flex-start;
     align-items: center;
     border-radius: var(--radius-sm);
-    padding: var(--space-2) var(--space-3);
+    padding: var(--space-2) var(--space-3) var(--space-2) 15px;
     gap: var(--space-3);
     min-height: var(--target-lg);
     font-size: var(--text-sm);
@@ -2576,8 +2577,8 @@ textarea.input { resize: vertical; }
 /* ── Sidebar: Morphende Indikator-Pille (Strukturell) ── */
 .nav-sidebar__indicator {
   position: absolute;
-  left: 0;
-  right: 0;
+  left: var(--space-1);
+  right: var(--space-1);
   top: 0;
   height: var(--target-base); /* 44px */
   border-radius: var(--radius-sm);
@@ -2601,6 +2602,12 @@ textarea.input { resize: vertical; }
 
 /* Kein statischer Hintergrund und kein Shadow-Highlight wenn Indikator aktiv */
 .nav-sidebar__items--liquid .nav-item[aria-current="page"] {
+  background: transparent !important;
+  box-shadow: none !important;
+}
+
+/* Kein statischer Hover-Hintergrund wenn Liquid-Indikator aktiv */
+.nav-sidebar__items--liquid .nav-item:hover:not([aria-current="page"]) {
   background: transparent !important;
   box-shadow: none !important;
 }

--- a/test/test-frontend-audit.js
+++ b/test/test-frontend-audit.js
@@ -6,7 +6,7 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync, readdirSync } from 'node:fs';
 
-const read = (path) => readFileSync(new URL(path, import.meta.url), 'utf8');
+const read = (path) => readFileSync(new URL(path, import.meta.url), 'utf8').replace(/\r/g, '');
 
 function walkJsFiles(dir) {
   const entries = readdirSync(new URL(dir, import.meta.url), { withFileTypes: true });


### PR DESCRIPTION
This PR fixes the sidebar alignment and jumping issues described in #314.

### Changes:
- **Logo Horizontal Alignment**: Adjusted left padding to 14px so the 28px logomark centers at exactly 28px.
- **Logo Vertical Alignment**: Set a fixed height of 56px to prevent vertical jumps when expanding/collapsing.
- **Navigation Item Alignment**: Adjusted left padding to 15px to align icon wells (26px) at exactly 28px.
- **Indicator Pill Spacing**: Set left/right spacing to 4px (var(--space-1)) for a floating centered design.
- **Vertical Indicator Centering**: Added a +2px offset in router.js to vertically center the 44px pill inside the 48px item.
- **Test Compatibility**: Normalized carriage returns in test-frontend-audit.js to prevent failures on Windows.