### PR TITLE
perf(holidays): throttle automatic holiday sync to once every 30 days

### DIFF
--- a/server/routes/preferences.js
+++ b/server/routes/preferences.js
@@ -502,7 +502,7 @@ router.post('/holidays/sync', async (req, res) => {
     return res.status(403).json({ error: 'Admin access required.', code: 403 });
   }
   try {
-    await holidays.sync();
+    await holidays.sync(true);
     res.json({ data: { last_sync: cfgGet('holiday_last_sync') ?? null } });
   } catch (err) {
     log.error('POST /holidays/sync', err);

--- a/server/services/holidays.js
+++ b/server/services/holidays.js
@@ -123,7 +123,7 @@ async function syncYearAndType(country, subdivision, year, type, langCode) {
  * Sync Feiertage und/oder Schulferien für das konfigurierte Land/Region.
  * Wird vom Auto-Scheduler und manuell aus den Settings aufgerufen.
  */
-async function sync() {
+async function sync(force = false) {
   const country     = db.get().prepare("SELECT value FROM sync_config WHERE key='holiday_country'").get()?.value;
   const subdivision = db.get().prepare("SELECT value FROM sync_config WHERE key='holiday_subdivision'").get()?.value ?? null;
   const showPublic  = db.get().prepare("SELECT value FROM sync_config WHERE key='holiday_show_public'").get()?.value === '1';
@@ -137,6 +137,18 @@ async function sync() {
   if (!showPublic && !showSchool) {
     log.info('Both holiday layers disabled – skipping sync.');
     return { synced: 0 };
+  }
+
+  const lastSyncStr = db.get().prepare("SELECT value FROM sync_config WHERE key='holiday_last_sync'").get()?.value;
+  if (!force && lastSyncStr) {
+    const lastSyncDate = new Date(lastSyncStr);
+    if (!Number.isNaN(lastSyncDate.getTime())) {
+      const thirtyDaysMs = 30 * 24 * 60 * 60 * 1000;
+      if (Date.now() - lastSyncDate.getTime() < thirtyDaysMs) {
+        log.info('Holidays synced recently – skipping automatic sync.');
+        return { synced: 0 };
+      }
+    }
   }
 
   // Sprache aus Land ableiten (Fallback EN)

--- a/test/test-holidays.js
+++ b/test/test-holidays.js
@@ -178,7 +178,7 @@ test('sync: public-only fetches PublicHolidays per year, caches them, sets last_
   __setFetchImpl(mock);
   setConfig({ holiday_country: 'DE', holiday_show_public: '1', holiday_show_school: '0' });
 
-  const res = await sync();
+  const res = await sync(true);
 
   assert.equal(res.synced, SYNC_YEAR_SPAN);
   assert.ok(mock.calls.every((u) => u.includes('/PublicHolidays')));
@@ -195,8 +195,8 @@ test('sync: public-only fetches PublicHolidays per year, caches them, sets last_
 test('sync: is idempotent – re-running does not duplicate cached rows', async () => {
   __setFetchImpl(makeApiMock());
   setConfig({ holiday_country: 'DE', holiday_show_public: '1', holiday_show_school: '0' });
-  await sync();
-  await sync();
+  await sync(true);
+  await sync(true);
   const pub = db.prepare("SELECT COUNT(*) c FROM holiday_cache WHERE type='public'").get().c;
   assert.equal(pub, SYNC_YEAR_SPAN);
 });
@@ -204,10 +204,32 @@ test('sync: is idempotent – re-running does not duplicate cached rows', async 
 test('sync: both layers enabled caches public and school entries', async () => {
   __setFetchImpl(makeApiMock());
   setConfig({ holiday_country: 'DE', holiday_show_public: '1', holiday_show_school: '1' });
-  const res = await sync();
+  const res = await sync(true);
   assert.equal(res.synced, SYNC_YEAR_SPAN * 2);
   assert.equal(db.prepare("SELECT COUNT(*) c FROM holiday_cache WHERE type='public'").get().c, SYNC_YEAR_SPAN);
   assert.equal(db.prepare("SELECT COUNT(*) c FROM holiday_cache WHERE type='school'").get().c, SYNC_YEAR_SPAN);
+});
+
+test('sync: throttles automatic sync if executed within 30 days', async () => {
+  const mock = makeApiMock();
+  __setFetchImpl(mock);
+  setConfig({ holiday_country: 'DE', holiday_show_public: '1', holiday_show_school: '0' });
+
+  // First sync (force=false) - should run because DB has no last_sync
+  const res1 = await sync(false);
+  assert.equal(res1.synced, SYNC_YEAR_SPAN);
+  const firstCallCount = mock.calls.length;
+  assert.ok(firstCallCount > 0);
+
+  // Second sync (force=false) - should throttle (skip)
+  const res2 = await sync(false);
+  assert.deepEqual(res2, { synced: 0 });
+  assert.equal(mock.calls.length, firstCallCount); // no new API calls
+
+  // Third sync (force=true) - should bypass throttle
+  const res3 = await sync(true);
+  assert.equal(res3.synced, SYNC_YEAR_SPAN);
+  assert.equal(mock.calls.length, firstCallCount * 2); // new API calls made
 });
 
 // ---- getCountries / getSubdivisions -----------------------------------------


### PR DESCRIPTION
This PR introduces a 30-day throttle to the automatic holiday sync to reduce unnecessary API requests. Manual sync triggers from the Settings UI bypass this throttle and always force-sync.