### PR TITLE
fix(security): replace non-functional CodeQL suppression in davFetch

### DIFF
--- a/server/services/document-storage.js
+++ b/server/services/document-storage.js
@@ -392,7 +392,12 @@ function remoteUrl(config, relativeSegments) {
 async function davFetch(config, method, relativeSegments, { body, headers } = {}) {
   const url = remoteUrl(config, relativeSegments);
   const agent = requestAgent(url, config);
-  return fetch(url, { // codeql[js/request-forgery] - SSRF mitigated: agent uses validatedLookup (blocks private IPs at DNS time) + assertWebdavTargetAllowed pre-flight
+  // SSRF-Schutz: URL ist ausschliesslich admin-konfigurierbar; agent nutzt
+  // validatedLookup (blockiert private/loopback/link-local IPs zur DNS-Zeit)
+  // und assertWebdavTargetAllowed als Pre-Flight. CodeQL js/request-forgery
+  // ist als False Positive dismissed (GitHub-Alert #19) — Inline-Suppression-
+  // Kommentare werden von GitHub Code Scanning fuer CodeQL nicht ausgewertet.
+  return fetch(url, {
     method,
     redirect: 'manual',
     agent,


### PR DESCRIPTION
## Was

CodeQL-Alert #19 (`js/request-forgery`, SSRF in `davFetch`) ist seit mehreren Anläufen offen geblieben.

**Ursache:** Die bisherigen Fixes (`ca8aac9`, `0ac92f6`) versuchten den Alert über `// codeql[js/request-forgery]`-Inline-Kommentare zu unterdrücken. **GitHub Code Scanning wertet solche Suppression-Kommentare für CodeQL nicht aus** — die Syntax stammt vom abgeschalteten LGTM.com. Jeder Versuch war damit ein No-Op, egal auf welcher Zeile.

## Lösung

- Alert #19 via API als **`false positive`** dismissed.
- Den toten `// codeql[...]`-Direktiv-Kommentar in `davFetch` durch eine ehrliche Mitigations-Notiz ersetzt, die auch festhält, dass Inline-Suppression hier prinzipiell nicht greift.

## Warum False Positive

Der WebDAV-Ziel-URL ist **ausschließlich admin-konfigurierbar** (`isAdmin`-gated `/storage/config` & `/storage/test`). SSRF auf interne Dienste ist geschlossen:
- `validatedLookup` blockiert private/loopback/link-local IPs zur DNS-Auflösungszeit
- `assertWebdavTargetAllowed` als Pre-Flight-Check

## Tests

`npm run test:document-storage` → 58/58 grün (reine Kommentar-Änderung).