### PR TITLE
fix: clear offline API cache even when logout request fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.78.9] - 2026-06-30
+
+### Fixed
+- **Offline cache isolation on logout failure:** the read-only offline API cache is now cleared even when the logout request itself fails (offline or unreachable server). Previously the cache clear was skipped if the logout POST threw, so a subsequent user on the same device could still fall back to the previous user's cached data.
+
 ## [0.78.8] - 2026-06-30
 
 ### Added

--- a/docs/index.html
+++ b/docs/index.html
@@ -562,7 +562,7 @@
     <span class="sep dt">·</span>
     <span data-t="proof_mit">MIT licensed</span>
     <span class="sep">·</span>
-    <span><b>v0.78.8</b></span>
+    <span><b>v0.78.9</b></span>
   </div>
 </div>
 
@@ -907,7 +907,7 @@ cp .env.example .env  <span class="c"># set SESSION_SECRET and DB_ENCRYPTION_KEY
       </div>
     </div>
     <div class="foot-bottom">
-      <span><span id="gh-stars-footer" data-gh-stars>★ 826 · </span><b>v0.78.8</b> · June 2026</span>
+      <span><span id="gh-stars-footer" data-gh-stars>★ 826 · </span><b>v0.78.9</b> · June 2026</span>
       <span data-t="foot_madewith">Self-hosted · Privacy-first · Open source</span>
     </div>
   </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oikos",
-  "version": "0.78.8",
+  "version": "0.78.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oikos",
-      "version": "0.78.8",
+      "version": "0.78.9",
       "license": "MIT",
       "dependencies": {
         "bcrypt": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yuvomi",
-  "version": "0.78.8",
+  "version": "0.78.9",
   "description": "Self-hosted family planner - calendar, tasks, shopping, meal planning, budget and more. Private, open-source, no subscription.",
   "main": "server/index.js",
   "type": "module",

--- a/public/api.js
+++ b/public/api.js
@@ -156,11 +156,15 @@ const api = {
 const auth = {
   login: (username, password) => api.post('/auth/login', { username, password }),
   logout: async () => {
-    const res = await api.post('/auth/logout');
-    // API-Cache leeren, damit am selben Gerät kein Nutzer die offline
-    // gecachten Daten des vorigen sieht.
-    clearApiCache();
-    return res;
+    try {
+      return await api.post('/auth/logout');
+    } finally {
+      // API-Cache IMMER leeren — auch wenn der Logout-Request offline oder bei
+      // nicht erreichbarem Server fehlschlägt. Der Settings-Handler navigiert in
+      // seinem finally trotzdem zu /login, daher darf hier kein offline gecachter
+      // Stand des vorigen Nutzers am selben Gerät zurückbleiben.
+      clearApiCache();
+    }
   },
   me: () => api.get('/auth/me'),
   setup: (username, display_name, password) => api.post('/auth/setup', { username, display_name, password }),

--- a/public/sw.js
+++ b/public/sw.js
@@ -15,7 +15,7 @@
  *   → bypassCacheUntil (in-memory + Cache API für SW-Restart-Robustheit)
  */
 
-const APP_RELEASE   = '0.78.8';
+const APP_RELEASE   = '0.78.9';
 const SHELL_CACHE   = `oikos-shell-${APP_RELEASE}`;
 const PAGES_CACHE   = `oikos-pages-${APP_RELEASE}`;
 const LOCALES_CACHE = `oikos-locales-${APP_RELEASE}`;


### PR DESCRIPTION
## Clear offline API cache even when logout fails

Follow-up to #422 — addresses the Codex P1 review finding on `public/api.js`.

**Problem:** In `auth.logout`, when the `POST /auth/logout` request failed (offline or unreachable server), the `await` threw **before** `clearApiCache()` ran. The settings logout handler still navigates to `/login` in its `finally`, so a subsequent user on the same device could fall back to the previous user's read-only offline API cache.

**Fix:** Move the cache clear into a `try/finally` so it runs whether or not the network logout succeeds. The logout error still propagates to the caller.

Tests: full suite green.
