### PR TITLE
fix(docker): hardcode BACKUP_DIR container path to prevent host/container mismatch

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     environment:
       - NODE_ENV=production
       - DB_PATH=${DB_PATH:-/data/oikos.db}
-      - BACKUP_DIR=${BACKUP_DIR:-/backups}
+      - BACKUP_DIR=/backups
       # Secure cookies come from .env (the installer sets them):
       #   - Reverse proxy + HTTPS → SESSION_SECURE=true, TRUST_PROXY=1
       #   - Direct HTTP access     → SESSION_SECURE=false, TRUST_PROXY=loopback

--- a/podman-compose.yml
+++ b/podman-compose.yml
@@ -30,7 +30,7 @@ services:
     environment:
       - NODE_ENV=production
       - DB_PATH=${DB_PATH:-/data/oikos.db}
-      - BACKUP_DIR=${BACKUP_DIR:-/backups}
+      - BACKUP_DIR=/backups
       # Secure cookies come from .env (the installer sets them):
       #   - Reverse proxy + HTTPS → SESSION_SECURE=true, TRUST_PROXY=1
       #   - Direct HTTP access     → SESSION_SECURE=false, TRUST_PROXY=loopback


### PR DESCRIPTION
## Summary

- `BACKUP_DIR` in `docker-compose.yml` was interpolated from the host environment into the container's `environment:` section
- When a user sets `BACKUP_DIR=./backups` (or any custom path) in `.env` to control the **host-side** volume mount source, the container received `BACKUP_DIR=./backups` — a path that doesn't exist inside the container
- The container-side target is always `/backups` (hardcoded in the `volumes:` section), so the app env var must always be `/backups`

**Root cause vs. reported concern:** The issue author suspected `entrypoint.sh` was broken. The `chown` there is actually fine — it uses the fixed container paths `/data /backups /app/modules` which are the hardcoded volume-mount targets. The actual bug is the dual-use of `BACKUP_DIR` in `docker-compose.yml`.

## Change

```diff
- - BACKUP_DIR=${BACKUP_DIR:-/backups}
+ - BACKUP_DIR=/backups
```

## Test plan

- [ ] `docker compose up` with default `.env` → `BACKUP_DIR=/backups` inside container
- [ ] `docker compose up` with `BACKUP_DIR=./my-backups` in `.env` → volume mounts `./my-backups:/backups`, container still sees `BACKUP_DIR=/backups`
- [ ] Scheduled backup writes to the correct `/backups` path

Closes #325

🤖 Generated with [Claude Code](https://claude.com/claude-code)