### PR TITLE
fix(db): restore reminders.pushed_at dropped by migration 57

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -562,7 +562,7 @@
     <span class="sep dt">·</span>
     <span data-t="proof_mit">MIT licensed</span>
     <span class="sep">·</span>
-    <span><b>v0.75.2</b></span>
+    <span><b>v0.77.0</b></span>
   </div>
 </div>
 
@@ -907,7 +907,7 @@ cp .env.example .env  <span class="c"># set SESSION_SECRET and DB_ENCRYPTION_KEY
       </div>
     </div>
     <div class="foot-bottom">
-      <span><span id="gh-stars-footer" data-gh-stars>★ 803 · </span><b>v0.75.2</b> · June 2026</span>
+      <span><span id="gh-stars-footer" data-gh-stars>★ 803 · </span><b>v0.77.0</b> · June 2026</span>
       <span data-t="foot_madewith">Self-hosted · Privacy-first · Open source</span>
     </div>
   </div>

--- a/server/db.js
+++ b/server/db.js
@@ -2268,6 +2268,13 @@ const MIGRATIONS = [
         WHERE calendar_feed_token IS NOT NULL;
     `,
   },
+  {
+    version: 62,
+    description: 'restore reminders.pushed_at dropped by the migration 57 table rebuild',
+    up: `
+      ALTER TABLE reminders ADD COLUMN pushed_at TEXT;
+    `,
+  },
 ];
 
 /**


### PR DESCRIPTION
## Summary
- Migration 57 rebuilt the `reminders` table via `reminders_new` but only carried over the pre-`pushed_at` columns, silently dropping the column added by migration 54. `PushScheduler` then fails with `no such column: r.pushed_at` on every fresh install/update (still present as of v0.77.0).
- New migration 62 restores the column.
- Also fixes the version badge in `docs/index.html` (hero + footer), which was still pinned to v0.75.2 across the v0.76.0 and v0.77.0 releases.

Fixes #393

## Test plan
- [x] `npm run test:db` — 36/36 passing, confirms migration 62 restores `reminders.pushed_at`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aq7ZYsm5dthW4cLUBEmjap