### PR TITLE
New Feature: Bulk shopping item import from meal plan by date range

### DIFF
--- a/public/locales/ar.json
+++ b/public/locales/ar.json
@@ -320,10 +320,10 @@
         "catDrugstore": "صيدلية",
         "catMisc": "متنوع",
         "emptyAction": "إضافة عنصر",
-        "importMeals": "From meal plan",
-        "importMealsTitle": "Import from meal plan",
-        "importMealsAction": "Import",
-        "importMealsEmpty": "No meal ingredients were found in the selected range.",
+        "importMeals": "من خطة الوجبات",
+        "importMealsTitle": "استيراد من خطة الوجبات",
+        "importMealsAction": "استيراد",
+        "importMealsEmpty": "لم يتم العثور على مكونات وجبات في النطاق المحدد.",
         "manageCategories": "إدارة الفئات"
     },
     "meals": {

--- a/public/locales/ar.json
+++ b/public/locales/ar.json
@@ -323,6 +323,7 @@
         "importMeals": "From meal plan",
         "importMealsTitle": "Import from meal plan",
         "importMealsAction": "Import",
+        "importMealsEmpty": "No meal ingredients were found in the selected range.",
         "manageCategories": "إدارة الفئات"
     },
     "meals": {

--- a/public/locales/ar.json
+++ b/public/locales/ar.json
@@ -320,6 +320,9 @@
         "catDrugstore": "صيدلية",
         "catMisc": "متنوع",
         "emptyAction": "إضافة عنصر",
+        "importMeals": "From meal plan",
+        "importMealsTitle": "Import from meal plan",
+        "importMealsAction": "Import",
         "manageCategories": "إدارة الفئات"
     },
     "meals": {

--- a/public/locales/cs.json
+++ b/public/locales/cs.json
@@ -320,10 +320,10 @@
         "catDrugstore": "Drogerie",
         "catMisc": "Různé",
         "emptyAction": "Přidat položku",
-        "importMeals": "From meal plan",
-        "importMealsTitle": "Import from meal plan",
-        "importMealsAction": "Import",
-        "importMealsEmpty": "No meal ingredients were found in the selected range.",
+        "importMeals": "Z jídelníčku",
+        "importMealsTitle": "Import z jídelníčku",
+        "importMealsAction": "Importovat",
+        "importMealsEmpty": "Ve vybraném rozsahu nebyly nalezeny žádné ingredience jídel.",
         "manageCategories": "Spravovat kategorie"
     },
     "meals": {

--- a/public/locales/cs.json
+++ b/public/locales/cs.json
@@ -323,6 +323,7 @@
         "importMeals": "From meal plan",
         "importMealsTitle": "Import from meal plan",
         "importMealsAction": "Import",
+        "importMealsEmpty": "No meal ingredients were found in the selected range.",
         "manageCategories": "Spravovat kategorie"
     },
     "meals": {

--- a/public/locales/cs.json
+++ b/public/locales/cs.json
@@ -320,6 +320,9 @@
         "catDrugstore": "Drogerie",
         "catMisc": "Různé",
         "emptyAction": "Přidat položku",
+        "importMeals": "From meal plan",
+        "importMealsTitle": "Import from meal plan",
+        "importMealsAction": "Import",
         "manageCategories": "Spravovat kategorie"
     },
     "meals": {

--- a/public/locales/de.json
+++ b/public/locales/de.json
@@ -326,6 +326,9 @@
         "catHousehold": "Haushalt",
         "catDrugstore": "Drogerie",
         "catMisc": "Sonstiges",
+        "importMeals": "Aus Essensplan",
+        "importMealsTitle": "Essensplan importieren",
+        "importMealsAction": "Importieren",
         "manageCategories": "Kategorien verwalten"
     },
     "meals": {

--- a/public/locales/de.json
+++ b/public/locales/de.json
@@ -329,6 +329,7 @@
         "importMeals": "Aus Essensplan",
         "importMealsTitle": "Essensplan importieren",
         "importMealsAction": "Importieren",
+        "importMealsEmpty": "Im gewählten Zeitraum wurden keine Essensplan-Zutaten gefunden.",
         "manageCategories": "Kategorien verwalten"
     },
     "meals": {

--- a/public/locales/el.json
+++ b/public/locales/el.json
@@ -323,6 +323,7 @@
         "importMeals": "From meal plan",
         "importMealsTitle": "Import from meal plan",
         "importMealsAction": "Import",
+        "importMealsEmpty": "No meal ingredients were found in the selected range.",
         "manageCategories": "Διαχείριση κατηγοριών"
     },
     "meals": {

--- a/public/locales/el.json
+++ b/public/locales/el.json
@@ -320,10 +320,10 @@
         "catDrugstore": "Φαρμακείο",
         "catMisc": "Διάφορα",
         "emptyAction": "Προσθήκη στοιχείου",
-        "importMeals": "From meal plan",
-        "importMealsTitle": "Import from meal plan",
-        "importMealsAction": "Import",
-        "importMealsEmpty": "No meal ingredients were found in the selected range.",
+        "importMeals": "Από το πλάνο γευμάτων",
+        "importMealsTitle": "Εισαγωγή από το πλάνο γευμάτων",
+        "importMealsAction": "Εισαγωγή",
+        "importMealsEmpty": "Δεν βρέθηκαν υλικά γευμάτων στο επιλεγμένο εύρος.",
         "manageCategories": "Διαχείριση κατηγοριών"
     },
     "meals": {

--- a/public/locales/el.json
+++ b/public/locales/el.json
@@ -320,6 +320,9 @@
         "catDrugstore": "Φαρμακείο",
         "catMisc": "Διάφορα",
         "emptyAction": "Προσθήκη στοιχείου",
+        "importMeals": "From meal plan",
+        "importMealsTitle": "Import from meal plan",
+        "importMealsAction": "Import",
         "manageCategories": "Διαχείριση κατηγοριών"
     },
     "meals": {

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -323,6 +323,7 @@
         "importMeals": "From meal plan",
         "importMealsTitle": "Import from meal plan",
         "importMealsAction": "Import",
+        "importMealsEmpty": "No meal ingredients were found in the selected range.",
         "manageCategories": "Manage categories"
     },
     "meals": {

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -320,6 +320,9 @@
         "catDrugstore": "Drugstore",
         "catMisc": "Miscellaneous",
         "emptyAction": "Add item",
+        "importMeals": "From meal plan",
+        "importMealsTitle": "Import from meal plan",
+        "importMealsAction": "Import",
         "manageCategories": "Manage categories"
     },
     "meals": {

--- a/public/locales/es.json
+++ b/public/locales/es.json
@@ -323,6 +323,7 @@
         "importMeals": "From meal plan",
         "importMealsTitle": "Import from meal plan",
         "importMealsAction": "Import",
+        "importMealsEmpty": "No meal ingredients were found in the selected range.",
         "manageCategories": "Gestionar categorías"
     },
     "meals": {

--- a/public/locales/es.json
+++ b/public/locales/es.json
@@ -320,6 +320,9 @@
         "catDrugstore": "Droguería",
         "catMisc": "Otros",
         "emptyAction": "Agregar artículo",
+        "importMeals": "From meal plan",
+        "importMealsTitle": "Import from meal plan",
+        "importMealsAction": "Import",
         "manageCategories": "Gestionar categorías"
     },
     "meals": {

--- a/public/locales/es.json
+++ b/public/locales/es.json
@@ -320,10 +320,10 @@
         "catDrugstore": "Droguería",
         "catMisc": "Otros",
         "emptyAction": "Agregar artículo",
-        "importMeals": "From meal plan",
-        "importMealsTitle": "Import from meal plan",
-        "importMealsAction": "Import",
-        "importMealsEmpty": "No meal ingredients were found in the selected range.",
+        "importMeals": "Desde el plan de comidas",
+        "importMealsTitle": "Importar desde el plan de comidas",
+        "importMealsAction": "Importar",
+        "importMealsEmpty": "No se encontraron ingredientes de comidas en el rango seleccionado.",
         "manageCategories": "Gestionar categorías"
     },
     "meals": {

--- a/public/locales/fa.json
+++ b/public/locales/fa.json
@@ -329,6 +329,7 @@
         "importMeals": "From meal plan",
         "importMealsTitle": "Import from meal plan",
         "importMealsAction": "Import",
+        "importMealsEmpty": "No meal ingredients were found in the selected range.",
         "manageCategories": "مدیریت دسته‌ها"
     },
     "meals": {

--- a/public/locales/fa.json
+++ b/public/locales/fa.json
@@ -326,10 +326,10 @@
         "catHousehold": "خانگی",
         "catDrugstore": "بهداشتی",
         "catMisc": "متفرقه",
-        "importMeals": "From meal plan",
-        "importMealsTitle": "Import from meal plan",
-        "importMealsAction": "Import",
-        "importMealsEmpty": "No meal ingredients were found in the selected range.",
+        "importMeals": "از برنامه غذایی",
+        "importMealsTitle": "درون\u200cریزی از برنامه غذایی",
+        "importMealsAction": "درون\u200cریزی",
+        "importMealsEmpty": "هیچ ماده غذایی از برنامه غذایی در بازه انتخاب\u200cشده پیدا نشد.",
         "manageCategories": "مدیریت دسته‌ها"
     },
     "meals": {

--- a/public/locales/fa.json
+++ b/public/locales/fa.json
@@ -326,6 +326,9 @@
         "catHousehold": "خانگی",
         "catDrugstore": "بهداشتی",
         "catMisc": "متفرقه",
+        "importMeals": "From meal plan",
+        "importMealsTitle": "Import from meal plan",
+        "importMealsAction": "Import",
         "manageCategories": "مدیریت دسته‌ها"
     },
     "meals": {

--- a/public/locales/fr.json
+++ b/public/locales/fr.json
@@ -320,6 +320,9 @@
         "catDrugstore": "Pharmacie",
         "catMisc": "Divers",
         "emptyAction": "Ajouter un article",
+        "importMeals": "From meal plan",
+        "importMealsTitle": "Import from meal plan",
+        "importMealsAction": "Import",
         "manageCategories": "Gérer les catégories"
     },
     "meals": {

--- a/public/locales/fr.json
+++ b/public/locales/fr.json
@@ -323,6 +323,7 @@
         "importMeals": "From meal plan",
         "importMealsTitle": "Import from meal plan",
         "importMealsAction": "Import",
+        "importMealsEmpty": "No meal ingredients were found in the selected range.",
         "manageCategories": "Gérer les catégories"
     },
     "meals": {

--- a/public/locales/fr.json
+++ b/public/locales/fr.json
@@ -320,10 +320,10 @@
         "catDrugstore": "Pharmacie",
         "catMisc": "Divers",
         "emptyAction": "Ajouter un article",
-        "importMeals": "From meal plan",
-        "importMealsTitle": "Import from meal plan",
-        "importMealsAction": "Import",
-        "importMealsEmpty": "No meal ingredients were found in the selected range.",
+        "importMeals": "Depuis le plan de repas",
+        "importMealsTitle": "Importer depuis le plan de repas",
+        "importMealsAction": "Importer",
+        "importMealsEmpty": "Aucun ingrédient de repas n'a été trouvé dans la période sélectionnée.",
         "manageCategories": "Gérer les catégories"
     },
     "meals": {

--- a/public/locales/hi.json
+++ b/public/locales/hi.json
@@ -320,6 +320,9 @@
         "catDrugstore": "दवाखाना",
         "catMisc": "विविध",
         "emptyAction": "आइटम जोड़ें",
+        "importMeals": "From meal plan",
+        "importMealsTitle": "Import from meal plan",
+        "importMealsAction": "Import",
         "manageCategories": "श्रेणियाँ प्रबंधित करें"
     },
     "meals": {

--- a/public/locales/hi.json
+++ b/public/locales/hi.json
@@ -323,6 +323,7 @@
         "importMeals": "From meal plan",
         "importMealsTitle": "Import from meal plan",
         "importMealsAction": "Import",
+        "importMealsEmpty": "No meal ingredients were found in the selected range.",
         "manageCategories": "श्रेणियाँ प्रबंधित करें"
     },
     "meals": {

--- a/public/locales/hi.json
+++ b/public/locales/hi.json
@@ -320,10 +320,10 @@
         "catDrugstore": "दवाखाना",
         "catMisc": "विविध",
         "emptyAction": "आइटम जोड़ें",
-        "importMeals": "From meal plan",
-        "importMealsTitle": "Import from meal plan",
-        "importMealsAction": "Import",
-        "importMealsEmpty": "No meal ingredients were found in the selected range.",
+        "importMeals": "भोजन योजना से",
+        "importMealsTitle": "भोजन योजना से आयात करें",
+        "importMealsAction": "आयात करें",
+        "importMealsEmpty": "चयनित अवधि में भोजन योजना की कोई सामग्री नहीं मिली।",
         "manageCategories": "श्रेणियाँ प्रबंधित करें"
     },
     "meals": {

--- a/public/locales/hu.json
+++ b/public/locales/hu.json
@@ -320,10 +320,10 @@
         "catDrugstore": "Gyógyszertár",
         "catMisc": "Vegyes",
         "emptyAction": "Elem hozzáadása",
-        "importMeals": "From meal plan",
-        "importMealsTitle": "Import from meal plan",
-        "importMealsAction": "Import",
-        "importMealsEmpty": "No meal ingredients were found in the selected range.",
+        "importMeals": "Étkezési tervből",
+        "importMealsTitle": "Importálás az étkezési tervből",
+        "importMealsAction": "Importálás",
+        "importMealsEmpty": "A kiválasztott időszakban nem találhatók étkezési hozzávalók.",
         "manageCategories": "Kategóriák kezelése"
     },
     "meals": {

--- a/public/locales/hu.json
+++ b/public/locales/hu.json
@@ -320,6 +320,9 @@
         "catDrugstore": "Gyógyszertár",
         "catMisc": "Vegyes",
         "emptyAction": "Elem hozzáadása",
+        "importMeals": "From meal plan",
+        "importMealsTitle": "Import from meal plan",
+        "importMealsAction": "Import",
         "manageCategories": "Kategóriák kezelése"
     },
     "meals": {

--- a/public/locales/hu.json
+++ b/public/locales/hu.json
@@ -323,6 +323,7 @@
         "importMeals": "From meal plan",
         "importMealsTitle": "Import from meal plan",
         "importMealsAction": "Import",
+        "importMealsEmpty": "No meal ingredients were found in the selected range.",
         "manageCategories": "Kategóriák kezelése"
     },
     "meals": {

--- a/public/locales/id.json
+++ b/public/locales/id.json
@@ -329,6 +329,7 @@
         "importMeals": "From meal plan",
         "importMealsTitle": "Import from meal plan",
         "importMealsAction": "Import",
+        "importMealsEmpty": "No meal ingredients were found in the selected range.",
         "manageCategories": "Kelola kategori"
     },
     "meals": {

--- a/public/locales/id.json
+++ b/public/locales/id.json
@@ -326,6 +326,9 @@
         "catHousehold": "Rumah tangga",
         "catDrugstore": "Perlengkapan mandi",
         "catMisc": "Lainnya",
+        "importMeals": "From meal plan",
+        "importMealsTitle": "Import from meal plan",
+        "importMealsAction": "Import",
         "manageCategories": "Kelola kategori"
     },
     "meals": {

--- a/public/locales/id.json
+++ b/public/locales/id.json
@@ -326,10 +326,10 @@
         "catHousehold": "Rumah tangga",
         "catDrugstore": "Perlengkapan mandi",
         "catMisc": "Lainnya",
-        "importMeals": "From meal plan",
-        "importMealsTitle": "Import from meal plan",
-        "importMealsAction": "Import",
-        "importMealsEmpty": "No meal ingredients were found in the selected range.",
+        "importMeals": "Dari rencana makan",
+        "importMealsTitle": "Impor dari rencana makan",
+        "importMealsAction": "Impor",
+        "importMealsEmpty": "Tidak ada bahan makanan yang ditemukan dalam rentang yang dipilih.",
         "manageCategories": "Kelola kategori"
     },
     "meals": {

--- a/public/locales/it.json
+++ b/public/locales/it.json
@@ -320,6 +320,9 @@
         "catDrugstore": "Drogheria",
         "catMisc": "Varie",
         "emptyAction": "Aggiungi articolo",
+        "importMeals": "From meal plan",
+        "importMealsTitle": "Import from meal plan",
+        "importMealsAction": "Import",
         "manageCategories": "Gestisci categorie"
     },
     "meals": {

--- a/public/locales/it.json
+++ b/public/locales/it.json
@@ -320,10 +320,10 @@
         "catDrugstore": "Drogheria",
         "catMisc": "Varie",
         "emptyAction": "Aggiungi articolo",
-        "importMeals": "From meal plan",
-        "importMealsTitle": "Import from meal plan",
-        "importMealsAction": "Import",
-        "importMealsEmpty": "No meal ingredients were found in the selected range.",
+        "importMeals": "Dal piano pasti",
+        "importMealsTitle": "Importa dal piano pasti",
+        "importMealsAction": "Importa",
+        "importMealsEmpty": "Nell'intervallo selezionato non sono stati trovati ingredienti dei pasti.",
         "manageCategories": "Gestisci categorie"
     },
     "meals": {

--- a/public/locales/it.json
+++ b/public/locales/it.json
@@ -323,6 +323,7 @@
         "importMeals": "From meal plan",
         "importMealsTitle": "Import from meal plan",
         "importMealsAction": "Import",
+        "importMealsEmpty": "No meal ingredients were found in the selected range.",
         "manageCategories": "Gestisci categorie"
     },
     "meals": {

--- a/public/locales/ja.json
+++ b/public/locales/ja.json
@@ -320,6 +320,9 @@
         "catDrugstore": "薬局",
         "catMisc": "その他",
         "emptyAction": "アイテムを追加",
+        "importMeals": "From meal plan",
+        "importMealsTitle": "Import from meal plan",
+        "importMealsAction": "Import",
         "manageCategories": "カテゴリを管理"
     },
     "meals": {

--- a/public/locales/ja.json
+++ b/public/locales/ja.json
@@ -320,10 +320,10 @@
         "catDrugstore": "薬局",
         "catMisc": "その他",
         "emptyAction": "アイテムを追加",
-        "importMeals": "From meal plan",
-        "importMealsTitle": "Import from meal plan",
-        "importMealsAction": "Import",
-        "importMealsEmpty": "No meal ingredients were found in the selected range.",
+        "importMeals": "献立から",
+        "importMealsTitle": "献立からインポート",
+        "importMealsAction": "インポート",
+        "importMealsEmpty": "選択した期間内に献立の材料が見つかりませんでした。",
         "manageCategories": "カテゴリを管理"
     },
     "meals": {

--- a/public/locales/ja.json
+++ b/public/locales/ja.json
@@ -323,6 +323,7 @@
         "importMeals": "From meal plan",
         "importMealsTitle": "Import from meal plan",
         "importMealsAction": "Import",
+        "importMealsEmpty": "No meal ingredients were found in the selected range.",
         "manageCategories": "カテゴリを管理"
     },
     "meals": {

--- a/public/locales/ko.json
+++ b/public/locales/ko.json
@@ -326,10 +326,10 @@
         "catHousehold": "생활용품",
         "catDrugstore": "생활잡화",
         "catMisc": "기타",
-        "importMeals": "From meal plan",
-        "importMealsTitle": "Import from meal plan",
-        "importMealsAction": "Import",
-        "importMealsEmpty": "No meal ingredients were found in the selected range.",
+        "importMeals": "식단에서",
+        "importMealsTitle": "식단에서 가져오기",
+        "importMealsAction": "가져오기",
+        "importMealsEmpty": "선택한 기간에 식단 재료가 없습니다.",
         "manageCategories": "카테고리 관리"
     },
     "meals": {

--- a/public/locales/ko.json
+++ b/public/locales/ko.json
@@ -329,6 +329,7 @@
         "importMeals": "From meal plan",
         "importMealsTitle": "Import from meal plan",
         "importMealsAction": "Import",
+        "importMealsEmpty": "No meal ingredients were found in the selected range.",
         "manageCategories": "카테고리 관리"
     },
     "meals": {

--- a/public/locales/ko.json
+++ b/public/locales/ko.json
@@ -326,6 +326,9 @@
         "catHousehold": "생활용품",
         "catDrugstore": "생활잡화",
         "catMisc": "기타",
+        "importMeals": "From meal plan",
+        "importMealsTitle": "Import from meal plan",
+        "importMealsAction": "Import",
         "manageCategories": "카테고리 관리"
     },
     "meals": {

--- a/public/locales/nl.json
+++ b/public/locales/nl.json
@@ -320,6 +320,9 @@
         "catDrugstore": "Drogisterij",
         "catMisc": "Overig",
         "emptyAction": "Item toevoegen",
+        "importMeals": "From meal plan",
+        "importMealsTitle": "Import from meal plan",
+        "importMealsAction": "Import",
         "manageCategories": "Categorieën beheren"
     },
     "meals": {

--- a/public/locales/nl.json
+++ b/public/locales/nl.json
@@ -323,6 +323,7 @@
         "importMeals": "From meal plan",
         "importMealsTitle": "Import from meal plan",
         "importMealsAction": "Import",
+        "importMealsEmpty": "No meal ingredients were found in the selected range.",
         "manageCategories": "Categorieën beheren"
     },
     "meals": {

--- a/public/locales/nl.json
+++ b/public/locales/nl.json
@@ -320,10 +320,10 @@
         "catDrugstore": "Drogisterij",
         "catMisc": "Overig",
         "emptyAction": "Item toevoegen",
-        "importMeals": "From meal plan",
-        "importMealsTitle": "Import from meal plan",
-        "importMealsAction": "Import",
-        "importMealsEmpty": "No meal ingredients were found in the selected range.",
+        "importMeals": "Uit maaltijdplan",
+        "importMealsTitle": "Importeren uit maaltijdplan",
+        "importMealsAction": "Importeren",
+        "importMealsEmpty": "Er zijn geen maaltijdingrediënten gevonden in de geselecteerde periode.",
         "manageCategories": "Categorieën beheren"
     },
     "meals": {

--- a/public/locales/pl.json
+++ b/public/locales/pl.json
@@ -326,10 +326,10 @@
         "catHousehold": "Dom",
         "catDrugstore": "Drogeria",
         "catMisc": "Inne",
-        "importMeals": "From meal plan",
-        "importMealsTitle": "Import from meal plan",
-        "importMealsAction": "Import",
-        "importMealsEmpty": "No meal ingredients were found in the selected range.",
+        "importMeals": "Z planu posiłków",
+        "importMealsTitle": "Importuj z planu posiłków",
+        "importMealsAction": "Importuj",
+        "importMealsEmpty": "Nie znaleziono składników posiłków w wybranym zakresie dat.",
         "manageCategories": "Zarządzaj kategoriami"
     },
     "meals": {

--- a/public/locales/pl.json
+++ b/public/locales/pl.json
@@ -326,6 +326,9 @@
         "catHousehold": "Dom",
         "catDrugstore": "Drogeria",
         "catMisc": "Inne",
+        "importMeals": "From meal plan",
+        "importMealsTitle": "Import from meal plan",
+        "importMealsAction": "Import",
         "manageCategories": "Zarządzaj kategoriami"
     },
     "meals": {

--- a/public/locales/pl.json
+++ b/public/locales/pl.json
@@ -329,6 +329,7 @@
         "importMeals": "From meal plan",
         "importMealsTitle": "Import from meal plan",
         "importMealsAction": "Import",
+        "importMealsEmpty": "No meal ingredients were found in the selected range.",
         "manageCategories": "Zarządzaj kategoriami"
     },
     "meals": {

--- a/public/locales/pt.json
+++ b/public/locales/pt.json
@@ -320,10 +320,10 @@
         "catDrugstore": "Farmácia",
         "catMisc": "Outros",
         "emptyAction": "Adicionar item",
-        "importMeals": "From meal plan",
-        "importMealsTitle": "Import from meal plan",
-        "importMealsAction": "Import",
-        "importMealsEmpty": "No meal ingredients were found in the selected range.",
+        "importMeals": "Do plano de refeições",
+        "importMealsTitle": "Importar do plano de refeições",
+        "importMealsAction": "Importar",
+        "importMealsEmpty": "Não foram encontrados ingredientes de refeições no intervalo selecionado.",
         "manageCategories": "Gerir categorias"
     },
     "meals": {

--- a/public/locales/pt.json
+++ b/public/locales/pt.json
@@ -320,6 +320,9 @@
         "catDrugstore": "Farmácia",
         "catMisc": "Outros",
         "emptyAction": "Adicionar item",
+        "importMeals": "From meal plan",
+        "importMealsTitle": "Import from meal plan",
+        "importMealsAction": "Import",
         "manageCategories": "Gerir categorias"
     },
     "meals": {

--- a/public/locales/pt.json
+++ b/public/locales/pt.json
@@ -323,6 +323,7 @@
         "importMeals": "From meal plan",
         "importMealsTitle": "Import from meal plan",
         "importMealsAction": "Import",
+        "importMealsEmpty": "No meal ingredients were found in the selected range.",
         "manageCategories": "Gerir categorias"
     },
     "meals": {

--- a/public/locales/ru.json
+++ b/public/locales/ru.json
@@ -320,6 +320,9 @@
         "catDrugstore": "Аптека",
         "catMisc": "Разное",
         "emptyAction": "Добавить товар",
+        "importMeals": "From meal plan",
+        "importMealsTitle": "Import from meal plan",
+        "importMealsAction": "Import",
         "manageCategories": "Управление категориями"
     },
     "meals": {

--- a/public/locales/ru.json
+++ b/public/locales/ru.json
@@ -320,10 +320,10 @@
         "catDrugstore": "Аптека",
         "catMisc": "Разное",
         "emptyAction": "Добавить товар",
-        "importMeals": "From meal plan",
-        "importMealsTitle": "Import from meal plan",
-        "importMealsAction": "Import",
-        "importMealsEmpty": "No meal ingredients were found in the selected range.",
+        "importMeals": "Из плана питания",
+        "importMealsTitle": "Импорт из плана питания",
+        "importMealsAction": "Импортировать",
+        "importMealsEmpty": "В выбранном диапазоне не найдено ингредиентов блюд.",
         "manageCategories": "Управление категориями"
     },
     "meals": {

--- a/public/locales/ru.json
+++ b/public/locales/ru.json
@@ -323,6 +323,7 @@
         "importMeals": "From meal plan",
         "importMealsTitle": "Import from meal plan",
         "importMealsAction": "Import",
+        "importMealsEmpty": "No meal ingredients were found in the selected range.",
         "manageCategories": "Управление категориями"
     },
     "meals": {

--- a/public/locales/sv.json
+++ b/public/locales/sv.json
@@ -320,10 +320,10 @@
         "catDrugstore": "Apotek",
         "catMisc": "Diverse",
         "emptyAction": "Lägg till artikel",
-        "importMeals": "From meal plan",
-        "importMealsTitle": "Import from meal plan",
-        "importMealsAction": "Import",
-        "importMealsEmpty": "No meal ingredients were found in the selected range.",
+        "importMeals": "Från matplanen",
+        "importMealsTitle": "Importera från matplanen",
+        "importMealsAction": "Importera",
+        "importMealsEmpty": "Inga måltidsingredienser hittades i det valda intervallet.",
         "manageCategories": "Hantera kategorier"
     },
     "meals": {

--- a/public/locales/sv.json
+++ b/public/locales/sv.json
@@ -323,6 +323,7 @@
         "importMeals": "From meal plan",
         "importMealsTitle": "Import from meal plan",
         "importMealsAction": "Import",
+        "importMealsEmpty": "No meal ingredients were found in the selected range.",
         "manageCategories": "Hantera kategorier"
     },
     "meals": {

--- a/public/locales/sv.json
+++ b/public/locales/sv.json
@@ -320,6 +320,9 @@
         "catDrugstore": "Apotek",
         "catMisc": "Diverse",
         "emptyAction": "Lägg till artikel",
+        "importMeals": "From meal plan",
+        "importMealsTitle": "Import from meal plan",
+        "importMealsAction": "Import",
         "manageCategories": "Hantera kategorier"
     },
     "meals": {

--- a/public/locales/tr.json
+++ b/public/locales/tr.json
@@ -320,6 +320,9 @@
         "catDrugstore": "Eczane",
         "catMisc": "Diğer",
         "emptyAction": "Öğe ekle",
+        "importMeals": "From meal plan",
+        "importMealsTitle": "Import from meal plan",
+        "importMealsAction": "Import",
         "manageCategories": "Kategorileri yönet"
     },
     "meals": {

--- a/public/locales/tr.json
+++ b/public/locales/tr.json
@@ -320,10 +320,10 @@
         "catDrugstore": "Eczane",
         "catMisc": "Diğer",
         "emptyAction": "Öğe ekle",
-        "importMeals": "From meal plan",
-        "importMealsTitle": "Import from meal plan",
-        "importMealsAction": "Import",
-        "importMealsEmpty": "No meal ingredients were found in the selected range.",
+        "importMeals": "Yemek planından",
+        "importMealsTitle": "Yemek planından içe aktar",
+        "importMealsAction": "İçe aktar",
+        "importMealsEmpty": "Seçilen aralıkta yemek malzemesi bulunamadı.",
         "manageCategories": "Kategorileri yönet"
     },
     "meals": {

--- a/public/locales/tr.json
+++ b/public/locales/tr.json
@@ -323,6 +323,7 @@
         "importMeals": "From meal plan",
         "importMealsTitle": "Import from meal plan",
         "importMealsAction": "Import",
+        "importMealsEmpty": "No meal ingredients were found in the selected range.",
         "manageCategories": "Kategorileri yönet"
     },
     "meals": {

--- a/public/locales/uk.json
+++ b/public/locales/uk.json
@@ -320,10 +320,10 @@
         "catDrugstore": "Аптека",
         "catMisc": "Різне",
         "emptyAction": "Додати товар",
-        "importMeals": "From meal plan",
-        "importMealsTitle": "Import from meal plan",
-        "importMealsAction": "Import",
-        "importMealsEmpty": "No meal ingredients were found in the selected range.",
+        "importMeals": "З плану харчування",
+        "importMealsTitle": "Імпортувати з плану харчування",
+        "importMealsAction": "Імпортувати",
+        "importMealsEmpty": "У вибраному діапазоні не знайдено інгредієнтів страв.",
         "manageCategories": "Керувати категоріями"
     },
     "meals": {

--- a/public/locales/uk.json
+++ b/public/locales/uk.json
@@ -323,6 +323,7 @@
         "importMeals": "From meal plan",
         "importMealsTitle": "Import from meal plan",
         "importMealsAction": "Import",
+        "importMealsEmpty": "No meal ingredients were found in the selected range.",
         "manageCategories": "Керувати категоріями"
     },
     "meals": {

--- a/public/locales/uk.json
+++ b/public/locales/uk.json
@@ -320,6 +320,9 @@
         "catDrugstore": "Аптека",
         "catMisc": "Різне",
         "emptyAction": "Додати товар",
+        "importMeals": "From meal plan",
+        "importMealsTitle": "Import from meal plan",
+        "importMealsAction": "Import",
         "manageCategories": "Керувати категоріями"
     },
     "meals": {

--- a/public/locales/vi.json
+++ b/public/locales/vi.json
@@ -320,6 +320,9 @@
         "catDrugstore": "Nhà thuốc",
         "catMisc": "Khác",
         "emptyAction": "Thêm mục",
+        "importMeals": "From meal plan",
+        "importMealsTitle": "Import from meal plan",
+        "importMealsAction": "Import",
         "manageCategories": "Quản lý danh mục"
     },
     "meals": {

--- a/public/locales/vi.json
+++ b/public/locales/vi.json
@@ -323,6 +323,7 @@
         "importMeals": "From meal plan",
         "importMealsTitle": "Import from meal plan",
         "importMealsAction": "Import",
+        "importMealsEmpty": "No meal ingredients were found in the selected range.",
         "manageCategories": "Quản lý danh mục"
     },
     "meals": {

--- a/public/locales/vi.json
+++ b/public/locales/vi.json
@@ -320,10 +320,10 @@
         "catDrugstore": "Nhà thuốc",
         "catMisc": "Khác",
         "emptyAction": "Thêm mục",
-        "importMeals": "From meal plan",
-        "importMealsTitle": "Import from meal plan",
-        "importMealsAction": "Import",
-        "importMealsEmpty": "No meal ingredients were found in the selected range.",
+        "importMeals": "Từ kế hoạch bữa ăn",
+        "importMealsTitle": "Nhập từ kế hoạch bữa ăn",
+        "importMealsAction": "Nhập",
+        "importMealsEmpty": "Không tìm thấy nguyên liệu bữa ăn nào trong phạm vi đã chọn.",
         "manageCategories": "Quản lý danh mục"
     },
     "meals": {

--- a/public/locales/zh.json
+++ b/public/locales/zh.json
@@ -323,6 +323,7 @@
         "importMeals": "From meal plan",
         "importMealsTitle": "Import from meal plan",
         "importMealsAction": "Import",
+        "importMealsEmpty": "No meal ingredients were found in the selected range.",
         "manageCategories": "管理分类"
     },
     "meals": {

--- a/public/locales/zh.json
+++ b/public/locales/zh.json
@@ -320,6 +320,9 @@
         "catDrugstore": "日化",
         "catMisc": "其他",
         "emptyAction": "添加商品",
+        "importMeals": "From meal plan",
+        "importMealsTitle": "Import from meal plan",
+        "importMealsAction": "Import",
         "manageCategories": "管理分类"
     },
     "meals": {

--- a/public/locales/zh.json
+++ b/public/locales/zh.json
@@ -320,10 +320,10 @@
         "catDrugstore": "日化",
         "catMisc": "其他",
         "emptyAction": "添加商品",
-        "importMeals": "From meal plan",
-        "importMealsTitle": "Import from meal plan",
-        "importMealsAction": "Import",
-        "importMealsEmpty": "No meal ingredients were found in the selected range.",
+        "importMeals": "从餐食计划",
+        "importMealsTitle": "从餐食计划导入",
+        "importMealsAction": "导入",
+        "importMealsEmpty": "在所选范围内未找到餐食配料。",
         "manageCategories": "管理分类"
     },
     "meals": {

--- a/public/pages/shopping.js
+++ b/public/pages/shopping.js
@@ -10,6 +10,7 @@ import { t } from '/i18n.js';
 import { esc } from '/utils/html.js';
 import { promptModal, openModal, closeModal } from '/components/modal.js';
 import { DEFAULT_CATEGORY_NAME, categoryLabel } from '/utils/shopping-categories.js';
+import { addLocalDays, toLocalDateKey } from '/utils/date.js';
 import { renderKitchenTabsBar } from '/utils/kitchen-tabs.js';
 import '/components/shopping-category-manager.js';
 
@@ -169,6 +170,12 @@ function renderListContent(container) {
             <i data-lucide="trash-2" class="icon-md" aria-hidden="true"></i>
             ${t('shopping.clearChecked', { count: checkedCount })}
           </button>` : ''}
+        <button class="btn btn--ghost list-header__import-btn" data-action="import-meals"
+                aria-label="${t('shopping.importMeals')}" title="${t('shopping.importMeals')}"
+                style="color:var(--color-text-secondary)">
+          <i data-lucide="utensils" class="icon-md" aria-hidden="true"></i>
+          <span>${t('shopping.importMeals')}</span>
+        </button>
         <button class="btn btn--ghost btn--icon" data-action="manage-categories"
                 aria-label="${t('shopping.manageCategories')}" title="${t('shopping.manageCategories')}"
                 style="color:var(--color-text-secondary)">
@@ -775,6 +782,59 @@ function updateListCounter(listId, totalDelta, checkedDelta) {
   }
 }
 
+function openMealPlanImport(container) {
+  if (!state.activeListId) return;
+  const today = toLocalDateKey(new Date());
+  const defaultTo = addLocalDays(today, 6);
+
+  openModal({
+    title: t('shopping.importMealsTitle'),
+    size: 'sm',
+    content: `
+      <form id="shopping-import-meals-form" class="shopping-import-meals-form" novalidate autocomplete="off">
+        <div class="form-group">
+          <label class="form-label" for="shopping-import-from">${t('calendar.fromLabel')}</label>
+          <input class="form-input" type="date" id="shopping-import-from" value="${esc(today)}" required>
+        </div>
+        <div class="form-group">
+          <label class="form-label" for="shopping-import-to">${t('calendar.toLabel')}</label>
+          <input class="form-input" type="date" id="shopping-import-to" value="${esc(defaultTo)}" required>
+        </div>
+        <div class="modal-actions">
+          <button type="button" class="btn btn--secondary" id="shopping-import-cancel">${t('common.cancel')}</button>
+          <button type="submit" class="btn btn--primary">${t('shopping.importMealsAction')}</button>
+        </div>
+      </form>`,
+    onSave: (panel) => {
+      const form = panel.querySelector('#shopping-import-meals-form');
+      const cancelBtn = panel.querySelector('#shopping-import-cancel');
+      cancelBtn?.addEventListener('click', () => closeModal());
+      form?.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const from = panel.querySelector('#shopping-import-from')?.value || '';
+        const to = panel.querySelector('#shopping-import-to')?.value || '';
+        if (!from || !to) return;
+        try {
+          const data = await api.post(`/shopping/${state.activeListId}/import-meal-plan`, { from, to });
+          if (!data.data?.transferred) {
+            window.yuvomi.showToast(t('meals.transferAlreadyDone'), 'default');
+            return;
+          }
+          await Promise.all([loadLists(), loadItems(state.activeListId)]);
+          renderTabs(container);
+          renderListContent(container);
+          wireListContentEvents(container);
+          closeModal();
+          const count = Number(data.data.transferred) || 0;
+          window.yuvomi.showToast(count === 1 ? t('meals.transferSuccess', { count }) : t('meals.transferSuccessPlural', { count }), 'success');
+        } catch (err) {
+          window.yuvomi.showToast(err.data?.error ?? t('common.errorGeneric'), 'danger');
+        }
+      });
+    },
+  });
+}
+
 // --------------------------------------------------------
 // API-Aktionen
 // --------------------------------------------------------
@@ -987,6 +1047,10 @@ function wireListContentEvents(container) {
     // ---- Kategorien verwalten ----
     if (action === 'manage-categories') {
       openCategoryManager(container);
+    }
+
+    if (action === 'import-meals') {
+      openMealPlanImport(container);
     }
 
     // ---- Liste umbenennen ----

--- a/public/pages/shopping.js
+++ b/public/pages/shopping.js
@@ -817,7 +817,7 @@ function openMealPlanImport(container) {
         try {
           const data = await api.post(`/shopping/${state.activeListId}/import-meal-plan`, { from, to });
           if (!data.data?.transferred) {
-            window.yuvomi.showToast(t('meals.transferAlreadyDone'), 'default');
+            window.yuvomi.showToast(t('shopping.importMealsEmpty'), 'default');
             return;
           }
           await Promise.all([loadLists(), loadItems(state.activeListId)]);

--- a/public/styles/shopping.css
+++ b/public/styles/shopping.css
@@ -161,6 +161,32 @@
   flex-shrink: 0;
 }
 
+.list-header__import-btn {
+  gap: var(--space-2);
+}
+
+.shopping-import-meals-form {
+  display: grid;
+  gap: var(--space-3);
+}
+
+@media (max-width: 767px) {
+  .list-header {
+    align-items: flex-start;
+    flex-wrap: wrap;
+  }
+
+  .list-header__actions {
+    width: 100%;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+  }
+
+  .list-header__import-btn span {
+    display: none;
+  }
+}
+
 /* --------------------------------------------------------
  * Quick-Add Eingabe
  * -------------------------------------------------------- */

--- a/server/routes/shopping.js
+++ b/server/routes/shopping.js
@@ -10,7 +10,8 @@
 import { createLogger } from '../logger.js';
 import express from 'express';
 import * as db from '../db.js';
-import { str, oneOf, url, collectErrors, MAX_TITLE, MAX_SHORT, MAX_TEXT } from '../middleware/validate.js';
+import { str, oneOf, url, date, collectErrors, MAX_TITLE, MAX_SHORT, MAX_TEXT } from '../middleware/validate.js';
+import { aggregateMealIngredients } from '../services/shopping-import.js';
 
 const log = createLogger('Shopping');
 
@@ -438,6 +439,64 @@ router.post('/:listId/items', (req, res) => {
     res.status(201).json({ data: item });
   } catch (err) {
     log.error('POST /:listId/items error:', err);
+    res.status(500).json({ error: 'Internal server error.', code: 500 });
+  }
+});
+
+// --------------------------------------------------------
+// POST /api/v1/shopping/:listId/import-meal-plan
+// Importiert Zutaten aus dem Essensplan eines Datumsbereichs in eine Liste.
+// Body: { from: YYYY-MM-DD, to: YYYY-MM-DD }
+// Response: { data: { transferred: number, added: number } }
+// --------------------------------------------------------
+router.post('/:listId/import-meal-plan', (req, res) => {
+  try {
+    const list = db.get()
+      .prepare('SELECT id FROM shopping_lists WHERE id = ?')
+      .get(req.params.listId);
+    if (!list) return res.status(404).json({ error: 'List not found.', code: 404 });
+
+    const vFrom = date(req.body.from, 'From date', true);
+    const vTo = date(req.body.to, 'To date', true);
+    const errors = collectErrors([vFrom, vTo]);
+    if (errors.length) return res.status(400).json({ error: errors.join(' '), code: 400 });
+    if (vFrom.value > vTo.value) {
+      return res.status(400).json({ error: 'From date must be before or equal to end date.', code: 400 });
+    }
+
+    const ingredients = db.get().prepare(`
+      SELECT mi.id, mi.meal_id, mi.name, mi.quantity, mi.category
+      FROM meal_ingredients mi
+      JOIN meals m ON m.id = mi.meal_id
+      WHERE m.date BETWEEN ? AND ?
+        AND mi.on_shopping_list = 0
+      ORDER BY m.date ASC, mi.id ASC
+    `).all(vFrom.value, vTo.value);
+
+    if (!ingredients.length) {
+      return res.json({ data: { transferred: 0, added: 0 } });
+    }
+
+    const aggregated = aggregateMealIngredients(ingredients);
+    const added = db.get().transaction(() => {
+      const insertItem = db.get().prepare(`
+        INSERT INTO shopping_items (list_id, name, quantity, category, added_from_meal)
+        VALUES (?, ?, ?, ?, ?)
+      `);
+      const markDone = db.get().prepare('UPDATE meal_ingredients SET on_shopping_list = 1 WHERE id = ?');
+
+      for (const item of aggregated) {
+        insertItem.run(req.params.listId, item.name, item.quantity, item.category, item.added_from_meal);
+      }
+      for (const ingredient of ingredients) {
+        markDone.run(ingredient.id);
+      }
+      return aggregated.length;
+    })();
+
+    res.json({ data: { transferred: ingredients.length, added } });
+  } catch (err) {
+    log.error('POST /:listId/import-meal-plan error:', err);
     res.status(500).json({ error: 'Internal server error.', code: 500 });
   }
 });

--- a/server/services/shopping-import.js
+++ b/server/services/shopping-import.js
@@ -1,0 +1,68 @@
+function parseQuantity(value) {
+  const raw = String(value || '').trim();
+  if (!raw) return null;
+  const match = raw.match(/^([+-]?\d+(?:[.,]\d+)?)\s*(.*)$/);
+  if (!match) return null;
+  const amount = Number(match[1].replace(',', '.'));
+  if (!Number.isFinite(amount)) return null;
+  const unit = match[2].trim().replace(/\s+/g, ' ').toLowerCase();
+  return { amount, unit };
+}
+
+function formatQuantity(amount, unit) {
+  const rounded = Math.round(amount * 100) / 100;
+  const number = Number.isInteger(rounded) ? String(rounded) : String(rounded).replace(/\.0+$/, '').replace(/(\.\d*?)0+$/, '$1');
+  return unit ? `${number} ${unit}` : number;
+}
+
+function aggregateMealIngredients(ingredients = []) {
+  const groups = new Map();
+
+  for (const ingredient of ingredients) {
+    const name = String(ingredient?.name || '').trim();
+    if (!name) continue;
+    const category = String(ingredient?.category || 'Sonstiges').trim() || 'Sonstiges';
+    const parsed = parseQuantity(ingredient?.quantity);
+    const quantity = String(ingredient?.quantity || '').trim();
+    const key = parsed
+      ? `${name.toLowerCase()}\u0000${category}\u0000parsed\u0000${parsed.unit}`
+      : `${name.toLowerCase()}\u0000${category}\u0000raw\u0000${quantity.toLowerCase()}`;
+
+    if (!groups.has(key)) {
+      groups.set(key, {
+        name,
+        category,
+        quantity: quantity || null,
+        amount: 0,
+        unit: parsed?.unit ?? '',
+        mealIds: new Set(),
+        ingredientIds: [],
+        count: 0,
+      });
+    }
+
+    const group = groups.get(key);
+    group.count += 1;
+    if (parsed) {
+      group.amount = (group.amount ?? 0) + parsed.amount;
+      group.quantity = formatQuantity(group.amount, group.unit);
+    } else if (!quantity) {
+      group.quantity = null;
+    } else if (group.count > 1) {
+      group.quantity = `${group.count} x ${quantity}`;
+    }
+
+    if (ingredient.meal_id != null) group.mealIds.add(ingredient.meal_id);
+    if (ingredient.id != null) group.ingredientIds.push(ingredient.id);
+  }
+
+  return [...groups.values()].map((group) => ({
+    name: group.name,
+    category: group.category,
+    quantity: group.quantity,
+    added_from_meal: group.mealIds.size === 1 ? [...group.mealIds][0] : null,
+    ingredientIds: group.ingredientIds,
+  }));
+}
+
+export { aggregateMealIngredients, parseQuantity };

--- a/test/test-shopping.js
+++ b/test/test-shopping.js
@@ -8,6 +8,7 @@ import { DatabaseSync } from 'node:sqlite';
 import { readFileSync } from 'node:fs';
 import { MIGRATIONS_SQL } from '../server/db-schema-test.js';
 import { url } from '../server/middleware/validate.js';
+import { aggregateMealIngredients } from '../server/services/shopping-import.js';
 
 let passed = 0;
 let failed = 0;
@@ -51,6 +52,16 @@ test('Shopping-Seite importiert den Category-Manager und öffnet ihn bei manage=
   assert(/manage.*===\s*'categories'|get\('manage'\)|manage=categories|'manage'/.test(source), 'shopping.js muss den manage-Query-Parameter auswerten');
   assert(/shopping\.manageCategories/.test(source), 'Eine übersetzte „Kategorien verwalten"-Aktion muss vorhanden sein');
   assert(/shopping-categories-changed/.test(source), 'shopping.js muss auf das shopping-categories-changed-Event reagieren');
+});
+
+test('Shopping-Seite bietet einen Essensplan-Import mit Datumsbereich an', () => {
+  const source = readFileSync(new URL('../public/pages/shopping.js', import.meta.url), 'utf8');
+  assert(/data-action="import-meals"/.test(source), 'Shopping-Header muss eine Import-Aktion aus dem Essensplan anbieten');
+  assert(/function openMealPlanImport/.test(source), 'Shopping-Seite muss einen Import-Dialog für den Essensplan besitzen');
+  assert(/api\.post\(`\/shopping\/\$\{state\.activeListId\}\/import-meal-plan`/.test(source), 'Import-Dialog muss die Shopping-Range-Import-Route aufrufen');
+  assert(/type="date" id="shopping-import-from"/.test(source), 'Import-Dialog muss ein Von-Datum anbieten');
+  assert(/type="date" id="shopping-import-to"/.test(source), 'Import-Dialog muss ein Bis-Datum anbieten');
+  assert(/addLocalDays\(today, 6\)/.test(source), 'Import-Dialog muss standardmäßig 7 Tage (heute + 6) vorauswählen');
 });
 
 test('Shopping-Category-Manager-Komponente erfüllt die Web-Component-Verträge', () => {
@@ -252,6 +263,45 @@ test('Autocomplete - kein Match gibt leeres Array', () => {
   assert(results.length === 0, 'Kein Match erwartet');
 });
 
+test('Essensplan-Import aggregiert gleiche Zutaten mit numerischen Mengen', () => {
+  const result = aggregateMealIngredients([
+    { id: 1, meal_id: 10, name: 'Tomaten', quantity: '2', category: 'Obst & Gemüse' },
+    { id: 2, meal_id: 11, name: 'Tomaten', quantity: '3', category: 'Obst & Gemüse' },
+  ]);
+  assert(result.length === 1, `Erwartet 1 aggregierten Eintrag, erhalten ${result.length}`);
+  assert(result[0].name === 'Tomaten', 'Name muss erhalten bleiben');
+  assert(result[0].quantity === '5', `Erwartet summierte Menge 5, erhalten ${result[0].quantity}`);
+  assert(result[0].added_from_meal === null, 'Bei mehreren Mahlzeiten darf kein einzelner meal-Verweis gesetzt werden');
+});
+
+test('Essensplan-Import aggregiert gleiche Zutaten mit Einheiten', () => {
+  const result = aggregateMealIngredients([
+    { id: 1, meal_id: 10, name: 'Reis', quantity: '100 g', category: 'Sonstiges' },
+    { id: 2, meal_id: 11, name: 'Reis', quantity: '50 g', category: 'Sonstiges' },
+  ]);
+  assert(result.length === 1, `Erwartet 1 aggregierten Eintrag, erhalten ${result.length}`);
+  assert(result[0].quantity === '150 g', `Erwartet summierte Menge 150 g, erhalten ${result[0].quantity}`);
+});
+
+test('Essensplan-Import summiert auch Mengen mit gleicher Einheit', () => {
+  const result = aggregateMealIngredients([
+    { id: 1, meal_id: 10, name: 'Eier', quantity: '1 pack', category: 'Milchprodukte' },
+    { id: 2, meal_id: 11, name: 'Eier', quantity: '1 pack', category: 'Milchprodukte' },
+    { id: 3, meal_id: 12, name: 'Eier', quantity: '2 pack', category: 'Milchprodukte' },
+  ]);
+  assert(result.length === 1, `Erwartet 1 aggregierten Eintrag, erhalten ${result.length}`);
+  assert(result[0].quantity === '4 pack', `Erwartet summierte Menge 4 pack, erhalten ${result[0].quantity}`);
+});
+
+test('Essensplan-Import zählt rein textuelle Mengen sichtbar zusammen', () => {
+  const result = aggregateMealIngredients([
+    { id: 1, meal_id: 10, name: 'Salz', quantity: 'nach Geschmack', category: 'Sonstiges' },
+    { id: 2, meal_id: 11, name: 'Salz', quantity: 'nach Geschmack', category: 'Sonstiges' },
+  ]);
+  assert(result.length === 1, `Erwartet 1 aggregierten Eintrag, erhalten ${result.length}`);
+  assert(result[0].quantity === '2 x nach Geschmack', `Erwartet 2 x nach Geschmack, erhalten ${result[0].quantity}`);
+});
+
 // --------------------------------------------------------
 // Zähler-Abfrage
 // --------------------------------------------------------
@@ -412,6 +462,14 @@ test('shopping-Route validiert und persistiert notes/url', () => {
   assert(/url\(req\.body\.url,\s*'URL'\)/.test(source), 'POST muss req.body.url über url() validieren');
   assert(/INSERT INTO shopping_items \(list_id, name, quantity, category, notes, url\)/.test(source), 'INSERT muss notes/url enthalten');
   assert(/SET is_checked = \?, name = \?, quantity = \?, category = \?, notes = \?, url = \?/.test(source), 'UPDATE muss notes/url enthalten');
+});
+
+test('shopping-Route bietet einen Datumsbereich-Import aus dem Essensplan an', () => {
+  const source = readFileSync(new URL('../server/routes/shopping.js', import.meta.url), 'utf8');
+  assert(/router\.post\('\/:listId\/import-meal-plan'/.test(source), 'Shopping-Route muss eine Import-Route für den Essensplan bereitstellen');
+  assert(/aggregateMealIngredients/.test(source), 'Import-Route muss aggregierte Zutaten verwenden');
+  assert(/m\.date BETWEEN \? AND \?/.test(source), 'Import-Route muss Mahlzeiten nach Datumsbereich filtern');
+  assert(/mi\.on_shopping_list = 0/.test(source), 'Bereits übertragene Zutaten dürfen nicht erneut importiert werden');
 });
 
 // --------------------------------------------------------

--- a/test/test-shopping.js
+++ b/test/test-shopping.js
@@ -59,6 +59,7 @@ test('Shopping-Seite bietet einen Essensplan-Import mit Datumsbereich an', () =>
   assert(/data-action="import-meals"/.test(source), 'Shopping-Header muss eine Import-Aktion aus dem Essensplan anbieten');
   assert(/function openMealPlanImport/.test(source), 'Shopping-Seite muss einen Import-Dialog für den Essensplan besitzen');
   assert(/api\.post\(`\/shopping\/\$\{state\.activeListId\}\/import-meal-plan`/.test(source), 'Import-Dialog muss die Shopping-Range-Import-Route aufrufen');
+  assert(/shopping\.importMealsEmpty/.test(source), 'Import-Dialog muss leere Bereiche mit einer Shopping-spezifischen Meldung behandeln');
   assert(/type="date" id="shopping-import-from"/.test(source), 'Import-Dialog muss ein Von-Datum anbieten');
   assert(/type="date" id="shopping-import-to"/.test(source), 'Import-Dialog muss ein Bis-Datum anbieten');
   assert(/addLocalDays\(today, 6\)/.test(source), 'Import-Dialog muss standardmäßig 7 Tage (heute + 6) vorauswählen');


### PR DESCRIPTION
## Summary

Adds a new shopping-list import flow for meal-plan ingredients. From the shopping page, users can open an import dialog, choose a date range that defaults to the next 7 days, and import ingredients from planned meals into the active list. Repeated ingredients are aggregated before insertion so matching items are merged and their quantities are summed where possible, with clear empty-range feedback and full localization support. Made to work with existing single import as well so items aren't duplicated.

- Shopping page now has an From meal plan action in the list header.
- Clicking it opens a date-range modal.
- Default range is the next 7 days.
- Import sends the selected range to a dedicated shopping endpoint.
- Ingredients from all matching meals are imported into the active shopping list.
- Repeated ingredients are aggregated before insertion:
- numeric quantities are summed
- same numeric unit is preserved
- purely textual quantities are collapsed visibly like 2 x nach Geschmack
- Already transferred meal ingredients are still excluded via the existing on_shopping_list behavior.

Files changed:
- public/pages/shopping.js
- public/styles/shopping.css
- server/routes/shopping.js
- server/services/shopping-import.js
- test/test-shopping.js
- locale files under public/locales/*.json (AI Based Localization - No verification)

Verification:
- npm run test:shopping
- npm run test:meals
- npm run test:frontend-audit
All passed.

This was in fact AI Built but Human reviewed by me (a long time developer). the AI even used your language in test suite, I found that amusing.