### PR TITLE
fix(security): suppress false-positive CodeQL SSRF alert in davFetch

### DIFF
--- a/server/services/document-storage.js
+++ b/server/services/document-storage.js
@@ -392,6 +392,7 @@ function remoteUrl(config, relativeSegments) {
 async function davFetch(config, method, relativeSegments, { body, headers } = {}) {
   const url = remoteUrl(config, relativeSegments);
   const agent = requestAgent(url, config);
+  // codeql[js/request-forgery] - SSRF mitigated: agent uses validatedLookup (blocks private IPs at DNS time) + assertWebdavTargetAllowed pre-flight
   return fetch(url, {
     method,
     redirect: 'manual',


### PR DESCRIPTION
## Summary

- Adds a `// codeql[js/request-forgery]` inline suppression comment before the `fetch()` call in `davFetch` (`server/services/document-storage.js:395`)
- Closes GitHub Code Scanning alert #18 (`js/request-forgery`) which CodeQL marks as open despite the SSRF mitigation being present

## Why this is a false positive

The SSRF is already mitigated at two layers:
1. **Pre-flight:** `assertWebdavTargetAllowed` resolves all DNS addresses and blocks private/loopback ranges before any request is made
2. **At connection time:** `requestAgent` returns an HTTP/HTTPS agent backed by `validatedLookup`, which re-validates the resolved IP against `BLOCKED_NETWORKS` during the actual DNS lookup — preventing DNS rebinding attacks

CodeQL's static analysis cannot trace this custom agent callback chain, so it reports a false positive. The suppression comment documents the decision in-code.

## Test plan

- [ ] `npm test` passes
- [ ] CodeQL scan on this branch should close alert #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)