### PR TITLE
Improvement dashboard widget sizing - Expand dashboard widget sizing options

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1158,7 +1158,7 @@ Responsive grid: 1 column on mobile, 2 on tablet, 3 on desktop.
 
 The three newer modules (Rewards, Health, Housekeeping) start **hidden** by default — they are specialised and not active in every household, so they are offered as opt-ins in **Customize** rather than adding empty tiles to a fresh dashboard. Existing saved layouts are untouched.
 
-**Widget sizes:** each widget has a configurable size using named presets — Tiny (1×1), Narrow (2×1), Tall (1×2), Standard (2×2), Large (3×2), and Full (4×2) — that map to `columns × rows` in the CSS grid. List widgets (tasks, calendar) default to the tall/narrow **Tall** (1×2) preset so a short list keeps useful height without occupying a full two-column row. Sizes are persisted in user preferences and survive page reloads.
+**Widget sizes:** each widget has a configurable size using named presets — Tiny (1×1), Narrow (2×1), Wide (3×1), Full row (4×1), Tall (1×2), Standard (2×2), Large (3×2), and Full (4×2) — that map to `columns × rows` in the CSS grid. List widgets (tasks, calendar) default to the tall/narrow **Tall** (1×2) preset so a short list keeps useful height without occupying a full two-column row. Sizes are persisted in user preferences and survive page reloads.
 
 Skeleton loading instead of spinners (the skeleton mirrors the default-visible widgets at their correct grid-spanning sizes to prevent layout shift). Clicking any widget navigates to that module.
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1158,7 +1158,7 @@ Responsive grid: 1 column on mobile, 2 on tablet, 3 on desktop.
 
 The three newer modules (Rewards, Health, Housekeeping) start **hidden** by default — they are specialised and not active in every household, so they are offered as opt-ins in **Customize** rather than adding empty tiles to a fresh dashboard. Existing saved layouts are untouched.
 
-**Widget sizes:** each widget has a configurable size using named presets (Tiny, Narrow, Tall, Standard, Large, Full) that map to `columns × rows` in the CSS grid. List widgets (tasks, calendar) default to the tall/narrow **Tall** (1×2) preset so a short list keeps useful height without occupying a full two-column row. Sizes are persisted in user preferences and survive page reloads.
+**Widget sizes:** each widget has a configurable size using named presets — Tiny (1×1), Narrow (2×1), Tall (1×2), Standard (2×2), Large (3×2), and Full (4×2) — that map to `columns × rows` in the CSS grid. List widgets (tasks, calendar) default to the tall/narrow **Tall** (1×2) preset so a short list keeps useful height without occupying a full two-column row. Sizes are persisted in user preferences and survive page reloads.
 
 Skeleton loading instead of spinners (the skeleton mirrors the default-visible widgets at their correct grid-spanning sizes to prevent layout shift). Clicking any widget navigates to that module.
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1158,7 +1158,7 @@ Responsive grid: 1 column on mobile, 2 on tablet, 3 on desktop.
 
 The three newer modules (Rewards, Health, Housekeeping) start **hidden** by default — they are specialised and not active in every household, so they are offered as opt-ins in **Customize** rather than adding empty tiles to a fresh dashboard. Existing saved layouts are untouched.
 
-**Widget sizes:** each widget has a configurable size using named presets — Tiny (1×1), Narrow (2×1), Wide (3×1), Full row (4×1), Tall (1×2), Standard (2×2), Large (3×2), and Full (4×2) — that map to `columns × rows` in the CSS grid. List widgets (tasks, calendar) default to the tall/narrow **Tall** (1×2) preset so a short list keeps useful height without occupying a full two-column row. Sizes are persisted in user preferences and survive page reloads.
+**Widget sizes:** each widget has a configurable size using named presets grouped by height in Customize: one-row presets — Tiny (1×1), Narrow (2×1), Wide (3×1), Full row (4×1) — and two-row presets — Tall (1×2), Standard (2×2), Large (3×2), Full (4×2). They map to `columns × rows` in the CSS grid. List widgets (tasks, calendar) default to the tall/narrow **Tall** (1×2) preset so a short list keeps useful height without occupying a full two-column row. Sizes are persisted in user preferences and survive page reloads; older/direct 3- or 4-row matrix values are normalized to the nearest offered one- or two-row preset so the stored value and active picker state remain truthful.
 
 Skeleton loading instead of spinners (the skeleton mirrors the default-visible widgets at their correct grid-spanning sizes to prevent layout shift). Clicking any widget navigates to that module.
 

--- a/public/locales/ar.json
+++ b/public/locales/ar.json
@@ -145,6 +145,8 @@
         "customizeExit": "إنهاء التخصيص",
         "customizeSize": "الحجم",
         "customizeSizeFor": "حجم {{widget}}",
+        "widgetSizeOneRowGroup": "صف واحد",
+        "widgetSizeTwoRowsGroup": "صفان",
         "customizeHide": "إخفاء {{widget}}",
         "customizeHiddenTitle": "Ausgeblendete Widgets",
         "customizeShow": "{{widget}} einblenden",

--- a/public/locales/ar.json
+++ b/public/locales/ar.json
@@ -150,6 +150,8 @@
         "customizeShow": "{{widget}} einblenden",
         "widgetSizeTiny": "صغير (1×1)",
         "widgetSizeNarrow": "ضيق (2×1)",
+        "widgetSizeWide": "عريض (3×1)",
+        "widgetSizeFullRow": "صف كامل (4×1)",
         "widgetSizeTall": "طويل (1×2)",
         "widgetSizeStandard": "قياسي (2×2)",
         "widgetSizeLarge": "كبير (3×2)",

--- a/public/locales/cs.json
+++ b/public/locales/cs.json
@@ -150,6 +150,8 @@
         "customizeShow": "{{widget}} einblenden",
         "widgetSizeTiny": "Malý (1×1)",
         "widgetSizeNarrow": "Úzký (2×1)",
+        "widgetSizeWide": "Široký (3×1)",
+        "widgetSizeFullRow": "Celý řádek (4×1)",
         "widgetSizeTall": "Vysoký (1×2)",
         "widgetSizeStandard": "Standardní (2×2)",
         "widgetSizeLarge": "Velký (3×2)",

--- a/public/locales/cs.json
+++ b/public/locales/cs.json
@@ -145,6 +145,8 @@
         "customizeExit": "Ukončit přizpůsobení",
         "customizeSize": "Velikost",
         "customizeSizeFor": "Velikost pro {{widget}}",
+        "widgetSizeOneRowGroup": "1 řádek",
+        "widgetSizeTwoRowsGroup": "2 řádky",
         "customizeHide": "Skrýt {{widget}}",
         "customizeHiddenTitle": "Ausgeblendete Widgets",
         "customizeShow": "{{widget}} einblenden",

--- a/public/locales/de.json
+++ b/public/locales/de.json
@@ -151,6 +151,8 @@
         "customizeExit": "Anpassung beenden",
         "customizeSize": "Größe",
         "customizeSizeFor": "Größe für {{widget}}",
+        "widgetSizeOneRowGroup": "1 Zeile",
+        "widgetSizeTwoRowsGroup": "2 Zeilen",
         "customizeHide": "{{widget}} ausblenden",
         "customizeHiddenTitle": "Ausgeblendete Widgets",
         "customizeShow": "{{widget}} einblenden",

--- a/public/locales/de.json
+++ b/public/locales/de.json
@@ -156,6 +156,8 @@
         "customizeShow": "{{widget}} einblenden",
         "widgetSizeTiny": "Klein (1×1)",
         "widgetSizeNarrow": "Schmal (2×1)",
+        "widgetSizeWide": "Breit (3×1)",
+        "widgetSizeFullRow": "Ganze Zeile (4×1)",
         "widgetSizeTall": "Hoch (1×2)",
         "widgetSizeStandard": "Standard (2×2)",
         "widgetSizeLarge": "Groß (3×2)",

--- a/public/locales/el.json
+++ b/public/locales/el.json
@@ -145,6 +145,8 @@
         "customizeExit": "Έξοδος από προσαρμογή",
         "customizeSize": "Μέγεθος",
         "customizeSizeFor": "Μέγεθος για {{widget}}",
+        "widgetSizeOneRowGroup": "1 σειρά",
+        "widgetSizeTwoRowsGroup": "2 σειρές",
         "customizeHide": "Απόκρυψη {{widget}}",
         "customizeHiddenTitle": "Ausgeblendete Widgets",
         "customizeShow": "{{widget}} einblenden",

--- a/public/locales/el.json
+++ b/public/locales/el.json
@@ -150,6 +150,8 @@
         "customizeShow": "{{widget}} einblenden",
         "widgetSizeTiny": "Μικρό (1×1)",
         "widgetSizeNarrow": "Στενό (2×1)",
+        "widgetSizeWide": "Πλατύ (3×1)",
+        "widgetSizeFullRow": "Πλήρης σειρά (4×1)",
         "widgetSizeTall": "Ψηλό (1×2)",
         "widgetSizeStandard": "Τυπικό (2×2)",
         "widgetSizeLarge": "Μεγάλο (3×2)",

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -150,6 +150,8 @@
         "customizeShow": "Show {{widget}}",
         "widgetSizeTiny": "Small (1×1)",
         "widgetSizeNarrow": "Narrow (2×1)",
+        "widgetSizeWide": "Wide (3×1)",
+        "widgetSizeFullRow": "Full row (4×1)",
         "widgetSizeTall": "Tall (1×2)",
         "widgetSizeStandard": "Standard (2×2)",
         "widgetSizeLarge": "Large (3×2)",

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -145,6 +145,8 @@
         "customizeExit": "Exit customization",
         "customizeSize": "Size",
         "customizeSizeFor": "Size for {{widget}}",
+        "widgetSizeOneRowGroup": "1 row",
+        "widgetSizeTwoRowsGroup": "2 rows",
         "customizeHide": "Hide {{widget}}",
         "customizeHiddenTitle": "Hidden widgets",
         "customizeShow": "Show {{widget}}",

--- a/public/locales/es.json
+++ b/public/locales/es.json
@@ -150,6 +150,8 @@
         "customizeShow": "{{widget}} einblenden",
         "widgetSizeTiny": "Pequeño (1×1)",
         "widgetSizeNarrow": "Estrecho (2×1)",
+        "widgetSizeWide": "Ancho (3×1)",
+        "widgetSizeFullRow": "Fila completa (4×1)",
         "widgetSizeTall": "Alto (1×2)",
         "widgetSizeStandard": "Estándar (2×2)",
         "widgetSizeLarge": "Grande (3×2)",

--- a/public/locales/es.json
+++ b/public/locales/es.json
@@ -145,6 +145,8 @@
         "customizeExit": "Salir de personalización",
         "customizeSize": "Tamaño",
         "customizeSizeFor": "Tamaño de {{widget}}",
+        "widgetSizeOneRowGroup": "1 fila",
+        "widgetSizeTwoRowsGroup": "2 filas",
         "customizeHide": "Ocultar {{widget}}",
         "customizeHiddenTitle": "Ausgeblendete Widgets",
         "customizeShow": "{{widget}} einblenden",

--- a/public/locales/fa.json
+++ b/public/locales/fa.json
@@ -156,6 +156,8 @@
         "customizeShow": "{{widget}} einblenden",
         "widgetSizeTiny": "کوچک (۱×۱)",
         "widgetSizeNarrow": "باریک (۲×۱)",
+        "widgetSizeWide": "عریض (۳×۱)",
+        "widgetSizeFullRow": "ردیف کامل (۴×۱)",
         "widgetSizeTall": "بلند (1×2)",
         "widgetSizeStandard": "استاندارد (۲×۲)",
         "widgetSizeLarge": "بزرگ (۳×۲)",

--- a/public/locales/fa.json
+++ b/public/locales/fa.json
@@ -151,6 +151,8 @@
         "customizeExit": "پایان سفارشی‌سازی",
         "customizeSize": "اندازه",
         "customizeSizeFor": "اندازه برای {{widget}}",
+        "widgetSizeOneRowGroup": "۱ ردیف",
+        "widgetSizeTwoRowsGroup": "۲ ردیف",
         "customizeHide": "پنهان کردن {{widget}}",
         "customizeHiddenTitle": "Ausgeblendete Widgets",
         "customizeShow": "{{widget}} einblenden",

--- a/public/locales/fr.json
+++ b/public/locales/fr.json
@@ -150,6 +150,8 @@
         "customizeShow": "{{widget}} einblenden",
         "widgetSizeTiny": "Petit (1×1)",
         "widgetSizeNarrow": "Étroit (2×1)",
+        "widgetSizeWide": "Large (3×1)",
+        "widgetSizeFullRow": "Ligne complète (4×1)",
         "widgetSizeTall": "Haut (1×2)",
         "widgetSizeStandard": "Standard (2×2)",
         "widgetSizeLarge": "Grand (3×2)",

--- a/public/locales/fr.json
+++ b/public/locales/fr.json
@@ -145,6 +145,8 @@
         "customizeExit": "Quitter la personnalisation",
         "customizeSize": "Taille",
         "customizeSizeFor": "Taille de {{widget}}",
+        "widgetSizeOneRowGroup": "1 ligne",
+        "widgetSizeTwoRowsGroup": "2 lignes",
         "customizeHide": "Masquer {{widget}}",
         "customizeHiddenTitle": "Ausgeblendete Widgets",
         "customizeShow": "{{widget}} einblenden",

--- a/public/locales/hi.json
+++ b/public/locales/hi.json
@@ -150,6 +150,8 @@
         "customizeShow": "{{widget}} einblenden",
         "widgetSizeTiny": "छोटा (1×1)",
         "widgetSizeNarrow": "संकरा (2×1)",
+        "widgetSizeWide": "चौड़ा (3×1)",
+        "widgetSizeFullRow": "पूरी पंक्ति (4×1)",
         "widgetSizeTall": "लंबा (1×2)",
         "widgetSizeStandard": "मानक (2×2)",
         "widgetSizeLarge": "बड़ा (3×2)",

--- a/public/locales/hi.json
+++ b/public/locales/hi.json
@@ -145,6 +145,8 @@
         "customizeExit": "अनुकूलन से बाहर निकलें",
         "customizeSize": "आकार",
         "customizeSizeFor": "{{widget}} का आकार",
+        "widgetSizeOneRowGroup": "1 पंक्ति",
+        "widgetSizeTwoRowsGroup": "2 पंक्तियाँ",
         "customizeHide": "{{widget}} छिपाएँ",
         "customizeHiddenTitle": "Ausgeblendete Widgets",
         "customizeShow": "{{widget}} einblenden",

--- a/public/locales/hu.json
+++ b/public/locales/hu.json
@@ -145,6 +145,8 @@
         "customizeExit": "Kilépés a testreszabásból",
         "customizeSize": "Méret",
         "customizeSizeFor": "Méret {{widget}} számára",
+        "widgetSizeOneRowGroup": "1 sor",
+        "widgetSizeTwoRowsGroup": "2 sor",
         "customizeHide": "Elrejtés {{widget}}",
         "customizeHiddenTitle": "Ausgeblendete Widgets",
         "customizeShow": "{{widget}} einblenden",

--- a/public/locales/hu.json
+++ b/public/locales/hu.json
@@ -150,6 +150,8 @@
         "customizeShow": "{{widget}} einblenden",
         "widgetSizeTiny": "Kicsi (1×1)",
         "widgetSizeNarrow": "Keskeny (2×1)",
+        "widgetSizeWide": "Széles (3×1)",
+        "widgetSizeFullRow": "Teljes sor (4×1)",
         "widgetSizeTall": "Magas (1×2)",
         "widgetSizeStandard": "Normál (2×2)",
         "widgetSizeLarge": "Nagy (3×2)",

--- a/public/locales/id.json
+++ b/public/locales/id.json
@@ -156,6 +156,8 @@
         "customizeShow": "{{widget}} einblenden",
         "widgetSizeTiny": "Kecil (1×1)",
         "widgetSizeNarrow": "Sempit (2×1)",
+        "widgetSizeWide": "Lebar (3×1)",
+        "widgetSizeFullRow": "Baris penuh (4×1)",
         "widgetSizeTall": "Tinggi (1×2)",
         "widgetSizeStandard": "Standar (2×2)",
         "widgetSizeLarge": "Besar (3×2)",

--- a/public/locales/id.json
+++ b/public/locales/id.json
@@ -151,6 +151,8 @@
         "customizeExit": "Selesai menyesuaikan",
         "customizeSize": "Ukuran",
         "customizeSizeFor": "Ukuran untuk {{widget}}",
+        "widgetSizeOneRowGroup": "1 baris",
+        "widgetSizeTwoRowsGroup": "2 baris",
         "customizeHide": "Sembunyikan {{widget}}",
         "customizeHiddenTitle": "Ausgeblendete Widgets",
         "customizeShow": "{{widget}} einblenden",

--- a/public/locales/it.json
+++ b/public/locales/it.json
@@ -150,6 +150,8 @@
         "customizeShow": "{{widget}} einblenden",
         "widgetSizeTiny": "Piccolo (1×1)",
         "widgetSizeNarrow": "Stretto (2×1)",
+        "widgetSizeWide": "Ampio (3×1)",
+        "widgetSizeFullRow": "Riga intera (4×1)",
         "widgetSizeTall": "Alto (1×2)",
         "widgetSizeStandard": "Standard (2×2)",
         "widgetSizeLarge": "Grande (3×2)",

--- a/public/locales/it.json
+++ b/public/locales/it.json
@@ -145,6 +145,8 @@
         "customizeExit": "Esci dalla personalizzazione",
         "customizeSize": "Dimensione",
         "customizeSizeFor": "Dimensione di {{widget}}",
+        "widgetSizeOneRowGroup": "1 riga",
+        "widgetSizeTwoRowsGroup": "2 righe",
         "customizeHide": "Nascondi {{widget}}",
         "customizeHiddenTitle": "Ausgeblendete Widgets",
         "customizeShow": "{{widget}} einblenden",

--- a/public/locales/ja.json
+++ b/public/locales/ja.json
@@ -150,6 +150,8 @@
         "customizeShow": "{{widget}} einblenden",
         "widgetSizeTiny": "小 (1×1)",
         "widgetSizeNarrow": "縦長 (2×1)",
+        "widgetSizeWide": "ワイド (3×1)",
+        "widgetSizeFullRow": "行全体 (4×1)",
         "widgetSizeTall": "縦長 (1×2)",
         "widgetSizeStandard": "標準 (2×2)",
         "widgetSizeLarge": "大 (3×2)",

--- a/public/locales/ja.json
+++ b/public/locales/ja.json
@@ -145,6 +145,8 @@
         "customizeExit": "カスタマイズを終了",
         "customizeSize": "サイズ",
         "customizeSizeFor": "{{widget}} のサイズ",
+        "widgetSizeOneRowGroup": "1行",
+        "widgetSizeTwoRowsGroup": "2行",
         "customizeHide": "{{widget}} を非表示",
         "customizeHiddenTitle": "Ausgeblendete Widgets",
         "customizeShow": "{{widget}} einblenden",

--- a/public/locales/ko.json
+++ b/public/locales/ko.json
@@ -151,6 +151,8 @@
         "customizeExit": "맞춤 설정 종료",
         "customizeSize": "크기",
         "customizeSizeFor": "{{widget}} 크기",
+        "widgetSizeOneRowGroup": "1행",
+        "widgetSizeTwoRowsGroup": "2행",
         "customizeHide": "{{widget}} 숨기기",
         "customizeHiddenTitle": "Ausgeblendete Widgets",
         "customizeShow": "{{widget}} einblenden",

--- a/public/locales/ko.json
+++ b/public/locales/ko.json
@@ -156,6 +156,8 @@
         "customizeShow": "{{widget}} einblenden",
         "widgetSizeTiny": "작게 (1×1)",
         "widgetSizeNarrow": "좁게 (2×1)",
+        "widgetSizeWide": "넓게 (3×1)",
+        "widgetSizeFullRow": "전체 행 (4×1)",
         "widgetSizeTall": "세로형 (1×2)",
         "widgetSizeStandard": "표준 (2×2)",
         "widgetSizeLarge": "크게 (3×2)",

--- a/public/locales/nl.json
+++ b/public/locales/nl.json
@@ -145,6 +145,8 @@
         "customizeExit": "Aanpassing beëindigen",
         "customizeSize": "Grootte",
         "customizeSizeFor": "Grootte voor {{widget}}",
+        "widgetSizeOneRowGroup": "1 rij",
+        "widgetSizeTwoRowsGroup": "2 rijen",
         "customizeHide": "{{widget}} verbergen",
         "customizeHiddenTitle": "Ausgeblendete Widgets",
         "customizeShow": "{{widget}} einblenden",

--- a/public/locales/nl.json
+++ b/public/locales/nl.json
@@ -150,6 +150,8 @@
         "customizeShow": "{{widget}} einblenden",
         "widgetSizeTiny": "Klein (1×1)",
         "widgetSizeNarrow": "Smal (2×1)",
+        "widgetSizeWide": "Breed (3×1)",
+        "widgetSizeFullRow": "Volledige rij (4×1)",
         "widgetSizeTall": "Hoog (1×2)",
         "widgetSizeStandard": "Standaard (2×2)",
         "widgetSizeLarge": "Groot (3×2)",

--- a/public/locales/pl.json
+++ b/public/locales/pl.json
@@ -156,6 +156,8 @@
         "customizeShow": "{{widget}} einblenden",
         "widgetSizeTiny": "Mały (1×1)",
         "widgetSizeNarrow": "Wąski (2×1)",
+        "widgetSizeWide": "Szeroki (3×1)",
+        "widgetSizeFullRow": "Cały wiersz (4×1)",
         "widgetSizeTall": "Wysoki (1×2)",
         "widgetSizeStandard": "Standardowy (2×2)",
         "widgetSizeLarge": "Duży (3×2)",

--- a/public/locales/pl.json
+++ b/public/locales/pl.json
@@ -151,6 +151,8 @@
         "customizeExit": "Zakończ dostosowywanie",
         "customizeSize": "Rozmiar",
         "customizeSizeFor": "Rozmiar dla {{widget}}",
+        "widgetSizeOneRowGroup": "1 wiersz",
+        "widgetSizeTwoRowsGroup": "2 wiersze",
         "customizeHide": "Ukryj {{widget}}",
         "customizeHiddenTitle": "Ausgeblendete Widgets",
         "customizeShow": "{{widget}} einblenden",

--- a/public/locales/pt.json
+++ b/public/locales/pt.json
@@ -150,6 +150,8 @@
         "customizeShow": "{{widget}} einblenden",
         "widgetSizeTiny": "Pequeno (1×1)",
         "widgetSizeNarrow": "Estreito (2×1)",
+        "widgetSizeWide": "Largo (3×1)",
+        "widgetSizeFullRow": "Linha completa (4×1)",
         "widgetSizeTall": "Alto (1×2)",
         "widgetSizeStandard": "Padrão (2×2)",
         "widgetSizeLarge": "Grande (3×2)",

--- a/public/locales/pt.json
+++ b/public/locales/pt.json
@@ -145,6 +145,8 @@
         "customizeExit": "Sair da personalização",
         "customizeSize": "Tamanho",
         "customizeSizeFor": "Tamanho de {{widget}}",
+        "widgetSizeOneRowGroup": "1 linha",
+        "widgetSizeTwoRowsGroup": "2 linhas",
         "customizeHide": "Ocultar {{widget}}",
         "customizeHiddenTitle": "Ausgeblendete Widgets",
         "customizeShow": "{{widget}} einblenden",

--- a/public/locales/ru.json
+++ b/public/locales/ru.json
@@ -150,6 +150,8 @@
         "customizeShow": "{{widget}} einblenden",
         "widgetSizeTiny": "Маленький (1×1)",
         "widgetSizeNarrow": "Узкий (2×1)",
+        "widgetSizeWide": "Широкий (3×1)",
+        "widgetSizeFullRow": "На всю строку (4×1)",
         "widgetSizeTall": "Высокий (1×2)",
         "widgetSizeStandard": "Стандартный (2×2)",
         "widgetSizeLarge": "Большой (3×2)",

--- a/public/locales/ru.json
+++ b/public/locales/ru.json
@@ -145,6 +145,8 @@
         "customizeExit": "Выйти из настройки",
         "customizeSize": "Размер",
         "customizeSizeFor": "Размер для {{widget}}",
+        "widgetSizeOneRowGroup": "1 строка",
+        "widgetSizeTwoRowsGroup": "2 строки",
         "customizeHide": "Скрыть {{widget}}",
         "customizeHiddenTitle": "Ausgeblendete Widgets",
         "customizeShow": "{{widget}} einblenden",

--- a/public/locales/sv.json
+++ b/public/locales/sv.json
@@ -150,6 +150,8 @@
         "customizeShow": "{{widget}} einblenden",
         "widgetSizeTiny": "Liten (1×1)",
         "widgetSizeNarrow": "Smal (2×1)",
+        "widgetSizeWide": "Bred (3×1)",
+        "widgetSizeFullRow": "Hel rad (4×1)",
         "widgetSizeTall": "Hög (1×2)",
         "widgetSizeStandard": "Standard (2×2)",
         "widgetSizeLarge": "Stor (3×2)",

--- a/public/locales/sv.json
+++ b/public/locales/sv.json
@@ -145,6 +145,8 @@
         "customizeExit": "Avsluta anpassning",
         "customizeSize": "Storlek",
         "customizeSizeFor": "Storlek för {{widget}}",
+        "widgetSizeOneRowGroup": "1 rad",
+        "widgetSizeTwoRowsGroup": "2 rader",
         "customizeHide": "Dölj {{widget}}",
         "customizeHiddenTitle": "Ausgeblendete Widgets",
         "customizeShow": "{{widget}} einblenden",

--- a/public/locales/tr.json
+++ b/public/locales/tr.json
@@ -145,6 +145,8 @@
         "customizeExit": "Özelleştirmeden çık",
         "customizeSize": "Boyut",
         "customizeSizeFor": "{{widget}} boyutu",
+        "widgetSizeOneRowGroup": "1 satır",
+        "widgetSizeTwoRowsGroup": "2 satır",
         "customizeHide": "{{widget}} gizle",
         "customizeHiddenTitle": "Ausgeblendete Widgets",
         "customizeShow": "{{widget}} einblenden",

--- a/public/locales/tr.json
+++ b/public/locales/tr.json
@@ -150,6 +150,8 @@
         "customizeShow": "{{widget}} einblenden",
         "widgetSizeTiny": "Küçük (1×1)",
         "widgetSizeNarrow": "Dar (2×1)",
+        "widgetSizeWide": "Geniş (3×1)",
+        "widgetSizeFullRow": "Tam satır (4×1)",
         "widgetSizeTall": "Yüksek (1×2)",
         "widgetSizeStandard": "Standart (2×2)",
         "widgetSizeLarge": "Büyük (3×2)",

--- a/public/locales/uk.json
+++ b/public/locales/uk.json
@@ -145,6 +145,8 @@
         "customizeExit": "Вийти з налаштування",
         "customizeSize": "Розмір",
         "customizeSizeFor": "Розмір для {{widget}}",
+        "widgetSizeOneRowGroup": "1 рядок",
+        "widgetSizeTwoRowsGroup": "2 рядки",
         "customizeHide": "Приховати {{widget}}",
         "customizeHiddenTitle": "Ausgeblendete Widgets",
         "customizeShow": "{{widget}} einblenden",

--- a/public/locales/uk.json
+++ b/public/locales/uk.json
@@ -150,6 +150,8 @@
         "customizeShow": "{{widget}} einblenden",
         "widgetSizeTiny": "Маленький (1×1)",
         "widgetSizeNarrow": "Вузький (2×1)",
+        "widgetSizeWide": "Широкий (3×1)",
+        "widgetSizeFullRow": "На весь рядок (4×1)",
         "widgetSizeTall": "Високий (1×2)",
         "widgetSizeStandard": "Стандартний (2×2)",
         "widgetSizeLarge": "Великий (3×2)",

--- a/public/locales/vi.json
+++ b/public/locales/vi.json
@@ -145,6 +145,8 @@
         "customizeExit": "Thoát tùy chỉnh",
         "customizeSize": "Kích thước",
         "customizeSizeFor": "Kích thước cho {{widget}}",
+        "widgetSizeOneRowGroup": "1 hàng",
+        "widgetSizeTwoRowsGroup": "2 hàng",
         "customizeHide": "Ẩn {{widget}}",
         "customizeHiddenTitle": "Ausgeblendete Widgets",
         "customizeShow": "{{widget}} einblenden",

--- a/public/locales/vi.json
+++ b/public/locales/vi.json
@@ -150,6 +150,8 @@
         "customizeShow": "{{widget}} einblenden",
         "widgetSizeTiny": "Nhỏ (1×1)",
         "widgetSizeNarrow": "Hẹp (2×1)",
+        "widgetSizeWide": "Rộng (3×1)",
+        "widgetSizeFullRow": "Toàn hàng (4×1)",
         "widgetSizeTall": "Cao (1×2)",
         "widgetSizeStandard": "Tiêu chuẩn (2×2)",
         "widgetSizeLarge": "Lớn (3×2)",

--- a/public/locales/zh.json
+++ b/public/locales/zh.json
@@ -150,6 +150,8 @@
         "customizeShow": "{{widget}} einblenden",
         "widgetSizeTiny": "小 (1×1)",
         "widgetSizeNarrow": "窄 (2×1)",
+        "widgetSizeWide": "宽 (3×1)",
+        "widgetSizeFullRow": "整行 (4×1)",
         "widgetSizeTall": "高 (1×2)",
         "widgetSizeStandard": "标准 (2×2)",
         "widgetSizeLarge": "大 (3×2)",

--- a/public/locales/zh.json
+++ b/public/locales/zh.json
@@ -145,6 +145,8 @@
         "customizeExit": "退出自定义",
         "customizeSize": "大小",
         "customizeSizeFor": "{{widget}} 的大小",
+        "widgetSizeOneRowGroup": "1 行",
+        "widgetSizeTwoRowsGroup": "2 行",
         "customizeHide": "隐藏 {{widget}}",
         "customizeHiddenTitle": "Ausgeblendete Widgets",
         "customizeShow": "{{widget}} einblenden",

--- a/public/pages/dashboard.js
+++ b/public/pages/dashboard.js
@@ -196,13 +196,16 @@ function maybeHintCustomize(container) {
 // (weather) steht bewusst am Ende, statt die sichtbare Grid-Spitze zu belegen.
 const WIDGET_IDS = ['tasks', 'calendar', 'meals', 'shopping', 'birthdays', 'budget', 'rewards', 'health', 'cycle', 'housekeeping', 'family', 'notes', 'weather'];
 
-// Sechs benannte Formen decken die üblichen Dashboard-Bedürfnisse ab: kompakte
-// Statuskacheln, hohe Listen, Standardkarten sowie breite Übersichten. Die volle
+// Benannte Formen decken die üblichen Dashboard-Bedürfnisse ab: kompakte
+// Statuskacheln, hohe Listen, Standardkarten sowie breite Übersichten in echter
+// Ein-Zeilen- und Zwei-Zeilen-Höhe. Die volle
 // 1-4 x 1-4-Matrix bleibt als gespeicherter/validierter Wert erhalten, damit
 // bestehende Layouts nicht beim nächsten Rendern zusammengezogen werden.
 const WIDGET_SIZE_PRESETS = [
   { value: '1x1', labelKey: 'dashboard.widgetSizeTiny'     },
   { value: '2x1', labelKey: 'dashboard.widgetSizeNarrow'   },
+  { value: '3x1', labelKey: 'dashboard.widgetSizeWide'     },
+  { value: '4x1', labelKey: 'dashboard.widgetSizeFullRow'  },
   { value: '1x2', labelKey: 'dashboard.widgetSizeTall'     },
   { value: '2x2', labelKey: 'dashboard.widgetSizeStandard' },
   { value: '3x2', labelKey: 'dashboard.widgetSizeLarge'    },
@@ -224,8 +227,8 @@ function nearestPreset(size) {
   if (values.includes(size)) return size;
   const [cols, rows] = String(size).split('x').map(Number);
   if (!Number.isFinite(cols) || !Number.isFinite(rows)) return '1x1';
-  if (cols >= 4) return '4x2';
-  if (cols >= 3) return '3x2';
+  if (cols >= 4) return rows >= 2 ? '4x2' : '4x1';
+  if (cols >= 3) return rows >= 2 ? '3x2' : '3x1';
   if (cols >= 2) return rows >= 2 ? '2x2' : '2x1';
   return rows >= 2 ? '1x2' : '1x1';
 }

--- a/public/pages/dashboard.js
+++ b/public/pages/dashboard.js
@@ -196,34 +196,38 @@ function maybeHintCustomize(container) {
 // (weather) steht bewusst am Ende, statt die sichtbare Grid-Spitze zu belegen.
 const WIDGET_IDS = ['tasks', 'calendar', 'meals', 'shopping', 'birthdays', 'budget', 'rewards', 'health', 'cycle', 'housekeeping', 'family', 'notes', 'weather'];
 
-// Vier kuratierte Formen statt sechs: über vier Auswahlmöglichkeiten pro Widget
-// (× bis zu 12 Widgets) kippt der Anpassen-Modus in Mikro-Entscheidungs-Overhead
-// für ein Familienpublikum (Critique P2, ≤4-Choices-Regel). Die früheren 3x2/4x2
-// bleiben als Legacy-Werte gültig (WIDGET_SIZE_OPTIONS) — bestehende Layouts werden
-// nicht zurückgesetzt, nur die Neu-Auswahl steuert auf diese vier zu.
+// Sechs benannte Formen decken die üblichen Dashboard-Bedürfnisse ab: kompakte
+// Statuskacheln, hohe Listen, Standardkarten sowie breite Übersichten. Die volle
+// 1-4 x 1-4-Matrix bleibt als gespeicherter/validierter Wert erhalten, damit
+// bestehende Layouts nicht beim nächsten Rendern zusammengezogen werden.
 const WIDGET_SIZE_PRESETS = [
   { value: '1x1', labelKey: 'dashboard.widgetSizeTiny'     },
   { value: '2x1', labelKey: 'dashboard.widgetSizeNarrow'   },
   { value: '1x2', labelKey: 'dashboard.widgetSizeTall'     },
   { value: '2x2', labelKey: 'dashboard.widgetSizeStandard' },
+  { value: '3x2', labelKey: 'dashboard.widgetSizeLarge'    },
+  { value: '4x2', labelKey: 'dashboard.widgetSizeFull'     },
 ];
 
-// Alle bekannten Größen inkl. Legacy-Werte — für normalizeDashboardConfig-Validierung
-const WIDGET_SIZE_OPTIONS = [...new Set([
-  ...WIDGET_SIZE_PRESETS.map((p) => p.value),
-  '1x2', '1x3', '1x4', '2x3', '2x4', '3x1', '3x3', '3x4', '4x1', '4x3', '4x4',
-])];
+// Alle bekannten Größen inkl. API-validierter Legacy-/Direktwerte.
+const WIDGET_SIZE_OPTIONS = [
+  '1x1', '1x2', '1x3', '1x4',
+  '2x1', '2x2', '2x3', '2x4',
+  '3x1', '3x2', '3x3', '3x4',
+  '4x1', '4x2', '4x3', '4x4',
+];
 
-// Bildet einen beliebigen (auch Legacy-)Größenwert auf das nächstliegende der vier
-// kuratierten Presets ab: Breite/Höhe ≥2 → 2, sonst 1. So kann normalizeDashboardConfig
-// migrierte Layouts (z.B. 4x2 aus einer früheren Version) auf ein Preset zusammenziehen,
-// statt dem betroffenen Nutzer als einziger eine 5. Dropdown-Option zu zeigen (Critique P2).
+// Markiert in der UI bei nicht direkt angebotenen Matrixwerten das nächstliegende
+// benannte Preset, ohne den gespeicherten Wert zu verändern.
 function nearestPreset(size) {
   const values = WIDGET_SIZE_PRESETS.map((p) => p.value);
   if (values.includes(size)) return size;
   const [cols, rows] = String(size).split('x').map(Number);
   if (!Number.isFinite(cols) || !Number.isFinite(rows)) return '1x1';
-  return `${cols >= 2 ? 2 : 1}x${rows >= 2 ? 2 : 1}`;
+  if (cols >= 4) return '4x2';
+  if (cols >= 3) return '3x2';
+  if (cols >= 2) return rows >= 2 ? '2x2' : '2x1';
+  return rows >= 2 ? '1x2' : '1x1';
 }
 
 function defaultWidgetSize(id) {
@@ -276,9 +280,7 @@ function normalizeDashboardConfig(input) {
         id: w.id,
         visible: w.visible !== false,
         order: Number.isFinite(Number(w.order)) ? Number(w.order) : i,
-        // Gültige (inkl. Legacy-)Größen auf das nächste Preset ziehen; Unbekanntes
-        // fällt auf den Domänen-Default. So sieht niemand eine 5. Größen-Option.
-        size: WIDGET_SIZE_OPTIONS.includes(w.size) ? nearestPreset(w.size) : defaultWidgetSize(w.id),
+        size: WIDGET_SIZE_OPTIONS.includes(w.size) ? w.size : defaultWidgetSize(w.id),
       }))
     : [];
   const presentIds = new Set(valid.map((w) => w.id));
@@ -1191,7 +1193,7 @@ function renderWidgetCustomizeControls(w, index = 0, total = 1) {
   const isLast = index === total - 1;
   const activeSize = nearestPreset(w.size);
 
-  // Segmentiertes Größen-Steuerelement: vier klickbare Mini-Grid-Presets ersetzen
+  // Segmentiertes Größen-Steuerelement: klickbare Mini-Grid-Presets ersetzen
   // die frühere Kombination aus dekorativem Mini-Grid + „Größe"-Label + 132px-
   // <select> (Critique P1: doppelte Kontrolle + Overflow auf 1×1-Kacheln). Jeder
   // Button zeigt seine Form direkt und markiert die aktive Größe.
@@ -2079,7 +2081,15 @@ export async function render(container, { user }) {
   }
 }
 
-export const __test = { buildTodayHighlights, normalizeVisibleMealTypes, renderTodayMeals, calendarEventRoute, eventOccurrenceDateKey };
+export const __test = {
+  buildTodayHighlights,
+  normalizeVisibleMealTypes,
+  renderTodayMeals,
+  calendarEventRoute,
+  eventOccurrenceDateKey,
+  normalizeDashboardConfig,
+  WIDGET_SIZE_PRESETS,
+};
 
 function wireWeatherRefresh(container, onUpdated = null) {
   const refreshBtn = container.querySelector('#weather-refresh-btn');

--- a/public/pages/dashboard.js
+++ b/public/pages/dashboard.js
@@ -198,9 +198,10 @@ const WIDGET_IDS = ['tasks', 'calendar', 'meals', 'shopping', 'birthdays', 'budg
 
 // Benannte Formen decken die üblichen Dashboard-Bedürfnisse ab: kompakte
 // Statuskacheln, hohe Listen, Standardkarten sowie breite Übersichten in echter
-// Ein-Zeilen- und Zwei-Zeilen-Höhe. Die volle
-// 1-4 x 1-4-Matrix bleibt als gespeicherter/validierter Wert erhalten, damit
-// bestehende Layouts nicht beim nächsten Rendern zusammengezogen werden.
+// Ein-Zeilen- und Zwei-Zeilen-Höhe. Gespeicherte 3-/4-Zeilen-Matrixwerte aus
+// alten oder direkten API-Konfigurationen werden auf das nächste angebotene
+// Preset normalisiert, damit gespeicherter Wert und UI-Aktivzustand nicht
+// auseinanderlaufen.
 const WIDGET_SIZE_PRESETS = [
   { value: '1x1', labelKey: 'dashboard.widgetSizeTiny'     },
   { value: '2x1', labelKey: 'dashboard.widgetSizeNarrow'   },
@@ -212,25 +213,28 @@ const WIDGET_SIZE_PRESETS = [
   { value: '4x2', labelKey: 'dashboard.widgetSizeFull'     },
 ];
 
-// Alle bekannten Größen inkl. API-validierter Legacy-/Direktwerte.
-const WIDGET_SIZE_OPTIONS = [
-  '1x1', '1x2', '1x3', '1x4',
-  '2x1', '2x2', '2x3', '2x4',
-  '3x1', '3x2', '3x3', '3x4',
-  '4x1', '4x2', '4x3', '4x4',
+const WIDGET_SIZE_PRESET_GROUPS = [
+  { labelKey: 'dashboard.widgetSizeOneRowGroup', values: ['1x1', '2x1', '3x1', '4x1'] },
+  { labelKey: 'dashboard.widgetSizeTwoRowsGroup', values: ['1x2', '2x2', '3x2', '4x2'] },
 ];
 
-// Markiert in der UI bei nicht direkt angebotenen Matrixwerten das nächstliegende
-// benannte Preset, ohne den gespeicherten Wert zu verändern.
-function nearestPreset(size) {
-  const values = WIDGET_SIZE_PRESETS.map((p) => p.value);
-  if (values.includes(size)) return size;
-  const [cols, rows] = String(size).split('x').map(Number);
-  if (!Number.isFinite(cols) || !Number.isFinite(rows)) return '1x1';
-  if (cols >= 4) return rows >= 2 ? '4x2' : '4x1';
-  if (cols >= 3) return rows >= 2 ? '3x2' : '3x1';
-  if (cols >= 2) return rows >= 2 ? '2x2' : '2x1';
-  return rows >= 2 ? '1x2' : '1x1';
+const WIDGET_SIZE_PRESET_VALUES = WIDGET_SIZE_PRESETS.map((p) => p.value);
+const WIDGET_SIZE_PRESETS_BY_VALUE = new Map(WIDGET_SIZE_PRESETS.map((p) => [p.value, p]));
+const WIDGET_SIZE_OPTIONS = WIDGET_SIZE_PRESET_VALUES;
+
+function collapseMatrixSizeToPreset(size) {
+  const match = String(size || '').match(/^([1-4])x([1-4])$/);
+  if (!match) return null;
+  const cols = Number(match[1]);
+  const rows = Number(match[2]) > 1 ? 2 : 1;
+  return `${cols}x${rows}`;
+}
+
+function normalizeWidgetSize(size, widgetId) {
+  if (WIDGET_SIZE_PRESET_VALUES.includes(size)) return size;
+  const collapsed = collapseMatrixSizeToPreset(size);
+  if (collapsed && WIDGET_SIZE_PRESET_VALUES.includes(collapsed)) return collapsed;
+  return defaultWidgetSize(widgetId);
 }
 
 function defaultWidgetSize(id) {
@@ -283,7 +287,7 @@ function normalizeDashboardConfig(input) {
         id: w.id,
         visible: w.visible !== false,
         order: Number.isFinite(Number(w.order)) ? Number(w.order) : i,
-        size: WIDGET_SIZE_OPTIONS.includes(w.size) ? w.size : defaultWidgetSize(w.id),
+        size: normalizeWidgetSize(w.size, w.id),
       }))
     : [];
   const presentIds = new Set(valid.map((w) => w.id));
@@ -1191,22 +1195,36 @@ function renderSizeMiniGridCells(size) {
   }).join('');
 }
 
+function renderSizeButton(p, activeSize, widgetId) {
+  const active = p.value === activeSize;
+  return `<button type="button" class="widget-size-btn${active ? ' widget-size-btn--active' : ''}"
+            data-widget-size-preset="${p.value}" data-widget-id="${esc(widgetId)}"
+            aria-pressed="${active ? 'true' : 'false'}" aria-label="${esc(t(p.labelKey))}" title="${esc(t(p.labelKey))}">
+      ${renderSizeMiniGrid(p.value)}
+    </button>`;
+}
+
 function renderWidgetCustomizeControls(w, index = 0, total = 1) {
   const isFirst = index === 0;
   const isLast = index === total - 1;
-  const activeSize = nearestPreset(w.size);
+  const activeSize = WIDGET_SIZE_PRESET_VALUES.includes(w.size) ? w.size : null;
 
   // Segmentiertes Größen-Steuerelement: klickbare Mini-Grid-Presets ersetzen
   // die frühere Kombination aus dekorativem Mini-Grid + „Größe"-Label + 132px-
-  // <select> (Critique P1: doppelte Kontrolle + Overflow auf 1×1-Kacheln). Jeder
-  // Button zeigt seine Form direkt und markiert die aktive Größe.
-  const sizeButtons = WIDGET_SIZE_PRESETS.map((p) => {
-    const active = p.value === activeSize;
-    return `<button type="button" class="widget-size-btn${active ? ' widget-size-btn--active' : ''}"
-              data-widget-size-preset="${p.value}" data-widget-id="${esc(w.id)}"
-              aria-pressed="${active ? 'true' : 'false'}" aria-label="${esc(t(p.labelKey))}" title="${esc(t(p.labelKey))}">
-        ${renderSizeMiniGrid(p.value)}
-      </button>`;
+  // <select> (Critique P1: doppelte Kontrolle + Overflow auf 1×1-Kacheln). Die
+  // acht Presets sind in 1- und 2-Zeilen-Gruppen sortiert, damit pro Entscheidung
+  // nur noch die Breite verglichen werden muss.
+  const sizeButtons = WIDGET_SIZE_PRESET_GROUPS.map((group) => {
+    const label = t(group.labelKey);
+    const buttons = group.values
+      .map((value) => WIDGET_SIZE_PRESETS_BY_VALUE.get(value))
+      .filter(Boolean)
+      .map((p) => renderSizeButton(p, activeSize, w.id))
+      .join('');
+    return `<div class="widget-size-row" role="group" aria-label="${esc(label)}">
+        <span class="widget-size-row__label">${esc(label)}</span>
+        <div class="widget-size-row__buttons">${buttons}</div>
+      </div>`;
   }).join('');
 
   return `
@@ -2091,6 +2109,7 @@ export const __test = {
   calendarEventRoute,
   eventOccurrenceDateKey,
   normalizeDashboardConfig,
+  renderWidgetCustomizeControls,
   WIDGET_SIZE_PRESETS,
 };
 

--- a/public/styles/dashboard.css
+++ b/public/styles/dashboard.css
@@ -105,7 +105,7 @@
      * Zeilen-Spans der hohen Widgets füllen Restlücken; verbleibender Weißraum
      * wandert ans ruhige Grid-Ende statt in die Mitte. */
     grid-template-columns: repeat(auto-fill, minmax(min(100%, 240px), 1fr));
-    grid-auto-rows: 206px;
+    grid-auto-rows: minmax(132px, 206px);
     gap: var(--space-5);
     grid-auto-flow: row dense;
   }
@@ -2051,7 +2051,7 @@ svg.weather-forecast__icon {
 }
 
 .widget-wrapper--editing {
-  padding-top: 42px;
+  padding-top: 100px;
   outline: 1px solid color-mix(in srgb, var(--module-accent) 36%, var(--color-border));
   outline-offset: -1px;
   border-radius: var(--radius-sm);
@@ -2148,11 +2148,36 @@ svg.weather-forecast__icon {
 
 .widget-edit-controls__size {
   display: flex;
-  align-items: center;
+  flex-direction: column;
+  align-items: stretch;
   gap: var(--space-1);
   min-width: 0;
   flex: 1 1 auto;
-  flex-wrap: wrap;
+}
+
+.widget-size-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  min-width: 0;
+}
+
+.widget-size-row__label {
+  flex: 0 0 52px;
+  overflow: hidden;
+  color: var(--color-text-tertiary);
+  font-size: var(--text-xs);
+  font-weight: var(--font-weight-medium);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.widget-size-row__buttons {
+  display: flex;
+  flex: 0 1 auto;
+  flex-wrap: nowrap;
+  gap: var(--space-1);
+  min-width: 0;
 }
 
 /* Segmentierter Größen-Button: ein klickbares Mini-Grid pro Preset. Ersetzt das
@@ -2186,6 +2211,10 @@ svg.weather-forecast__icon {
 /* Edit-Mode-Controls sind auf dem Desktop bewusst kompakt (40px = --target-md,
    Maus-Minimum), müssen auf Fingereingabe aber das 44px-Minimum erreichen. */
 @media (pointer: coarse) {
+  .widget-wrapper--editing {
+    padding-top: 116px;
+  }
+
   .widget-restore-chip,
   .dashboard-customize-toolbar .btn {
     min-height: var(--target-base);

--- a/public/styles/dashboard.css
+++ b/public/styles/dashboard.css
@@ -105,7 +105,7 @@
      * Zeilen-Spans der hohen Widgets füllen Restlücken; verbleibender Weißraum
      * wandert ans ruhige Grid-Ende statt in die Mitte. */
     grid-template-columns: repeat(auto-fill, minmax(min(100%, 240px), 1fr));
-    grid-auto-rows: minmax(132px, auto);
+    grid-auto-rows: 206px;
     gap: var(--space-5);
     grid-auto-flow: row dense;
   }

--- a/server/routes/preferences.js
+++ b/server/routes/preferences.js
@@ -45,7 +45,7 @@ const SUBDIVISION_RE = /^[A-Z]{2}-[A-Z0-9-]{1,10}$/;
 // Order defines the default dashboard layout (weather first, then primary content).
 // Must stay in sync with WIDGET_IDS in public/pages/dashboard.js.
 const VALID_WIDGET_IDS = ['weather', 'tasks', 'calendar', 'meals', 'shopping', 'birthdays', 'budget', 'family', 'notes'];
-const VALID_WIDGET_SIZES = ['1x1', '1x2', '1x3', '1x4', '2x1', '2x2', '2x3', '2x4', '3x1', '3x2', '3x3', '3x4', '4x1', '4x2', '4x3', '4x4'];
+const VALID_WIDGET_SIZES = ['1x1', '2x1', '3x1', '4x1', '1x2', '2x2', '3x2', '4x2'];
 
 // Modul-Slugs, die per Settings deaktiviert werden können.
 // Dashboard und Settings sind absichtlich nicht enthalten — sie sind essentiell.
@@ -62,6 +62,21 @@ function defaultWidgetSize(id) {
   if (['tasks', 'calendar'].includes(id)) return '2x2';
   if (['weather', 'shopping', 'notes'].includes(id)) return '2x1';
   return '1x1';
+}
+
+function collapseMatrixSizeToPreset(size) {
+  const match = String(size || '').match(/^([1-4])x([1-4])$/);
+  if (!match) return null;
+  const cols = Number(match[1]);
+  const rows = Number(match[2]) > 1 ? 2 : 1;
+  return `${cols}x${rows}`;
+}
+
+function normalizeWidgetSize(size, widgetId) {
+  if (VALID_WIDGET_SIZES.includes(size)) return size;
+  const collapsed = collapseMatrixSizeToPreset(size);
+  if (collapsed && VALID_WIDGET_SIZES.includes(collapsed)) return collapsed;
+  return defaultWidgetSize(widgetId);
 }
 
 const DEFAULT_WIDGET_CONFIG = JSON.stringify(VALID_WIDGET_IDS.map((id, order) => ({
@@ -184,7 +199,7 @@ function normalizeWidgetConfig(input) {
         id: w.id,
         visible: w.visible !== false,
         order: Number.isFinite(Number(w.order)) ? Number(w.order) : order,
-        size: VALID_WIDGET_SIZES.includes(w.size) ? w.size : defaultWidgetSize(w.id),
+        size: normalizeWidgetSize(w.size, w.id),
       }))
     : [];
 

--- a/test/test-dashboard.js
+++ b/test/test-dashboard.js
@@ -201,6 +201,25 @@ test('Today-Meals-Widget rendert nur sichtbare Mahlzeit-Typen', async () => {
   nodeAssert.ok(!html.includes('data-type="lunch"'));
 });
 
+test('Dashboard-Widgetgrößen bieten große Presets und bewahren gültige Matrixwerte', async () => {
+  const { __test } = await import('../public/pages/dashboard.js');
+  const presetValues = __test.WIDGET_SIZE_PRESETS.map((p) => p.value);
+
+  nodeAssert.deepEqual(presetValues, ['1x1', '2x1', '1x2', '2x2', '3x2', '4x2']);
+
+  const normalized = __test.normalizeDashboardConfig([
+    { id: 'tasks', visible: true, order: 0, size: '3x2' },
+    { id: 'calendar', visible: true, order: 1, size: '4x2' },
+    { id: 'family', visible: true, order: 2, size: '4x3' },
+    { id: 'weather', visible: true, order: 3, size: '9x9' },
+  ]);
+
+  nodeAssert.equal(normalized.find((w) => w.id === 'tasks').size, '3x2');
+  nodeAssert.equal(normalized.find((w) => w.id === 'calendar').size, '4x2');
+  nodeAssert.equal(normalized.find((w) => w.id === 'family').size, '4x3');
+  nodeAssert.equal(normalized.find((w) => w.id === 'weather').size, '2x1');
+});
+
 // --------------------------------------------------------
 // Tests: Dringende Aufgaben
 // --------------------------------------------------------

--- a/test/test-dashboard.js
+++ b/test/test-dashboard.js
@@ -201,7 +201,7 @@ test('Today-Meals-Widget rendert nur sichtbare Mahlzeit-Typen', async () => {
   nodeAssert.ok(!html.includes('data-type="lunch"'));
 });
 
-test('Dashboard-Widgetgrößen bieten ein- und zweizeilige breite Presets und bewahren gültige Matrixwerte', async () => {
+test('Dashboard-Widgetgrößen bieten gruppierte ein-/zweizeilige Presets und normalisieren versteckte Matrixwerte', async () => {
   const { __test } = await import('../public/pages/dashboard.js');
   const presetValues = __test.WIDGET_SIZE_PRESETS.map((p) => p.value);
 
@@ -216,8 +216,14 @@ test('Dashboard-Widgetgrößen bieten ein- und zweizeilige breite Presets und be
 
   nodeAssert.equal(normalized.find((w) => w.id === 'tasks').size, '3x1');
   nodeAssert.equal(normalized.find((w) => w.id === 'calendar').size, '4x1');
-  nodeAssert.equal(normalized.find((w) => w.id === 'family').size, '4x3');
+  nodeAssert.equal(normalized.find((w) => w.id === 'family').size, '4x2');
   nodeAssert.equal(normalized.find((w) => w.id === 'weather').size, '2x1');
+
+  const controls = __test.renderWidgetCustomizeControls({ id: 'family', visible: true, order: 0, size: '4x2' }, 0, 1);
+  nodeAssert.equal((controls.match(/class="widget-size-row"/g) || []).length, 2);
+  nodeAssert.ok(controls.includes('data-widget-size-preset="4x1"'));
+  nodeAssert.ok(controls.includes('data-widget-size-preset="4x2"'));
+  nodeAssert.ok(!controls.includes('data-widget-size-preset="4x3"'));
 });
 
 // --------------------------------------------------------

--- a/test/test-dashboard.js
+++ b/test/test-dashboard.js
@@ -201,21 +201,21 @@ test('Today-Meals-Widget rendert nur sichtbare Mahlzeit-Typen', async () => {
   nodeAssert.ok(!html.includes('data-type="lunch"'));
 });
 
-test('Dashboard-Widgetgrößen bieten große Presets und bewahren gültige Matrixwerte', async () => {
+test('Dashboard-Widgetgrößen bieten ein- und zweizeilige breite Presets und bewahren gültige Matrixwerte', async () => {
   const { __test } = await import('../public/pages/dashboard.js');
   const presetValues = __test.WIDGET_SIZE_PRESETS.map((p) => p.value);
 
-  nodeAssert.deepEqual(presetValues, ['1x1', '2x1', '1x2', '2x2', '3x2', '4x2']);
+  nodeAssert.deepEqual(presetValues, ['1x1', '2x1', '3x1', '4x1', '1x2', '2x2', '3x2', '4x2']);
 
   const normalized = __test.normalizeDashboardConfig([
-    { id: 'tasks', visible: true, order: 0, size: '3x2' },
-    { id: 'calendar', visible: true, order: 1, size: '4x2' },
+    { id: 'tasks', visible: true, order: 0, size: '3x1' },
+    { id: 'calendar', visible: true, order: 1, size: '4x1' },
     { id: 'family', visible: true, order: 2, size: '4x3' },
     { id: 'weather', visible: true, order: 3, size: '9x9' },
   ]);
 
-  nodeAssert.equal(normalized.find((w) => w.id === 'tasks').size, '3x2');
-  nodeAssert.equal(normalized.find((w) => w.id === 'calendar').size, '4x2');
+  nodeAssert.equal(normalized.find((w) => w.id === 'tasks').size, '3x1');
+  nodeAssert.equal(normalized.find((w) => w.id === 'calendar').size, '4x1');
   nodeAssert.equal(normalized.find((w) => w.id === 'family').size, '4x3');
   nodeAssert.equal(normalized.find((w) => w.id === 'weather').size, '2x1');
 });


### PR DESCRIPTION
Dashboards are a big deal for some users, and as a self-hosted solution, empowering users and their families to have more customization options is not just a nice-to-have feature—it’s a core expectation. Self-hosting is fundamentally about control. By offering modularity and deep personalization, we respect the user's sovereignty over their self-hosted environment, turning a static interface into a truly tailored home hub.

Summary:

  - Adds more dashboard widget size presets, including real one-row wide options: 3x1 and 4x1.
  - Keeps two-row wide options available separately: 3x2 and 4x2.
  - Preserves valid saved widget matrix sizes instead of collapsing them to smaller presets.
  - Updates all app locales and the dashboard sizing spec.
  - Fixes desktop grid row sizing so one-row widgets render at the intended reduced height instead of expanding to content-driven height.
