### PR TITLE
fix(ui): only show today's calendar events in Today Cockpit on dashboard

### DIFF
--- a/public/pages/dashboard.js
+++ b/public/pages/dashboard.js
@@ -360,7 +360,15 @@ function buildTodayHighlights(data) {
   const meals = data?.meals ?? data?.todayMeals ?? null;
 
   const urgentTask = tasks.find((task) => task.priority === 'urgent') ?? tasks[0] ?? null;
-  const nextEvent = events[0] ?? null;
+
+  const today = new Date().toDateString();
+  const todayEvents = events.filter((e) => {
+    if (!e.start_datetime) return true;
+    const d = new Date(e.start_datetime);
+    return d.toDateString() === today;
+  });
+  const nextEvent = todayEvents[0] ?? null;
+
   const openShoppingCount = shoppingItems.length
     ? shoppingItems.filter((item) => !item.is_checked).length
     : shoppingLists.reduce((sum, list) => {
@@ -379,7 +387,7 @@ function buildTodayHighlights(data) {
     openShoppingCount,
     dinner,
     taskCount: tasks.length,
-    eventCount: events.length,
+    eventCount: todayEvents.length,
   };
 }
 

--- a/test/test-dashboard.js
+++ b/test/test-dashboard.js
@@ -132,6 +132,22 @@ test('Today-Highlights priorisieren dringende Aufgaben und nächsten Termin', as
   assert(result.dinner.title === 'Soup', 'Abendessen sollte übernommen werden');
 });
 
+test('Today-Highlights filtert Termine auf den heutigen Tag', async () => {
+  const { __test } = await import('../public/pages/dashboard.js');
+  const todayStr = new Date().toISOString().slice(0, 10);
+  const tomorrowStr = new Date(Date.now() + 86400000).toISOString().slice(0, 10);
+
+  const result = __test.buildTodayHighlights({
+    events: [
+      { id: 1, title: 'Termin Morgen', start_datetime: `${tomorrowStr}T10:00:00` },
+      { id: 2, title: 'Termin Heute', start_datetime: `${todayStr}T14:30:00` },
+    ],
+  });
+
+  assert(result.eventCount === 1, `Erwartet 1 Termin für heute, erhalten ${result.eventCount}`);
+  assert(result.nextEvent.title === 'Termin Heute', 'Erwartet "Termin Heute" als nächsten Termin');
+});
+
 // --------------------------------------------------------
 // Tests: Dringende Aufgaben
 // --------------------------------------------------------


### PR DESCRIPTION
On the dashboard's Today Cockpit ('Heute wichtig'), the calendar card was showing the count and title of all upcoming events (up to 5) instead of only today's events. This PR filters calendar events to the current day in \uildTodayHighlights\ so that the cockpit card correctly shows only today's events.