### PR TITLE
ci: allow dependabot to trigger claude-code-review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -39,6 +39,7 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          allowed_bots: 'dependabot[bot]'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 


### PR DESCRIPTION
## Summary
- `claude-code-action` rejects review runs from non-human actors by default, so every Dependabot PR's `claude-review` check fails with \"Workflow initiated by non-human actor: dependabot (type: Bot)\" regardless of the actual diff — seen on #391 and #392.
- Adds `allowed_bots: 'dependabot[bot]'` so dependency-bump PRs get reviewed like any other PR instead of permanently showing a red, unrelated check.

## Test plan
- [ ] Re-run `claude-review` on #391/#392 after merge and confirm it passes