### PR TITLE
feat(dashboard): open calendar event details on click

### DIFF
--- a/public/pages/calendar.js
+++ b/public/pages/calendar.js
@@ -835,6 +835,20 @@ export async function render(container, { user }) {
     </div>
   `);
 
+  const openId = new URLSearchParams(window.location.search).get('open');
+  let initialEvent = null;
+  if (openId) {
+    try {
+      const eventRes = await api.get(`/calendar/${openId}`);
+      if (eventRes?.data) {
+        initialEvent = eventRes.data;
+        state.cursor = localDate(initialEvent.start_datetime);
+      }
+    } catch (err) {
+      console.warn('[Calendar] Deep-link event load failed:', err);
+    }
+  }
+
   const { from, to } = getRangeForView(state.view, state.cursor);
   const [,, prefsRes, documentOptionsRes] = await Promise.all([
     loadRange(from, to),
@@ -852,16 +866,18 @@ export async function render(container, { user }) {
 
   container.querySelector('#fab-new-event')?.addEventListener('click', () => openEventModal({ mode: 'create' }));
 
-  // Deep-Link: ?open=<id> öffnet direkt das Edit-Modal
-  const openId = new URLSearchParams(window.location.search).get('open');
-  if (openId) {
-    try {
-      const [eventRes, reminder] = await Promise.all([
-        api.get(`/calendar/${openId}`),
-        loadReminderForEvent(openId),
-      ]);
-      openEventModal({ mode: 'edit', event: eventRes.data, reminder });
-    } catch { /* Event existiert nicht oder kein Zugriff */ }
+  if (initialEvent) {
+    const chip = container.querySelector(`[data-id="${openId}"]`);
+    if (chip) {
+      showEventPopup(initialEvent, chip);
+    } else {
+      try {
+        const reminder = await loadReminderForEvent(openId);
+        openEventModal({ mode: 'edit', event: initialEvent, reminder });
+      } catch {
+        openEventModal({ mode: 'edit', event: initialEvent });
+      }
+    }
   }
 }
 

--- a/public/pages/dashboard.js
+++ b/public/pages/dashboard.js
@@ -462,7 +462,7 @@ function renderUpcomingEvents(events) {
     const _suffix = t('calendar.timeSuffix');
     const timeStr = e.all_day ? t('dashboard.allDay') : `${formatTime(d)}${_suffix ? ' ' + _suffix : ''}`.trim();
     return `
-      <div class="event-item" data-route="/calendar" role="button" tabindex="0">
+      <div class="event-item" data-route="/calendar?open=${e.id}" role="button" tabindex="0">
         <div class="event-item__bar" style="background-color:${esc(e.color || e.cal_color) || 'var(--color-accent)'}"></div>
         <div class="event-item__content">
           <div class="event-item__title">${esc(e.title)}</div>
@@ -653,7 +653,7 @@ function renderTodayCockpit(data) {
       </div>
       <div class="today-cockpit__grid">
         ${!window.oikos?.isModuleDisabled('tasks')    ? renderTodayCard('check-square',   t('dashboard.todayTask'),     taskTitle, '/tasks', 'task', highlights.taskCount) : ''}
-        ${!window.oikos?.isModuleDisabled('calendar') ? renderTodayCard('calendar',        t('dashboard.todayEvent'),    eventTitle, '/calendar', 'event', highlights.eventCount) : ''}
+        ${!window.oikos?.isModuleDisabled('calendar') ? renderTodayCard('calendar',        t('dashboard.todayEvent'),    eventTitle, highlights.nextEvent ? `/calendar?open=${highlights.nextEvent.id}` : '/calendar', 'event', highlights.eventCount) : ''}
         ${!window.oikos?.isModuleDisabled('shopping') ? renderTodayCard('shopping-cart',   t('dashboard.todayShopping'), t('dashboard.todayShoppingCount', { count: highlights.openShoppingCount }), '/shopping', 'shopping') : ''}
         ${!window.oikos?.isModuleDisabled('meals')    ? renderTodayCard('utensils',        t('dashboard.todayDinner'),   dinnerTitle, '/meals', 'dinner') : ''}
       </div>


### PR DESCRIPTION
This pull request improves the user experience by linking calendar entries on the dashboard directly to their respective details popup (overlay) on the calendar page, rather than just opening the empty calendar view.

### Previous Behavior
Clicking a calendar event row in the dashboard's "Upcoming Events" widget or clicking the "Today Cockpit" card navigated the user to `/calendar`, but did not select or open the details for the specific event. The user had to manually find the event in the calendar again.

### New Behavior
1. **Upcoming Events List**: Clicking any event row now navigates to `/calendar?open=<event_id>`.
2. **Today Cockpit**: If there is a scheduled event today, clicking the "Today important" calendar card navigates directly to `/calendar?open=<next_event_id>`.
3. **Calendar Page Transition**:
   - The calendar module parses the `open` query parameter early.
   - If present, it fetches the event details and automatically shifts the calendar view to the day/month of the event (`state.cursor = localDate(start_datetime)`).
   - Once rendered, it opens the details popup overlay (`showEventPopup`) pointing directly to the event chip in the DOM.
   - If the event chip is not found in the DOM (e.g. edge cases), it falls back to opening the edit modal as a fail-safe.

### Technical Changes

#### `public/pages/dashboard.js`
- Modified `renderUpcomingEvents(events)` to set `data-route="/calendar?open=${e.id}"` on the event row element.
- Modified `renderTodayCockpit(data)` to set the card's route to `/calendar?open=${highlights.nextEvent.id}` when `highlights.nextEvent` is present, falling back to `/calendar` otherwise.

#### `public/pages/calendar.js`
- Modified `render()` to parse the `open` query parameter.
- Fetches the event details via API and adjusts the calendar's `state.cursor` so the correct date range is loaded and rendered.
- Queries the DOM for `[data-id="${openId}"]` after rendering and displays `showEventPopup`.
- Implements a fallback to `openEventModal` (edit mode) if the element is not present.

### Verification
- Both test suites (`npm run test:calendar` and `npm run test:dashboard`) pass successfully without regressions.
- Manually verified that:
  - Clicking dashboard items redirects to the calendar.
  - The calendar jumps to the correct date.
  - The details popup opens correctly pointing to the chip.
