### PR TITLE
Fix(Dashboard): keep widget event dates local

### DIFF
--- a/public/pages/dashboard.js
+++ b/public/pages/dashboard.js
@@ -8,7 +8,7 @@ import { api } from '/api.js';
 import { t, formatDate, formatTime, getLocale } from '/i18n.js';
 import { getReadableTextColor, AVATAR_FALLBACK_COLOR } from '/utils/color.js';
 import { esc, fmtLocation, renderMarkdownLight } from '/utils/html.js';
-import { toLocalDateKey } from '/utils/date.js';
+import { parseLocalDateKey, toLocalDateKey } from '/utils/date.js';
 import { predictCycle, PHASE } from '/utils/health-cycle.js';
 import { openModal, closeModal, confirmModal } from '/components/modal.js';
 import { renderAvatarStack } from '/components/user-multi-select.js';
@@ -30,6 +30,13 @@ function eventOccurrenceDateKey(event) {
 
   const date = new Date(value);
   return Number.isNaN(date.getTime()) ? value.slice(0, 10) : toLocalDateKey(date);
+}
+
+function eventOccurrenceDate(event) {
+  const occurrenceKey = eventOccurrenceDateKey(event);
+  if (/^\d{4}-\d{2}-\d{2}$/.test(occurrenceKey)) return parseLocalDateKey(occurrenceKey);
+  const fallback = new Date(event?.start_datetime || '');
+  return Number.isNaN(fallback.getTime()) ? null : fallback;
 }
 
 function calendarEventRoute(event) {
@@ -537,11 +544,10 @@ function buildTodayHighlights(data) {
 
   const urgentTask = tasks.find((task) => task.priority === 'urgent') ?? tasks[0] ?? null;
 
-  const today = new Date().toDateString();
+  const today = toLocalDateKey(new Date());
   const todayEvents = events.filter((e) => {
     if (!e.start_datetime) return true;
-    const d = new Date(e.start_datetime);
-    return d.toDateString() === today;
+    return eventOccurrenceDateKey(e) === today;
   });
   const nextEvent = todayEvents[0] ?? null;
 
@@ -650,10 +656,10 @@ function renderUpcomingEvents(events) {
     </div>`;
   }
 
-  const today = new Date().toDateString();
+  const today = toLocalDateKey(new Date());
   const items = events.map((e) => {
-    const d = new Date(e.start_datetime);
-    const isToday = d.toDateString() === today;
+    const d = eventOccurrenceDate(e);
+    const isToday = eventOccurrenceDateKey(e) === today;
     const _suffix = t('calendar.timeSuffix');
     const timeStr = e.all_day ? t('dashboard.allDay') : `${formatTime(d)}${_suffix ? ' ' + _suffix : ''}`.trim();
     return `
@@ -662,7 +668,7 @@ function renderUpcomingEvents(events) {
         <div class="event-item__content">
           <div class="event-item__title">${esc(e.title)}</div>
           <div class="event-item__time">
-            <span class="event-time-badge ${isToday ? 'event-time-badge--today' : ''}">${isToday ? t('common.today') : relativeDateLabel(new Date(e.start_datetime))}</span>
+            <span class="event-time-badge ${isToday ? 'event-time-badge--today' : ''}">${isToday ? t('common.today') : relativeDateLabel(d)}</span>
             ${timeStr}
             ${e.location ? ` · ${esc(fmtLocation(e.location))}` : ''}
             ${e.cal_name ? `<span class="event-item__cal">${esc(e.cal_name)}</span>` : ''}
@@ -2079,7 +2085,7 @@ export async function render(container, { user }) {
   }
 }
 
-export const __test = { buildTodayHighlights, normalizeVisibleMealTypes, renderTodayMeals, calendarEventRoute, eventOccurrenceDateKey };
+export const __test = { buildTodayHighlights, normalizeVisibleMealTypes, renderTodayMeals, calendarEventRoute, eventOccurrenceDateKey, eventOccurrenceDate };
 
 function wireWeatherRefresh(container, onUpdated = null) {
   const refreshBtn = container.querySelector('#weather-refresh-btn');

--- a/test/test-dashboard.js
+++ b/test/test-dashboard.js
@@ -187,6 +187,33 @@ test('Today-Highlights filtert Termine auf den heutigen Tag', async () => {
   assert(result.nextEvent.title === 'Termin Heute', 'Erwartet "Termin Heute" als nächsten Termin');
 });
 
+test('Dashboard-Date-Helper bewahrt date-only Eventtage ohne UTC-Shift', async () => {
+  const { __test } = await import('../public/pages/dashboard.js');
+  const dateKey = '2026-07-10';
+
+  const occurrenceKey = __test.eventOccurrenceDateKey({ start_datetime: dateKey, all_day: 1 });
+  const occurrenceDate = __test.eventOccurrenceDate({ start_datetime: dateKey, all_day: 1 });
+
+  assert(occurrenceKey === dateKey, `Erwartet unveränderten Date-Key ${dateKey}, erhalten ${occurrenceKey}`);
+  assert(toLocalDateKey(occurrenceDate) === dateKey, 'Date-only Event darf nicht auf den Vortag driften');
+});
+
+test('Today-Highlights behandeln date-only Events als lokalen Kalendertag', async () => {
+  const { __test } = await import('../public/pages/dashboard.js');
+  const todayStr = toLocalDateKey(new Date());
+  const tomorrowStr = addLocalDays(todayStr, 1);
+
+  const result = __test.buildTodayHighlights({
+    events: [
+      { id: 1, title: 'Ganztag heute', start_datetime: todayStr, all_day: 1 },
+      { id: 2, title: 'Ganztag morgen', start_datetime: tomorrowStr, all_day: 1 },
+    ],
+  });
+
+  assert(result.eventCount === 1, `Erwartet 1 date-only Termin für heute, erhalten ${result.eventCount}`);
+  assert(result.nextEvent.title === 'Ganztag heute', 'Date-only Event für heute sollte korrekt erkannt werden');
+});
+
 test('Today-Meals-Widget rendert nur sichtbare Mahlzeit-Typen', async () => {
   const { __test } = await import('../public/pages/dashboard.js');
   const html = __test.renderTodayMeals([


### PR DESCRIPTION
## Summary
Calendar widget was showing birthdays and all day events as the previous day in the widget.

## Root Cause: 
The dashboard widget treats date-only (all day, and birthdays for instance) event strings with new Date('YYYY-MM-DD'), which JS interprets as UTC midnight. West of UTC, that renders as the previous local day. 

What I changed:
- public/pages/dashboard.js
- Stopped using raw new Date('YYYY-MM-DD') semantics for dashboard event-day logic.
- Reused the dashboard’s occurrence-date key for “is this today?”
- date-only event comparison in today highlights
- displayed day badge for widget events
- Added eventOccurrenceDate() so date-only events become a local calendar date instead of drifting through UTC parsing.
- test/test-dashboard.js
- Added regression coverage for date-only/all-day dashboard events so they stay on the correct day.

Root cause:
- The dashboard widget parsed date-only strings like 2026-07-10 with new Date(...).
- In JS, that is interpreted as UTC midnight.
- In timezones west of UTC, it becomes the previous local date, so the widget showed events one day early.

