### PR TITLE
Fix(Dashboard) Sidebar collapse issues

### DIFF
--- a/public/router.js
+++ b/public/router.js
@@ -862,6 +862,9 @@ function renderAppShell(container) {
     const nowCollapsed = !document.documentElement.classList.contains('sidebar-collapsed');
     localStorage.setItem(SIDEBAR_COLLAPSED_KEY, nowCollapsed ? '1' : '0');
     applySidebarCollapsed(nowCollapsed);
+    if (event.detail > 0) {
+      document.documentElement.classList.toggle('sidebar-collapse-pointer-lock', nowCollapsed);
+    }
     // Pointer clicks leave the toggle focused, which immediately re-expands the
     // collapsed rail via .nav-sidebar:focus-within. Blur only for pointer-driven
     // activation so keyboard users keep the expected focus behavior.
@@ -917,6 +920,9 @@ function renderAppShell(container) {
   sidebar.addEventListener('mouseleave', syncSidebarIndicator);
   sidebar.addEventListener('focusin', syncSidebarIndicator);
   sidebar.addEventListener('focusout', syncSidebarIndicator);
+  sidebar.addEventListener('mouseleave', () => {
+    document.documentElement.classList.remove('sidebar-collapse-pointer-lock');
+  });
 
   sidebar.appendChild(sidebarLogo);
   sidebar.appendChild(sidebarToggle);
@@ -1646,6 +1652,9 @@ function isModuleDisabled(moduleName) {
 
 function applySidebarCollapsed(collapsed) {
   document.documentElement.classList.toggle('sidebar-collapsed', collapsed);
+  if (!collapsed) {
+    document.documentElement.classList.remove('sidebar-collapse-pointer-lock');
+  }
 }
 
 function setDisabledModules(modules) {

--- a/public/router.js
+++ b/public/router.js
@@ -858,10 +858,16 @@ function renderAppShell(container) {
   _toggleIcon.dataset.lucide = _sidebarInitCollapsed ? 'panel-left-open' : 'panel-left-close';
   _toggleIcon.setAttribute('aria-hidden', 'true');
   sidebarToggle.appendChild(_toggleIcon);
-  sidebarToggle.addEventListener('click', () => {
+  sidebarToggle.addEventListener('click', (event) => {
     const nowCollapsed = !document.documentElement.classList.contains('sidebar-collapsed');
     localStorage.setItem(SIDEBAR_COLLAPSED_KEY, nowCollapsed ? '1' : '0');
     applySidebarCollapsed(nowCollapsed);
+    // Pointer clicks leave the toggle focused, which immediately re-expands the
+    // collapsed rail via .nav-sidebar:focus-within. Blur only for pointer-driven
+    // activation so keyboard users keep the expected focus behavior.
+    if (nowCollapsed && event.detail > 0) {
+      requestAnimationFrame(() => sidebarToggle.blur());
+    }
     const lbl = nowCollapsed ? t('nav.sidebarExpand') : t('nav.sidebarCollapse');
     sidebarToggle.setAttribute('aria-label', lbl);
     sidebarToggle.setAttribute('title', lbl);

--- a/public/router.js
+++ b/public/router.js
@@ -907,6 +907,17 @@ function renderAppShell(container) {
     if (!sidebarItems.contains(ev.relatedTarget)) positionSidebarIndicator();
   });
 
+  const syncSidebarIndicator = () => {
+    requestAnimationFrame(() => positionSidebarIndicator());
+  };
+  // In collapsed mode the section headers are hidden. Expanding the rail on
+  // hover/focus puts them back into layout, which shifts the nav items down.
+  // Re-sync the active pill after those layout changes.
+  sidebar.addEventListener('mouseenter', syncSidebarIndicator);
+  sidebar.addEventListener('mouseleave', syncSidebarIndicator);
+  sidebar.addEventListener('focusin', syncSidebarIndicator);
+  sidebar.addEventListener('focusout', syncSidebarIndicator);
+
   sidebar.appendChild(sidebarLogo);
   sidebar.appendChild(sidebarToggle);
   sidebar.appendChild(sidebarItems);

--- a/public/styles/layout.css
+++ b/public/styles/layout.css
@@ -1047,20 +1047,20 @@ html.fab-anim-done .page-fab {
    * fixed und überlagert Inhalt beim Aufklappen wie ein Flyout — --sidebar-width
    * (und damit der .app-content-Margin) bleibt 56px, also kein Reflow. Die
    * Breite animiert über die bestehende width-Transition. */
-  html.sidebar-collapsed .nav-sidebar:hover,
+  html.sidebar-collapsed:not(.sidebar-collapse-pointer-lock) .nav-sidebar:hover,
   html.sidebar-collapsed .nav-sidebar:focus-within {
     width: var(--sidebar-width-expanded);
     box-shadow: var(--shadow-lg);
   }
 
-  html.sidebar-collapsed .nav-sidebar:hover .nav-sidebar__brand-text,
+  html.sidebar-collapsed:not(.sidebar-collapse-pointer-lock) .nav-sidebar:hover .nav-sidebar__brand-text,
   html.sidebar-collapsed .nav-sidebar:focus-within .nav-sidebar__brand-text {
     display: flex;
   }
 
-  html.sidebar-collapsed .nav-sidebar:hover .nav-item__label,
+  html.sidebar-collapsed:not(.sidebar-collapse-pointer-lock) .nav-sidebar:hover .nav-item__label,
   html.sidebar-collapsed .nav-sidebar:focus-within .nav-item__label,
-  html.sidebar-collapsed .nav-sidebar:hover .nav-section-label,
+  html.sidebar-collapsed:not(.sidebar-collapse-pointer-lock) .nav-sidebar:hover .nav-section-label,
   html.sidebar-collapsed .nav-sidebar:focus-within .nav-section-label {
     display: block;
   }


### PR DESCRIPTION
Fixes several UI issues related to sidebar. 
1) sidebar itself was not actually collapsing on click, central content would move left, but sidebar would never collapse down.
2) active button indicator did not shift properly with collapse of headers
3) sidebar collapse would not occur until mouse was moved from original expanded bar location
