### PR TITLE
chore: release v0.71.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.71.10] - 2026-06-11
+
+### Fixed
+- **CI test fix**: updated `test-frontend-audit` assertion for the DMS settings page to check for both `paperless` and `papra` provider option values, replacing the old static `provider: 'paperless'` literal that no longer exists after the multi-provider select was introduced in v0.71.9.
+
 ## [0.71.9] - 2026-06-11
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oikos",
-  "version": "0.71.9",
+  "version": "0.71.10",
   "description": "Self-hosted family planner - calendar, tasks, shopping, meal planning, budget and more. Private, open-source, no subscription.",
   "main": "server/index.js",
   "type": "module",


### PR DESCRIPTION
## Summary

- Patch release: bumps version to 0.71.10
- Fixes the `test-frontend-audit` CI failure introduced in #349 (multi-provider DMS select replaced the static `provider: 'paperless'` literal)

## Test plan

- [ ] `npm run test:frontend-audit` — 93 passed, 0 failed