### PR TITLE
refactor(settings): scope device-leaf cleanup observer to router swap node

### DIFF
--- a/public/settings/pages/personal-device.js
+++ b/public/settings/pages/personal-device.js
@@ -94,13 +94,15 @@ function bindPwaInstall(container) {
   if (unsubscribeRequested || !container.isConnected) {
     stopListening();
   } else {
+    // Cleanup-Erkennung: Der SPA-Router tauscht Seiten per
+    // #main-content.replaceChildren() aus. Wir beobachten nur diesen einen
+    // persistenten Container (childList, ohne subtree) statt das gesamte
+    // document.body-Subtree — Letzteres würde bei jeder DOM-Mutation der App feuern.
+    const swapRoot = document.getElementById('main-content') || container.parentNode;
     observer = new MutationObserver(() => {
       if (!container.isConnected) stopListening();
     });
-    observer.observe(document.body || document.documentElement, {
-      childList: true,
-      subtree: true,
-    });
+    if (swapRoot) observer.observe(swapRoot, { childList: true });
     if (!container.isConnected) stopListening();
   }
 

--- a/test/test-frontend-audit.js
+++ b/test/test-frontend-audit.js
@@ -298,7 +298,11 @@ test('personal device leaf owns PWA installation state and disconnect cleanup', 
   assert.match(source, /if \(unsubscribed\) return/);
   assert.match(source, /stopListening\(\)/);
   assert.match(source, /new MutationObserver\(/);
-  assert.match(source, /observer\.observe\(document\.body \|\| document\.documentElement/);
+  // Cleanup observes only the router's persistent swap container (#main-content),
+  // not the whole document.body subtree (which fires on every app DOM mutation).
+  assert.match(source, /getElementById\('main-content'\)/);
+  assert.match(source, /observer\.observe\(swapRoot, \{ childList: true \}\)/);
+  assert.doesNotMatch(source, /subtree:\s*true/);
   assert.match(source, /observer\?\.disconnect\(\)/);
   assert.match(source, /id="pwa-install-status"[^>]*aria-live=/);
   assert.match(source, /id="pwa-install-error"[^>]*role="alert"/);


### PR DESCRIPTION
Rescued code-review follow-up commit `4cf6425` that was left unpushed on the `codex/settings-information-architecture` branch after PR #340 was squash-merged — it is **not** contained in the squash and `main` still ships the inefficient observer.

## Was

`public/settings/pages/personal-device.js` observed the whole `document.body` subtree (`subtree: true`) just to detect its own teardown, so the callback fired on **every app-wide DOM mutation**. This scopes the `MutationObserver` to `#main-content` (the persistent node the SPA router `replaceChildren()`s on navigation) with `childList` only, which reliably catches the leaf's removal. The `container.isConnected` guard in `renderState` remains the lazy-cleanup safety net.

`test/test-frontend-audit.js` is updated to assert the new pattern and forbid the `subtree:true` anti-pattern.

## Verifikation

`npm run test:frontend-audit` → 93/93 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)