### PR TITLE
fix(test): update frontend-audit for multi-provider DMS

### DIFF
--- a/test/test-frontend-audit.js
+++ b/test/test-frontend-audit.js
@@ -631,14 +631,15 @@ test('documents-storage leaf owns WebDAV document storage with a status-first la
   assert.doesNotMatch(source, /\/documents\/dms/);
 });
 
-test('documents-dms leaf owns Paperless DMS account management', () => {
+test('documents-dms leaf owns DMS account management (Paperless + Papra)', () => {
   const source = read('../public/settings/pages/documents-dms.js');
 
   assert.match(source, /api\.get\('\/documents\/dms\/accounts'\)/);
   assert.match(source, /api\.post\('\/documents\/dms\/accounts'/);
   assert.match(source, /api\.delete\(`\/documents\/dms\/accounts\/\$\{[^}]+\}`\)/);
   assert.match(source, /\/documents\/dms\/accounts\/\$\{[^}]+\}\/test/);
-  assert.match(source, /provider: 'paperless'/);
+  assert.match(source, /value="paperless"/);
+  assert.match(source, /value="papra"/);
 
   // DMS leaf must not own storage concerns.
   assert.doesNotMatch(source, /\/documents\/storage/);


### PR DESCRIPTION
## Summary

- The DMS leaf now uses a provider `<select>` (paperless + papra) instead of hardcoding `provider: 'paperless'`
- `test-frontend-audit.js` was checking for the old static literal — CI broke after #349 merged
- Updated assertion checks for both `value="paperless"` and `value="papra"` option elements

## Test plan

- [ ] `npm run test:frontend-audit` — 93 passed, 0 failed