### PR TITLE
fix(security): move CodeQL suppression to flagged line in davFetch

### DIFF
--- a/server/services/document-storage.js
+++ b/server/services/document-storage.js
@@ -392,8 +392,7 @@ function remoteUrl(config, relativeSegments) {
 async function davFetch(config, method, relativeSegments, { body, headers } = {}) {
   const url = remoteUrl(config, relativeSegments);
   const agent = requestAgent(url, config);
-  // codeql[js/request-forgery] - SSRF mitigated: agent uses validatedLookup (blocks private IPs at DNS time) + assertWebdavTargetAllowed pre-flight
-  return fetch(url, {
+  return fetch(url, { // codeql[js/request-forgery] - SSRF mitigated: agent uses validatedLookup (blocks private IPs at DNS time) + assertWebdavTargetAllowed pre-flight
     method,
     redirect: 'manual',
     agent,


### PR DESCRIPTION
## Summary

- Moves the `// codeql[js/request-forgery]` comment from the line *above* `fetch(url, {...})` to the *same line* as the flagged expression
- For JavaScript/TypeScript, CodeQL requires the suppression comment to be **inline** (end of the flagged line), not on the preceding line
- Fixes alert #18 which remained open despite the previous suppression attempt in #344

## Test plan

- [ ] CodeQL scan on this branch should resolve alert #18 as suppressed
- [ ] No functional change — comment placement only

🤖 Generated with [Claude Code](https://claude.com/claude-code)