### PR TITLE
fix(dashboard): persist variable-length widget layouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Dashboard widget customisation now persists variable-length layouts and future widget IDs without a duplicated backend allow-list. The preferences API validates the safe storage shape instead of owning a fixed widget registry, so adding or removing dashboard widgets no longer requires a matching server change and malformed layouts return an error instead of being silently discarded.
+
 ## [1.40.7] - 2026-07-21
 
 ### Fixed

--- a/server/routes/preferences.js
+++ b/server/routes/preferences.js
@@ -76,18 +76,12 @@ const HEX_COLOR_RE = /^#[0-9a-fA-F]{6}$/;
 const COUNTRY_ISO_RE = /^[A-Z]{2}$/;
 const SUBDIVISION_RE = /^[A-Z]{2}-[A-Z0-9-]{1,10}$/;
 
-// Order defines the default dashboard layout.
-// Must stay in sync with WIDGET_IDS in public/pages/dashboard.js: der Client
-// erkennt eine Nutzer-Umsortierung am Vergleich gegen SEINEN Default; weicht der
-// Server-Default ab, gilt jede frische Installation als "nutzergeordnet" und das
-// dichte Bento-Layout greift nie (Audit A1-03).
-const VALID_WIDGET_IDS = ['tasks', 'calendar', 'meals', 'shopping', 'birthdays', 'budget', 'rewards', 'health', 'cycle', 'housekeeping', 'family', 'notes', 'weather'];
-
-// Opt-in-Widgets starten unsichtbar (Spiegel von DEFAULT_HIDDEN_WIDGETS im Client,
-// ohne die Cockpit-Teilmenge): sonst poppen sie bei Bestands-Configs, denen die
-// IDs noch fehlen, beim Normalisieren ungefragt auf.
-const DEFAULT_HIDDEN_WIDGET_IDS = new Set(['rewards', 'health', 'cycle', 'housekeeping']);
+// Widget identifiers are client-owned. The server validates only a safe storage shape,
+// so adding or removing dashboard widgets never requires a matching backend registry change.
+const WIDGET_ID_RE = /^[a-z][a-z0-9-]{0,63}$/;
+const MAX_DASHBOARD_WIDGETS = 64;
 const VALID_WIDGET_SIZES = ['1x1', '1x2', '1x3', '1x4', '2x1', '2x2', '2x3', '2x4', '3x1', '3x2', '3x3', '3x4', '4x1', '4x2', '4x3', '4x4'];
+const DEFAULT_WIDGET_CONFIG = '[]';
 
 // Modul-Slugs, die per Settings deaktiviert werden können.
 // Dashboard und Settings sind absichtlich nicht enthalten — sie sind essentiell.
@@ -99,20 +93,6 @@ const TOGGLEABLE_MODULES = [
 const MODULE_ORDER_RE = /^(dashboard|tasks|calendar|meals|recipes|shopping|birthdays|notes|contacts|budget|documents|housekeeping|rewards|health|third-party-[a-z0-9][a-z0-9-]{1,62}[a-z0-9])$/;
 const MOBILE_NAV_ORDER_RE = /^(tasks|calendar|kitchen|meals|recipes|shopping|birthdays|notes|contacts|budget|documents|housekeeping|rewards|health|third-party-[a-z0-9][a-z0-9-]{1,62}[a-z0-9])$/;
 const KITCHEN_NAV_IDS = new Set(['kitchen', 'meals', 'recipes', 'shopping']);
-
-function defaultWidgetSize(id) {
-  if (['tasks', 'calendar'].includes(id)) return '2x2';
-  if (['weather', 'shopping', 'notes', 'health', 'cycle'].includes(id)) return '2x1';
-  if (id === 'rewards') return '1x2';
-  return '1x1';
-}
-
-const DEFAULT_WIDGET_CONFIG = JSON.stringify(VALID_WIDGET_IDS.map((id, order) => ({
-  id,
-  visible: !DEFAULT_HIDDEN_WIDGET_IDS.has(id),
-  order,
-  size: defaultWidgetSize(id),
-})));
 
 // --------------------------------------------------------
 // Hilfsfunktionen
@@ -169,7 +149,7 @@ function weatherUserOverride(userId) {
 function parseWidgetConfig(raw) {
   try {
     const parsed = JSON.parse(raw ?? DEFAULT_WIDGET_CONFIG);
-    return normalizeWidgetConfig(parsed);
+    return normalizeWidgetConfig(parsed) ?? [];
   } catch {
     return JSON.parse(DEFAULT_WIDGET_CONFIG);
   }
@@ -220,27 +200,29 @@ function parseMobileNavOrder(raw) {
 }
 
 function normalizeWidgetConfig(input) {
-  const valid = Array.isArray(input)
-    ? input
-      .filter((w) => w && typeof w === 'object' && VALID_WIDGET_IDS.includes(w.id))
-      .map((w, order) => ({
-        id: w.id,
-        visible: w.visible !== false,
-        order: Number.isFinite(Number(w.order)) ? Number(w.order) : order,
-        size: VALID_WIDGET_SIZES.includes(w.size) ? w.size : defaultWidgetSize(w.id),
-      }))
-    : [];
+  if (!Array.isArray(input) || input.length > MAX_DASHBOARD_WIDGETS) return null;
 
-  // Fehlende Widget-IDs am Ende ergänzen; Opt-in-Widgets bleiben dabei unsichtbar
-  const presentIds = new Set(valid.map((w) => w.id));
-  for (const id of VALID_WIDGET_IDS) {
-    if (!presentIds.has(id)) {
-      valid.push({ id, visible: !DEFAULT_HIDDEN_WIDGET_IDS.has(id), order: valid.length, size: defaultWidgetSize(id) });
-    }
+  const seenIds = new Set();
+  const normalized = [];
+  for (const [index, widget] of input.entries()) {
+    if (!widget || typeof widget !== 'object' || Array.isArray(widget)) return null;
+    if (typeof widget.id !== 'string' || !WIDGET_ID_RE.test(widget.id) || seenIds.has(widget.id)) return null;
+    if (widget.visible !== undefined && typeof widget.visible !== 'boolean') return null;
+    if (widget.order !== undefined && !Number.isFinite(Number(widget.order))) return null;
+    if (widget.size !== undefined && !VALID_WIDGET_SIZES.includes(widget.size)) return null;
+
+    seenIds.add(widget.id);
+    normalized.push({
+      id: widget.id,
+      visible: widget.visible !== false,
+      order: widget.order === undefined ? index : Number(widget.order),
+      size: widget.size ?? '1x1',
+    });
   }
-  return valid
+
+  return normalized
     .sort((a, b) => a.order - b.order)
-    .map((w, order) => ({ ...w, order }));
+    .map((widget, order) => ({ ...widget, order }));
 }
 
 // --------------------------------------------------------
@@ -393,6 +375,9 @@ router.put('/', (req, res) => {
         return res.status(400).json({ error: 'dashboard_widgets muss ein Array sein', code: 400 });
       }
       const normalized = normalizeWidgetConfig(dashboard_widgets);
+      if (normalized === null) {
+        return res.status(400).json({ error: 'dashboard_widgets enthält ungültige Einträge', code: 400 });
+      }
       cfgSet('dashboard_widgets', JSON.stringify(normalized));
     }
 

--- a/test/test-preferences-routes.js
+++ b/test/test-preferences-routes.js
@@ -146,26 +146,62 @@ test('PUT app_name: gültig -> persist, leer -> Rückfall auf Default', async ()
 test('PUT dashboard_widgets: Nicht-Array -> 400', async () => {
   assert.equal((await put({ dashboard_widgets: {} })).status, 400);
 });
-test('PUT dashboard_widgets: Teilmenge -> fehlende IDs werden ergänzt, order neu vergeben', async () => {
-  const { status, body } = await put({ dashboard_widgets: [{ id: 'notes', visible: false, size: '2x1' }] });
-  assert.equal(status, 200);
-  const widgets = body.data.dashboard_widgets;
-  // Alle 13 IDs vorhanden, notes zuerst und unsichtbar, order lückenlos 0..n.
-  assert.equal(widgets.length, 13);
-  assert.equal(widgets[0].id, 'notes');
-  assert.equal(widgets[0].visible, false);
-  assert.deepEqual(widgets.map((w) => w.order), [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
-  // Ergänzte Opt-in-Widgets starten unsichtbar, Kern-Widgets sichtbar.
-  const byId = Object.fromEntries(widgets.map((w) => [w.id, w]));
-  for (const id of ['rewards', 'health', 'cycle', 'housekeeping']) assert.equal(byId[id].visible, false, id);
-  for (const id of ['tasks', 'calendar', 'weather']) assert.equal(byId[id].visible, true, id);
+test('PUT dashboard_widgets: ungültige Struktur, doppelte IDs oder zu viele Einträge -> 400', async () => {
+  assert.equal((await put({ dashboard_widgets: [{ id: '../weather', visible: true, order: 0, size: '1x1' }] })).status, 400);
+  assert.equal((await put({ dashboard_widgets: [{ id: 'weather', visible: 'yes', order: 0, size: '1x1' }] })).status, 400);
+  assert.equal((await put({ dashboard_widgets: [{ id: 'weather', visible: true, order: 'first', size: '1x1' }] })).status, 400);
+  assert.equal((await put({ dashboard_widgets: [{ id: 'weather', visible: true, order: 0, size: '5x5' }] })).status, 400);
+  assert.equal((await put({ dashboard_widgets: [
+    { id: 'weather', visible: true, order: 0, size: '1x1' },
+    { id: 'weather', visible: false, order: 1, size: '1x1' },
+  ] })).status, 400);
+  const tooMany = Array.from({ length: 65 }, (_, order) => ({
+    id: `widget-${order}`,
+    visible: true,
+    order,
+    size: '1x1',
+  }));
+  assert.equal((await put({ dashboard_widgets: tooMany })).status, 400);
 });
-test('PUT dashboard_widgets: Opt-in-Widget sichtbar geschaltet -> ueberlebt den Roundtrip', async () => {
-  const { status, body } = await put({ dashboard_widgets: [{ id: 'rewards', visible: true, size: '1x2' }] });
-  assert.equal(status, 200);
-  const rewards = body.data.dashboard_widgets.find((w) => w.id === 'rewards');
-  assert.ok(rewards, 'rewards bleibt in der gespeicherten Config');
-  assert.equal(rewards.visible, true);
+test('PUT dashboard_widgets: Teilmenge bleibt beim GET eine Teilmenge', async () => {
+  const requested = [{ id: 'notes', visible: false, order: 0, size: '2x1' }];
+  const saved = await put({ dashboard_widgets: requested });
+  assert.equal(saved.status, 200);
+  assert.deepEqual(saved.body.data.dashboard_widgets, requested);
+  assert.deepEqual((await get()).body.data.dashboard_widgets, requested);
+});
+test('PUT dashboard_widgets: zukünftige sichere Widget-ID wird unverändert persistiert', async () => {
+  const requested = [
+    { id: 'weather', visible: true, order: 0, size: '2x1' },
+    { id: 'solar-production', visible: true, order: 1, size: '2x1' },
+  ];
+
+  const saved = await put({ dashboard_widgets: requested });
+  assert.equal(saved.status, 200);
+  assert.deepEqual(saved.body.data.dashboard_widgets, requested);
+  assert.deepEqual((await get()).body.data.dashboard_widgets, requested);
+});
+test('PUT dashboard_widgets: aktuelle 13-Widget-Konfiguration bleibt beim GET erhalten', async () => {
+  const requested = [
+    { id: 'weather', visible: true, order: 0, size: '2x1' },
+    { id: 'tasks', visible: true, order: 1, size: '2x2' },
+    { id: 'calendar', visible: true, order: 2, size: '2x2' },
+    { id: 'notes', visible: true, order: 3, size: '2x1' },
+    { id: 'shopping', visible: true, order: 4, size: '2x1' },
+    { id: 'birthdays', visible: true, order: 5, size: '1x1' },
+    { id: 'family', visible: true, order: 6, size: '1x1' },
+    { id: 'meals', visible: true, order: 7, size: '1x1' },
+    { id: 'budget', visible: true, order: 8, size: '1x1' },
+    { id: 'rewards', visible: true, order: 9, size: '1x2' },
+    { id: 'health', visible: true, order: 10, size: '2x1' },
+    { id: 'cycle', visible: false, order: 11, size: '2x1' },
+    { id: 'housekeeping', visible: true, order: 12, size: '1x1' },
+  ];
+
+  const saved = await put({ dashboard_widgets: requested });
+  assert.equal(saved.status, 200);
+  assert.deepEqual(saved.body.data.dashboard_widgets, requested);
+  assert.deepEqual((await get()).body.data.dashboard_widgets, requested);
 });
 
 // --------------------------------------------------------
@@ -392,7 +428,7 @@ test('POST /holidays/sync: Admin ohne konfiguriertes Land -> 200 (netz-freier Ea
 test('GET / verkraftet korrupte dashboard_widgets (Fallback auf Default)', async () => {
   cfgSet('dashboard_widgets', '{ kaputt');
   const widgets = (await get()).body.data.dashboard_widgets;
-  assert.equal(widgets.length, 13); // Default-Set
+  assert.deepEqual(widgets, []); // Client erweitert leer auf seine aktuellen Defaults
   cfgDelete('dashboard_widgets');
 });
 test('GET / verkraftet korrupte per-user calendar_default_reminders', async () => {


### PR DESCRIPTION
## Summary

Make dashboard widget preference persistence variable-length and remove the duplicated server-side widget registry.

The backend currently owns its own widget allow-list, visibility defaults and size defaults alongside the canonical definitions in `public/pages/dashboard.js`. Although expanding that registry to the current 13 widgets fixes the immediate mismatch, it still requires every future widget addition or removal to be implemented in both the client and server. Unknown IDs are otherwise silently discarded.

This change makes the server responsible only for validating and storing a safe widget configuration shape. Widget identity, rendering and default layout policy remain owned by the dashboard client.

## Changes

- Remove the fixed server-side widget ID allow-list and duplicated dashboard defaults.
- Preserve the supplied variable-length set of widget entries instead of expanding every request to a fixed registry.
- Preserve future safe widget IDs without requiring a corresponding backend change.
- Validate:
  - widget IDs against a safe identifier format
  - unique widget IDs
  - boolean visibility values
  - finite order values
  - supported grid sizes
  - a maximum of 64 entries
- Return `400` for malformed widget configurations instead of silently filtering or replacing invalid entries.
- Return `[]` for missing or corrupt stored configurations.
- Leave default expansion to `normalizeDashboardConfig()` in the client, which already owns:
  - the current widget registry
  - default ordering
  - default visibility
  - default sizes
  - upgrade handling for newly introduced built-in widgets
- Preserve the existing hide and restore behaviour through `visible: false`.
- Add regression coverage for:
  - a one-widget subset remaining a subset at the API boundary
  - future safe widget IDs
  - the current 13-widget layout
  - hidden widgets
  - invalid IDs, visibility, order and size values
  - duplicate IDs
  - configurations exceeding the maximum length
  - corrupt stored data
- Document the user-facing fix under `CHANGELOG.md` `[Unreleased]`.

## Behaviour

The server no longer decides which widgets exist. It persists the validated set supplied by the client.

For a fresh or corrupt configuration, the API returns an empty array and the dashboard client expands it to its current defaults. Existing saved layouts continue to round-trip normally. Missing current built-ins are added in memory by the client, while unknown IDs are ignored for rendering until the client has corresponding registry and renderer support.

The current customisation UI continues to represent removal as `visible: false`, so hidden widgets remain available in the restore tray.

## Testing

- `npm test`
- Focused preference route suite: 48 tests passed
- Dashboard suite: 40 tests passed
- Changelog suite: 5 tests passed

## Checklist

- [x] `npm test` passes
- [x] Follows [CONTRIBUTING.md](../CONTRIBUTING.md) conventions
- [x] No new frontend dependencies (vanilla JS, no frameworks)
- [x] UI strings use `t('key')` (no hardcoded text)
- [x] CHANGELOG.md updated (if user-facing change)