### PR TITLE
docs: update version badge to v0.71.10

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -562,7 +562,7 @@
     <span class="sep dt">·</span>
     <span data-t="proof_mit">MIT licensed</span>
     <span class="sep">·</span>
-    <span><b>v0.71.5</b></span>
+    <span><b>v0.71.10</b></span>
   </div>
 </div>
 
@@ -907,7 +907,7 @@ cp .env.example .env  <span class="c"># set SESSION_SECRET and DB_ENCRYPTION_KEY
       </div>
     </div>
     <div class="foot-bottom">
-      <span><span id="gh-stars-footer" data-gh-stars>★ 810 · </span><b>v0.71.5</b> · June 2026</span>
+      <span><span id="gh-stars-footer" data-gh-stars>★ 810 · </span><b>v0.71.10</b> · June 2026</span>
       <span data-t="foot_madewith">Self-hosted · Privacy-first · Open source</span>
     </div>
   </div>


### PR DESCRIPTION
## Summary

- Updates hero and footer version badge in `docs/index.html` from v0.71.5 to v0.71.10

## Test plan

- [ ] Version badge shows v0.71.10 on the docs landing page