### PR TITLE
fix(db): mirror migration 62 in the schema-test export

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -562,7 +562,7 @@
     <span class="sep dt">·</span>
     <span data-t="proof_mit">MIT licensed</span>
     <span class="sep">·</span>
-    <span><b>v0.75.2</b></span>
+    <span><b>v0.77.0</b></span>
   </div>
 </div>
 
@@ -907,7 +907,7 @@ cp .env.example .env  <span class="c"># set SESSION_SECRET and DB_ENCRYPTION_KEY
       </div>
     </div>
     <div class="foot-bottom">
-      <span><span id="gh-stars-footer" data-gh-stars>★ 803 · </span><b>v0.75.2</b> · June 2026</span>
+      <span><span id="gh-stars-footer" data-gh-stars>★ 803 · </span><b>v0.77.0</b> · June 2026</span>
       <span data-t="foot_madewith">Self-hosted · Privacy-first · Open source</span>
     </div>
   </div>

--- a/server/db-schema-test.js
+++ b/server/db-schema-test.js
@@ -609,6 +609,9 @@ const MIGRATIONS_SQL = {
       ON users(calendar_feed_token)
       WHERE calendar_feed_token IS NOT NULL;
   `,
+  62: `
+    ALTER TABLE reminders ADD COLUMN pushed_at TEXT;
+  `,
 };
 
 export { MIGRATIONS_SQL };

--- a/server/db.js
+++ b/server/db.js
@@ -2268,6 +2268,13 @@ const MIGRATIONS = [
         WHERE calendar_feed_token IS NOT NULL;
     `,
   },
+  {
+    version: 62,
+    description: 'restore reminders.pushed_at dropped by the migration 57 table rebuild',
+    up: `
+      ALTER TABLE reminders ADD COLUMN pushed_at TEXT;
+    `,
+  },
 ];
 
 /**


### PR DESCRIPTION
## Summary
- Follow-up to #395 per [review comment](https://github.com/ulsklyc/yuvomi/pull/395#discussion_r3457129264).
- `server/db-schema-test.js` is the documented node:sqlite-synchronized export of `MIGRATIONS` and had stopped at version 61. Schema tests that apply the exported migrations therefore never picked up the restored `reminders.pushed_at` column from migration 62, leaving the regression untestable in that path.
- Adds the `62` entry mirroring the `ALTER TABLE reminders ADD COLUMN pushed_at TEXT;` from `server/db.js`.

## Test plan
- [x] `npm run test:db` — 36/36 passing