### PR TITLE
style: increase event item avatar size to 32px on dashboard

### DIFF
--- a/public/pages/dashboard.js
+++ b/public/pages/dashboard.js
@@ -461,7 +461,7 @@ function renderUpcomingEvents(events) {
             ${e.cal_name ? `<span class="event-item__cal">${esc(e.cal_name)}</span>` : ''}
           </div>
         </div>
-        ${renderAvatarStack(e.assigned_users ?? [], { size: 26 })}
+        ${renderAvatarStack(e.assigned_users ?? [], { size: 32 })}
       </div>
     `;
   }).join('');


### PR DESCRIPTION
This PR increases the avatar image size in the dashboard calendar widget event items from 26px to 32px. Since there is enough horizontal space available, this provides better visual presence and makes it easier to scan who is assigned to an event on the dashboard.
