### PR TITLE
fix: recurring calendar event deep-link opens correct occurrence from dashboard

### DIFF
--- a/public/pages/calendar.js
+++ b/public/pages/calendar.js
@@ -835,14 +835,18 @@ export async function render(container, { user }) {
     </div>
   `);
 
-  const openId = new URLSearchParams(window.location.search).get('open');
+  const params  = new URLSearchParams(window.location.search);
+  const openId   = params.get('open');
+  const dateParam = params.get('date'); // YYYY-MM-DD der gewünschten Instanz (bei Wiederholungen)
   let initialEvent = null;
   if (openId && /^\d+$/.test(openId)) {
     try {
       const eventRes = await api.get(`/calendar/${openId}`);
       if (eventRes?.data) {
         initialEvent = eventRes.data;
-        state.cursor = localDate(initialEvent.start_datetime);
+        // dateParam nutzen wenn vorhanden (zeigt auf die richtige Instanz einer Serie);
+        // sonst auf das Original-Startdatum des Master-Events zurückfallen.
+        state.cursor = dateParam || localDate(initialEvent.start_datetime);
       } else {
         console.warn('[Calendar] Deep-link event not found:', openId);
       }
@@ -869,16 +873,29 @@ export async function render(container, { user }) {
   container.querySelector('#fab-new-event')?.addEventListener('click', () => openEventModal({ mode: 'create' }));
 
   if (initialEvent) {
-    const chip = container.querySelector(`[data-id="${CSS.escape(openId)}"]`);
+    // Das Ziel-Datum für die Instanz (dateParam hat Vorrang vor dem Master-Startdatum).
+    const targetDate = dateParam || localDate(initialEvent.start_datetime);
+
+    // Die konkrete Instanz aus state.events holen (expandiert, mit korrektem start_datetime).
+    // Bei Nicht-Wiederholungen ist das identisch mit initialEvent.
+    const occurrence = state.events.find(
+      (ev) => ev.id === initialEvent.id && localDate(ev.start_datetime) === targetDate
+    ) || initialEvent;
+
+    // Chip im richtigen Tag-Container suchen; Fallback auf beliebigen Chip mit der ID.
+    const chip =
+      container.querySelector(`[data-date="${CSS.escape(targetDate)}"] [data-id="${CSS.escape(openId)}"]`)
+      ?? container.querySelector(`[data-id="${CSS.escape(openId)}"]`);
+
     if (chip) {
       chip.scrollIntoView({ block: 'center', behavior: 'instant' });
-      showEventPopup(initialEvent, chip);
+      showEventPopup(occurrence, chip);
     } else {
       try {
         const reminder = await loadReminderForEvent(openId);
-        openEventModal({ mode: 'edit', event: initialEvent, reminder });
+        openEventModal({ mode: 'edit', event: occurrence, reminder });
       } catch {
-        openEventModal({ mode: 'edit', event: initialEvent });
+        openEventModal({ mode: 'edit', event: occurrence });
       }
     }
   }

--- a/public/pages/calendar.js
+++ b/public/pages/calendar.js
@@ -213,6 +213,7 @@ const CALENDAR_VIEW_STORAGE_KEY = 'oikos:calendar:view';
 const LEGACY_CALENDAR_VIEW_STORAGE_KEY = 'oikos-calendar-view';
 const LAYER_HOLIDAYS_KEY = 'oikos:calendar:layer:holidays';
 const LAYER_SCHOOL_KEY   = 'oikos:calendar:layer:school';
+const DATE_KEY_RE = /^\d{4}-\d{2}-\d{2}$/;
 
 const HOUR_HEIGHT = 56; // px pro Stunde in Wochen-/Tagesansicht
 
@@ -431,6 +432,21 @@ function localDate(str) {
   if (!str || str.length <= 10) return (str || '').slice(0, 10);
   const d = new Date(str);
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+}
+
+function validDateParam(value) {
+  return DATE_KEY_RE.test(String(value || '')) ? String(value) : '';
+}
+
+function deepLinkTargetDate(initialEvent, dateParam) {
+  return validDateParam(dateParam) || localDate(initialEvent?.start_datetime);
+}
+
+function findDeepLinkedOccurrence(events, initialEvent, targetDate) {
+  if (!initialEvent) return null;
+  return events.find(
+    (ev) => ev.id === initialEvent.id && localDate(ev.start_datetime) === targetDate
+  ) || initialEvent;
 }
 
 // Extract HH:MM in the browser's local timezone from a datetime string.
@@ -835,18 +851,16 @@ export async function render(container, { user }) {
     </div>
   `);
 
-  const params  = new URLSearchParams(window.location.search);
-  const openId   = params.get('open');
-  const dateParam = params.get('date'); // YYYY-MM-DD der gewünschten Instanz (bei Wiederholungen)
+  const params    = new URLSearchParams(window.location.search);
+  const openId    = params.get('open');
+  const dateParam = validDateParam(params.get('date'));
   let initialEvent = null;
   if (openId && /^\d+$/.test(openId)) {
     try {
       const eventRes = await api.get(`/calendar/${openId}`);
       if (eventRes?.data) {
         initialEvent = eventRes.data;
-        // dateParam nutzen wenn vorhanden (zeigt auf die richtige Instanz einer Serie);
-        // sonst auf das Original-Startdatum des Master-Events zurückfallen.
-        state.cursor = dateParam || localDate(initialEvent.start_datetime);
+        state.cursor = deepLinkTargetDate(initialEvent, dateParam);
       } else {
         console.warn('[Calendar] Deep-link event not found:', openId);
       }
@@ -873,16 +887,9 @@ export async function render(container, { user }) {
   container.querySelector('#fab-new-event')?.addEventListener('click', () => openEventModal({ mode: 'create' }));
 
   if (initialEvent) {
-    // Das Ziel-Datum für die Instanz (dateParam hat Vorrang vor dem Master-Startdatum).
-    const targetDate = dateParam || localDate(initialEvent.start_datetime);
+    const targetDate = deepLinkTargetDate(initialEvent, dateParam);
+    const occurrence = findDeepLinkedOccurrence(state.events, initialEvent, targetDate);
 
-    // Die konkrete Instanz aus state.events holen (expandiert, mit korrektem start_datetime).
-    // Bei Nicht-Wiederholungen ist das identisch mit initialEvent.
-    const occurrence = state.events.find(
-      (ev) => ev.id === initialEvent.id && localDate(ev.start_datetime) === targetDate
-    ) || initialEvent;
-
-    // Chip im richtigen Tag-Container suchen; Fallback auf beliebigen Chip mit der ID.
     const chip =
       container.querySelector(`[data-date="${CSS.escape(targetDate)}"] [data-id="${CSS.escape(openId)}"]`)
       ?? container.querySelector(`[data-id="${CSS.escape(openId)}"]`);
@@ -1570,6 +1577,9 @@ export const __test = {
   isMultiDayEvent,
   isAllDayLike,
   agendaSegmentKind,
+  deepLinkTargetDate,
+  findDeepLinkedOccurrence,
+  validDateParam,
   hasAttachment,
   attachmentUrls,
   clickedTime,

--- a/public/pages/dashboard.js
+++ b/public/pages/dashboard.js
@@ -8,6 +8,7 @@ import { api } from '/api.js';
 import { t, formatDate, formatTime, getLocale } from '/i18n.js';
 import { getReadableTextColor } from '/utils/color.js';
 import { esc, fmtLocation, renderMarkdownLight } from '/utils/html.js';
+import { toLocalDateKey } from '/utils/date.js';
 import { openModal, closeModal } from '/components/modal.js';
 import { renderAvatarStack } from '/components/user-multi-select.js';
 
@@ -19,6 +20,23 @@ let _fabController = null;
 
 const ONBOARDING_KEY = 'oikos-onboarded';
 const APP_NAME_STORAGE_KEY = 'oikos-app-name';
+
+function eventOccurrenceDateKey(event) {
+  const value = String(event?.start_datetime || '');
+  if (!value) return '';
+  if (value.length <= 10) return value.slice(0, 10);
+
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? value.slice(0, 10) : toLocalDateKey(date);
+}
+
+function calendarEventRoute(event) {
+  if (!event?.id) return '/calendar';
+  const params = new URLSearchParams({ open: String(event.id) });
+  const occurrenceDate = eventOccurrenceDateKey(event);
+  if (/^\d{4}-\d{2}-\d{2}$/.test(occurrenceDate)) params.set('date', occurrenceDate);
+  return `/calendar?${params.toString()}`;
+}
 
 function getAppName() {
   return localStorage.getItem(APP_NAME_STORAGE_KEY) || 'Yuvomi';
@@ -471,7 +489,7 @@ function renderUpcomingEvents(events) {
     const _suffix = t('calendar.timeSuffix');
     const timeStr = e.all_day ? t('dashboard.allDay') : `${formatTime(d)}${_suffix ? ' ' + _suffix : ''}`.trim();
     return `
-      <div class="event-item" data-route="/calendar?open=${esc(e.id)}&date=${esc(e.start_datetime.slice(0, 10))}" role="button" tabindex="0">
+      <div class="event-item" data-route="${esc(calendarEventRoute(e))}" role="button" tabindex="0">
         <div class="event-item__bar" style="background-color:${esc(e.color || e.cal_color) || 'var(--color-accent)'}"></div>
         <div class="event-item__content">
           <div class="event-item__title">${esc(e.title)}</div>
@@ -665,7 +683,7 @@ function renderTodayCockpit(data) {
       </div>
       <div class="today-cockpit__grid">
         ${!window.oikos?.isModuleDisabled('tasks')    ? renderTodayCard('check-square',   t('dashboard.todayTask'),     taskTitle, '/tasks', 'task', highlights.taskCount) : ''}
-        ${!window.oikos?.isModuleDisabled('calendar') ? renderTodayCard('calendar',        t('dashboard.todayEvent'),    eventTitle, highlights.nextEvent?.id ? `/calendar?open=${esc(highlights.nextEvent.id)}&date=${esc(highlights.nextEvent.start_datetime.slice(0, 10))}` : '/calendar', 'event', highlights.eventCount) : ''}
+        ${!window.oikos?.isModuleDisabled('calendar') ? renderTodayCard('calendar',        t('dashboard.todayEvent'),    eventTitle, calendarEventRoute(highlights.nextEvent), 'event', highlights.eventCount) : ''}
         ${!window.oikos?.isModuleDisabled('shopping') ? renderTodayCard('shopping-cart',   t('dashboard.todayShopping'), t('dashboard.todayShoppingCount', { count: highlights.openShoppingCount }), '/shopping', 'shopping') : ''}
         ${!window.oikos?.isModuleDisabled('meals')    ? renderTodayCard('utensils',        t('dashboard.todayDinner'),   dinnerTitle, '/meals', 'dinner') : ''}
       </div>
@@ -1518,7 +1536,7 @@ export async function render(container, { user }) {
   }
 }
 
-export const __test = { buildTodayHighlights, normalizeVisibleMealTypes, renderTodayMeals };
+export const __test = { buildTodayHighlights, normalizeVisibleMealTypes, renderTodayMeals, calendarEventRoute, eventOccurrenceDateKey };
 
 function wireWeatherRefresh(container, onUpdated = null) {
   const refreshBtn = container.querySelector('#weather-refresh-btn');

--- a/public/pages/dashboard.js
+++ b/public/pages/dashboard.js
@@ -14,6 +14,7 @@ import { renderAvatarStack } from '/components/user-multi-select.js';
 // Hält den AbortController des aktuellen FAB-Listeners - wird bei jedem render() erneuert.
 let _fabController = null;
 
+
 // ── Onboarding ──────────────────────────────────────────────────────────────
 
 const ONBOARDING_KEY = 'oikos-onboarded';
@@ -470,7 +471,7 @@ function renderUpcomingEvents(events) {
     const _suffix = t('calendar.timeSuffix');
     const timeStr = e.all_day ? t('dashboard.allDay') : `${formatTime(d)}${_suffix ? ' ' + _suffix : ''}`.trim();
     return `
-      <div class="event-item" data-route="/calendar?open=${esc(e.id)}" role="button" tabindex="0">
+      <div class="event-item" data-route="/calendar?open=${esc(e.id)}&date=${esc(e.start_datetime.slice(0, 10))}" role="button" tabindex="0">
         <div class="event-item__bar" style="background-color:${esc(e.color || e.cal_color) || 'var(--color-accent)'}"></div>
         <div class="event-item__content">
           <div class="event-item__title">${esc(e.title)}</div>
@@ -664,7 +665,7 @@ function renderTodayCockpit(data) {
       </div>
       <div class="today-cockpit__grid">
         ${!window.oikos?.isModuleDisabled('tasks')    ? renderTodayCard('check-square',   t('dashboard.todayTask'),     taskTitle, '/tasks', 'task', highlights.taskCount) : ''}
-        ${!window.oikos?.isModuleDisabled('calendar') ? renderTodayCard('calendar',        t('dashboard.todayEvent'),    eventTitle, highlights.nextEvent?.id ? `/calendar?open=${esc(highlights.nextEvent.id)}` : '/calendar', 'event', highlights.eventCount) : ''}
+        ${!window.oikos?.isModuleDisabled('calendar') ? renderTodayCard('calendar',        t('dashboard.todayEvent'),    eventTitle, highlights.nextEvent?.id ? `/calendar?open=${esc(highlights.nextEvent.id)}&date=${esc(highlights.nextEvent.start_datetime.slice(0, 10))}` : '/calendar', 'event', highlights.eventCount) : ''}
         ${!window.oikos?.isModuleDisabled('shopping') ? renderTodayCard('shopping-cart',   t('dashboard.todayShopping'), t('dashboard.todayShoppingCount', { count: highlights.openShoppingCount }), '/shopping', 'shopping') : ''}
         ${!window.oikos?.isModuleDisabled('meals')    ? renderTodayCard('utensils',        t('dashboard.todayDinner'),   dinnerTitle, '/meals', 'dinner') : ''}
       </div>

--- a/test/test-calendar.js
+++ b/test/test-calendar.js
@@ -294,6 +294,26 @@ test('Monatsbereich: 42 Tage für Kalenderraster', () => {
   assert(to === '2026-04-11', `Erwartet 2026-04-11, erhalten ${to}`);
 });
 
+test('Deep-Link-Datum: gültiger date-Parameter gewinnt vor Serien-Masterdatum', () => {
+  const master = { id: 7, start_datetime: '2026-01-05T09:00' };
+  assert(calendarHelpers.deepLinkTargetDate(master, '2026-06-29') === '2026-06-29',
+    'date-Parameter muss als Zielinstanz verwendet werden');
+});
+
+test('Deep-Link-Datum: ungültiger date-Parameter fällt auf Masterdatum zurück', () => {
+  const master = { id: 7, start_datetime: '2026-01-05T09:00' };
+  assert(calendarHelpers.validDateParam('not-a-date') === '', 'Ungültige Query wird verworfen');
+  assert(calendarHelpers.deepLinkTargetDate(master, 'not-a-date') === '2026-01-05',
+    'Ungültige Query darf den Kalenderbereich nicht beschädigen');
+});
+
+test('Deep-Link-Instanz: expandiertes Event mit gleichem Datum wird bevorzugt', () => {
+  const master = { id: 7, title: 'Training', start_datetime: '2026-01-05T09:00' };
+  const occurrence = { id: 7, title: 'Training', start_datetime: '2026-06-29T09:00', is_recurring_instance: 1 };
+  const resolved = calendarHelpers.findDeepLinkedOccurrence([master, occurrence], master, '2026-06-29');
+  assert(resolved === occurrence, 'Popup/Edit-Flow muss die angeklickte Instanz erhalten');
+});
+
 // --------------------------------------------------------
 // nextOccurrence: INTERVAL-Korrektheit mit BYDAY
 // --------------------------------------------------------

--- a/test/test-dashboard.js
+++ b/test/test-dashboard.js
@@ -550,6 +550,27 @@ test('getUpcomingEvents: wiederkehrender Termin mit Vergangenheits-Start erschei
   assert(sofia.id === recurId, 'Behält die Original-Event-ID der Serie');
 });
 
+test('calendarEventRoute: Dashboard-Link enthält die expandierte Instanz-Datumskomponente', async () => {
+  const { __test: dashboardHelpers } = await import('../public/pages/dashboard.js');
+  const events = getUpcomingEvents(cdb, { userId: cuTheo, limit: 10 });
+  const sofia = events.find((e) => e.title === 'Sofia Field Trip');
+  const route = dashboardHelpers.calendarEventRoute(sofia);
+  const params = new URLSearchParams(route.split('?')[1]);
+  assert(route.startsWith('/calendar?'), `Unerwartete Route: ${route}`);
+  assert(params.get('open') === String(recurId), 'Route muss die Serien-ID öffnen');
+  assert(params.get('date') === sofia.start_datetime.slice(0, 10),
+    'Route muss auf die expandierte Dashboard-Instanz zeigen');
+});
+
+test('calendarEventRoute: ungültige oder fehlende Startdaten erzeugen keinen kaputten date-Parameter', async () => {
+  const { __test: dashboardHelpers } = await import('../public/pages/dashboard.js');
+  const route = dashboardHelpers.calendarEventRoute({ id: 123, start_datetime: 'not-a-date' });
+  const params = new URLSearchParams(route.split('?')[1]);
+  assert(params.get('open') === '123', 'Event-ID bleibt erhalten');
+  assert(params.has('date') === false, 'Ungültiges Datum darf nicht in die Kalender-Query');
+  assert(dashboardHelpers.calendarEventRoute(null) === '/calendar', 'Ohne Event geht es zur Kalenderübersicht');
+});
+
 test('getUpcomingEvents: vergangene Einzeltermine erscheinen nicht', () => {
   const events = getUpcomingEvents(cdb, { userId: cuTheo, limit: 10 });
   assert(!events.find((e) => e.title === 'Past one-off'), 'Vergangener Einzeltermin darf nicht erscheinen');


### PR DESCRIPTION
## Problem

When clicking a **recurring calendar event** on the dashboard, the calendar page always navigated to the **first (original) occurrence** of the series — not the occurrence that was shown on the dashboard.

**Example:** A weekly event created in January 2025 appears for today on the dashboard. Clicking it → calendar jumps back to January 2025.

## Root Cause

Deep-links only passed `?open=<id>`. The API endpoint `GET /calendar/:id` always returns the **master event** with the original `start_datetime` (e.g. January 2025). This caused three cascading issues:

1. `state.cursor` was set from the stale master date → calendar navigated into the past.
2. The popup/modal received the master event object, so the displayed date/time was wrong even if the view happened to be correct.
3. When multiple occurrences of the same series were visible in the week/month view, the first matching chip was highlighted rather than the one for the clicked date.

## Fix

### `dashboard.js`

Every calendar deep-link now includes an additional `&date=YYYY-MM-DD` parameter. The date is taken directly from `start_datetime.slice(0, 10)` — the server already sets this to the correct occurrence date when expanding recurring events via `expandRecurringEvents()`.

```js
// Upcoming events widget
data-route="/calendar?open=${e.id}&date=${e.start_datetime.slice(0, 10)}"

// Today highlight card
`/calendar?open=${highlights.nextEvent.id}&date=${highlights.nextEvent.start_datetime.slice(0, 10)}`
```

### `calendar.js`

The new `date` URL parameter is evaluated in three places:

```js
const dateParam = params.get('date'); // YYYY-MM-DD of the desired occurrence

// 1. Set cursor to the correct date
state.cursor = dateParam || localDate(initialEvent.start_datetime);

// 2. Resolve the expanded occurrence from state.events (correct date/time)
const occurrence = state.events.find(
  (ev) => ev.id === initialEvent.id && localDate(ev.start_datetime) === targetDate
) || initialEvent;

// 3. Find the chip inside the right day container
const chip =
  container.querySelector(`[data-date="${targetDate}"] [data-id="${openId}"]`)
  ?? container.querySelector(`[data-id="${openId}"]`);
```

## Changed Files

| File | Change |
|---|---|
| `public/pages/dashboard.js` | Added `&date=` to calendar links in the upcoming events widget and today highlight card |
| `public/pages/calendar.js` | Read `date` URL param, fixed `state.cursor` and occurrence lookup |

## Testing

1. Create a recurring event (e.g. weekly) with a start date in the past.
2. Open the dashboard — the event appears under upcoming events or in the today card.
3. Click the event.
4. ✅ Calendar opens on the correct date (today's occurrence).
5. ✅ Popup shows the correct date/time of the occurrence, not the original series start date.
