### PR TITLE
style(dashboard): make birthday widget avatars circular

### DIFF
--- a/public/styles/dashboard.css
+++ b/public/styles/dashboard.css
@@ -2512,7 +2512,7 @@ svg.weather-forecast__icon {
 .birthday-widget-item__avatar {
   width: 40px;
   height: 40px;
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-full);
   overflow: hidden;
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
This PR changes the border radius of birthday widget avatars on the dashboard to be circular. Currently, they are rendered as rounded squares (`var(--radius-sm)`), which stands in contrast to all other avatars (tasks, housekeeping, settings, contacts, split-expenses) which are circular (`var(--radius-full)`).

### Changes
- Updated `.birthday-widget-item__avatar` border-radius from `var(--radius-sm)` to `var(--radius-full)` in `public/styles/dashboard.css`.

### Verification
- Verified visually on the local dashboard.
- Checked that all unit tests pass (including `npm run test:dashboard`).
