### PR TITLE
fix(calendar): apply AM/PM time format to week/day view timeline labels

### DIFF
--- a/public/pages/calendar.js
+++ b/public/pages/calendar.js
@@ -1221,7 +1221,7 @@ function renderWeekView(container) {
           <div class="week-view__times">
             ${Array.from({ length: 24 }, (_, h) => `
               <div class="week-view__time-slot" style="height:${HOUR_HEIGHT}px;">
-                <span class="week-view__time-label">${h === 0 ? '' : `${pad(h)}:00`}</span>
+                <span class="week-view__time-label">${h === 0 ? '' : formatTime(new Date(2000, 0, 1, h, 0, 0))}</span>
               </div>
             `).join('')}
           </div>
@@ -1414,7 +1414,7 @@ function renderDayView(container) {
           <div class="day-view__times">
             ${Array.from({ length: 24 }, (_, h) => `
               <div class="week-view__time-slot" style="height:${HOUR_HEIGHT}px;">
-                <span class="week-view__time-label">${h === 0 ? '' : `${pad(h)}:00`}</span>
+                <span class="week-view__time-label">${h === 0 ? '' : formatTime(new Date(2000, 0, 1, h, 0, 0))}</span>
               </div>
             `).join('')}
           </div>


### PR DESCRIPTION
## Summary

- Timeline hour labels in the week and day views were hardcoded to 24h format (`pad(h) + ':00'`)
- Replaced both instances with `formatTime(new Date(2000, 0, 1, h, 0, 0))` so the user's time format preference (12h AM/PM or 24h) is applied consistently
- Calendar entries and task chips already used `formatTime` — this aligns the timeline column with them

Closes #339

## Test plan

- [ ] Set time format to AM/PM in Settings
- [ ] Open Calendar → Week view: confirm timeline labels show e.g. "1:00 AM", "12:00 PM"
- [ ] Open Calendar → Day view: confirm same
- [ ] Switch back to 24h format: confirm labels revert to "01:00", "12:00"
- [ ] All calendar tests pass (`npm run test:calendar`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)