### PR TITLE
fix: resolve settings layout horizontal shift/jump

### DIFF
--- a/public/styles/layout.css
+++ b/public/styles/layout.css
@@ -135,6 +135,7 @@
   min-height: 0;
   overflow-y: auto;
   overflow-x: hidden;
+  scrollbar-gutter: stable;
   overscroll-behavior-y: contain;
   touch-action: pan-y;
   -webkit-overflow-scrolling: touch;


### PR DESCRIPTION
Reserves layout space for vertical scrollbars on the main container (.app-content) using scrollbar-gutter: stable, preventing setting page components from shifting horizontally when scrollbars are toggled.