### PR TITLE
feat(calendar): pre-fill start time from click position in day/week view

### DIFF
--- a/public/pages/calendar.js
+++ b/public/pages/calendar.js
@@ -1320,7 +1320,7 @@ function nowTop() {
 function clickedTime(e, colEl) {
   const rect = colEl.getBoundingClientRect();
   const yOffset = Math.max(0, e.clientY - rect.top);
-  const totalMinutes = Math.round((yOffset / HOUR_HEIGHT) * 60 / 15) * 15;
+  const totalMinutes = Math.round((yOffset / HOUR_HEIGHT) * 60 / 30) * 30;
   const clamped = Math.min(Math.max(totalMinutes, 0), 23 * 60 + 30);
   return `${pad(Math.floor(clamped / 60))}:${pad(clamped % 60)}`;
 }

--- a/public/pages/calendar.js
+++ b/public/pages/calendar.js
@@ -1256,7 +1256,10 @@ function renderWeekView(container) {
       return;
     }
     const col = e.target.closest('[data-date]');
-    if (col) openEventModal({ mode: 'create', date: col.dataset.date });
+    if (col) {
+      const time = clickedTime(e, col);
+      openEventModal({ mode: 'create', date: col.dataset.date, time });
+    }
   });
 
   container.querySelector('.allday-row').addEventListener('click', (e) => {
@@ -1310,6 +1313,16 @@ function nowTop() {
   const now = new Date();
   const minutes = now.getHours() * 60 + now.getMinutes();
   return (minutes / 60) * HOUR_HEIGHT;
+}
+
+/** Berechnet die geklickte Uhrzeit (auf 15-Minuten gerundet) aus einem Click-Event
+ *  relativ zum übergebenen Spalten-Element. */
+function clickedTime(e, colEl) {
+  const rect = colEl.getBoundingClientRect();
+  const yOffset = Math.max(0, e.clientY - rect.top);
+  const totalMinutes = Math.round((yOffset / HOUR_HEIGHT) * 60 / 15) * 15;
+  const clamped = Math.min(Math.max(totalMinutes, 0), 23 * 60 + 30);
+  return `${pad(Math.floor(clamped / 60))}:${pad(clamped % 60)}`;
 }
 
 function timeRangeForEvent(ev) {
@@ -1450,7 +1463,8 @@ function renderDayView(container) {
       if (ev) showEventPopup(ev, evEl);
       return;
     }
-    openEventModal({ mode: 'create', date: state.cursor });
+    const time = clickedTime(e, e.currentTarget);
+    openEventModal({ mode: 'create', date: state.cursor, time });
   });
 
   const scroll = container.querySelector('#day-scroll');
@@ -1860,13 +1874,13 @@ async function loadSyncTargets(selectElement, currentEvent = null) {
 // Event-Modal (Erstellen / Bearbeiten)
 // --------------------------------------------------------
 
-function openEventModal({ mode, event = null, date = null, reminder = null }) {
+function openEventModal({ mode, event = null, date = null, reminder = null, time = null }) {
   if (mode === 'edit' && event?.housekeeping_visit_id) {
     window.oikos.navigate(`/housekeeping?editVisit=${event.housekeeping_visit_id}`);
     return;
   }
   const isEdit = mode === 'edit';
-  const content = buildEventModalContent({ mode, event, date, reminder });
+  const content = buildEventModalContent({ mode, event, date, reminder, time });
 
   openSharedModal({
     title: isEdit ? t('calendar.editEvent') : t('calendar.newEvent'),
@@ -2098,16 +2112,22 @@ function openEventModal({ mode, event = null, date = null, reminder = null }) {
   });
 }
 
-function buildEventModalContent({ mode, event, date, reminder = null }) {
+function buildEventModalContent({ mode, event, date, reminder = null, time = null }) {
   const isEdit = mode === 'edit';
   const today  = date || state.today;
 
   const startDate = isEdit ? localDate(event.start_datetime) : today;
   const startTime = isEdit && event.start_datetime.length > 10
-    ? localTime(event.start_datetime) : '09:00';
+    ? localTime(event.start_datetime) : (time ?? '09:00');
   const endDate   = isEdit && event.end_datetime ? localDate(event.end_datetime) : startDate;
   const endTime   = isEdit && event.end_datetime && event.end_datetime.length > 10
-    ? localTime(event.end_datetime) : '10:00';
+    ? localTime(event.end_datetime)
+    : (() => {
+        if (!time) return '10:00';
+        const totalMins = timeToMinutes(time) + 60;
+        const clamped   = Math.min(totalMins, 24 * 60 - 1);
+        return `${pad(Math.floor(clamped / 60))}:${pad(clamped % 60)}`;
+      })();
   const selectedIcon = eventIconName(isEdit ? event.icon : 'calendar');
 
   const selectedUserIds = isEdit

--- a/public/pages/calendar.js
+++ b/public/pages/calendar.js
@@ -1315,7 +1315,7 @@ function nowTop() {
   return (minutes / 60) * HOUR_HEIGHT;
 }
 
-/** Berechnet die geklickte Uhrzeit (auf 15-Minuten gerundet) aus einem Click-Event
+/** Berechnet die geklickte Uhrzeit (auf 30-Minuten gerundet) aus einem Click-Event
  *  relativ zum übergebenen Spalten-Element. */
 function clickedTime(e, colEl) {
   const rect = colEl.getBoundingClientRect();
@@ -1536,6 +1536,8 @@ export const __test = {
   agendaSegmentKind,
   hasAttachment,
   attachmentUrls,
+  clickedTime,
+  HOUR_HEIGHT,
 };
 
 function renderAgendaEvent(ev, dayStr) {

--- a/test/test-calendar.js
+++ b/test/test-calendar.js
@@ -414,6 +414,40 @@ test('agendaSegmentKind: Ganztags-Event ist all-day', () => {
   assert(agendaSegmentKind(ev, '2026-06-14') === 'all-day', 'Ganztägig → all-day');
 });
 
+const { clickedTime, HOUR_HEIGHT } = calendarHelpers;
+
+function colAt(top) {
+  return { getBoundingClientRect: () => ({ top }) };
+}
+
+test('clickedTime: Klick auf Spaltenanfang ergibt 00:00', () => {
+  assert(clickedTime({ clientY: 0 }, colAt(0)) === '00:00', 'yOffset 0 → 00:00');
+});
+
+test('clickedTime: Klick wird auf 30 Minuten gerundet', () => {
+  const y = (14.5 / 24) * (HOUR_HEIGHT * 24);
+  assert(clickedTime({ clientY: y }, colAt(0)) === '14:30', 'Klick bei 14:30 bleibt 14:30');
+});
+
+test('clickedTime: Minuten zwischen den Rastern runden zum nächsten 30-Minuten-Schritt', () => {
+  const y = (HOUR_HEIGHT * 10) + (HOUR_HEIGHT * 20 / 60);
+  assert(clickedTime({ clientY: y }, colAt(0)) === '10:30', '10:20 rundet auf 10:30');
+});
+
+test('clickedTime: Klick oberhalb der Spalte wird auf 00:00 geklemmt', () => {
+  assert(clickedTime({ clientY: 5 }, colAt(50)) === '00:00', 'negativer yOffset → 00:00');
+});
+
+test('clickedTime: Klick am Tagesende wird auf 23:30 geklemmt', () => {
+  const y = HOUR_HEIGHT * 25;
+  assert(clickedTime({ clientY: y }, colAt(0)) === '23:30', 'yOffset über 24h → 23:30');
+});
+
+test('clickedTime: berücksichtigt die Scroll-Position der Spalte (rect.top)', () => {
+  const y = 200 + (HOUR_HEIGHT * 2);
+  assert(clickedTime({ clientY: y }, colAt(200)) === '02:00', 'rect.top wird von clientY abgezogen');
+});
+
 // --------------------------------------------------------
 // Ergebnis
 // --------------------------------------------------------


### PR DESCRIPTION
## Summary

When clicking an empty time slot in the **day view** or **week view**, the new event modal now pre-fills the start time based on the exact position where the user clicked (rounded to the nearest 30 minutes). The end time is automatically set to **start + 1 hour**.

Previously the start time was always hardcoded to **09:00** regardless of where the user clicked.

## Changes

- Added helper function `clickedTime(e, colEl)` that calculates the clicked time from the Y-offset relative to the time column
- Week view click handler now passes the calculated time to `openEventModal`
- Day view click handler now passes the calculated time to `openEventModal`
- `openEventModal` accepts a new optional `time` parameter
- `buildEventModalContent` uses the passed `time` as start time (fallback: 09:00) and calculates end time as start + 1 hour

## Example

Click at 14:30  modal opens with start 14:30, end 15:30