### PR TITLE
fix(shopping): allow check/uncheck on lists other than the first (#398)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Shopping lists: can't check/uncheck items after switching lists:** switching to another list (or renaming one) re-bound the click handler on the persistent list container without removing the previous one, so each tap on an item's checkbox fired the toggle twice and cancelled itself out — only adding items still worked. The click delegation is now bound once per container. (Fixes #398)
+
 ## [0.77.1] - 2026-06-23
 
 ### Fixed

--- a/public/pages/shopping.js
+++ b/public/pages/shopping.js
@@ -739,6 +739,16 @@ function wireListContentEvents(container) {
   const content = container.querySelector('#list-content');
   if (!content) return;
 
+  // Die Klick-Delegation an das stabile #list-content-Element nur EINMAL anhängen.
+  // renderListContent ersetzt lediglich die Kinder (replaceChildren), nicht das
+  // Element selbst — würde der Listener bei jedem switchList/rename erneut gebunden,
+  // feuerte ein Toggle-Klick mehrfach und höbe sich auf (Issue #398).
+  if (content.dataset.eventsWired) {
+    wireRenameKeydown(content);
+    return;
+  }
+  content.dataset.eventsWired = 'true';
+
   content.addEventListener('click', async (e) => {
     const target = e.target.closest('[data-action]');
     if (!target) {
@@ -907,7 +917,15 @@ function wireListContentEvents(container) {
     }
   });
 
-  // Rename per Enter
+  wireRenameKeydown(content);
+}
+
+/**
+ * Verdrahtet „Rename per Enter" auf dem Listen-Header. Das Element wird bei jedem
+ * renderListContent neu erzeugt, daher muss diese Bindung pro Render erfolgen —
+ * im Gegensatz zur delegierten Klick-Bindung am stabilen #list-content (Issue #398).
+ */
+function wireRenameKeydown(content) {
   content.querySelector('[data-action="rename-list"]')?.addEventListener('keydown', (e) => {
     if (e.key === 'Enter') e.currentTarget.click();
   });

--- a/test/test-shopping.js
+++ b/test/test-shopping.js
@@ -300,6 +300,26 @@ test('Abhaken aktualisiert nur die betroffene Zeile statt die ganze Liste neu zu
 });
 
 // --------------------------------------------------------
+test('Klick-Delegation wird pro #list-content nur einmal gebunden (Issue #398)', () => {
+  const source = readFileSync(new URL('../public/pages/shopping.js', import.meta.url), 'utf8');
+  const wireFn = source.match(/function wireListContentEvents[\s\S]*?\n}/)?.[0] ?? '';
+  assert(wireFn, 'wireListContentEvents muss auffindbar sein');
+
+  // Die Klick-Delegation hängt am stabilen #list-content (nur Kinder werden via
+  // replaceChildren ersetzt). switchList/rename rufen wireListContentEvents erneut auf —
+  // ohne Guard würde der Listener dupliziert und ein Toggle-Klick höbe sich auf.
+  const guardIdx = wireFn.search(/dataset\.eventsWired/);
+  const clickIdx = wireFn.search(/addEventListener\('click'/);
+  assert(guardIdx >= 0, 'wireListContentEvents muss einen Einmal-Guard (dataset.eventsWired) besitzen');
+  assert(clickIdx >= 0, 'wireListContentEvents muss die Klick-Delegation binden');
+  assert(guardIdx < clickIdx, 'Der Einmal-Guard muss vor der Klick-Bindung greifen');
+
+  // Rename-per-Enter hängt an einem pro Render neu erzeugten Element und muss
+  // weiterhin bei jedem Aufruf verdrahtet werden.
+  assert(/function wireRenameKeydown/.test(source), 'wireRenameKeydown-Helper muss existieren');
+});
+
+// --------------------------------------------------------
 // Ergebnis
 // --------------------------------------------------------
 console.log(`\n[Shopping-Test] Ergebnis: ${passed} bestanden, ${failed} fehlgeschlagen\n`);


### PR DESCRIPTION
## Problem

Checking/unchecking items only worked on the **first** shopping list. After switching to any other list, the only interaction that still worked was *adding* items — taps on an item's checkbox did nothing. (Issue #398)

## Root cause

`wireListContentEvents` attaches a click listener to the persistent `#list-content` element. `renderListContent` only replaces that element's **children** via `replaceChildren()`, not the element itself. Every `switchList` (and `rename`) call re-invoked `wireListContentEvents`, stacking another listener on the same element.

After one switch there are two listeners, so a single tap fires the toggle handler twice — `is_checked` is flipped and immediately flipped back, netting no change. Adding items kept working because the quick-add form is recreated each render (fresh element → single listener).

## Fix

- Bind the click delegation **once per container** using a `content.dataset.eventsWired` guard.
- Extract the rename-on-Enter binding into `wireRenameKeydown`, which still runs on every render because its target element is recreated each time.

## Test

Added a regression test in `test/test-shopping.js` asserting the one-time guard precedes the click binding. All 24 shopping tests pass; without the fix the new test fails.

Fixes #398