### PR TITLE
fix: default manually added shopping items to Other category #548

### DIFF
--- a/public/pages/shopping.js
+++ b/public/pages/shopping.js
@@ -197,7 +197,7 @@ function renderListContent(container) {
         <input class="quick-add__qty" type="text" id="item-qty-input"
                placeholder="${t('shopping.itemQtyPlaceholder')}" aria-label="${t('shopping.itemQtyLabel')}" autocomplete="off">
         <select class="quick-add__cat" id="item-cat-select" aria-label="${t('shopping.categoryLabel')}">
-          ${state.categories.map((c) => `<option value="${esc(c.name)}">${esc(categoryLabel(c.name))}</option>`).join('')}
+              ${state.categories.map((c) => `<option value="${esc(c.name)}" ${c.name === DEFAULT_CATEGORY_NAME ? 'selected' : ''}>${esc(categoryLabel(c.name))}</option>`).join('')}
         </select>
         <button class="quick-add__btn" type="submit" aria-label="${t('shopping.addItemLabel')}">
           <i data-lucide="plus" class="icon-lg" aria-hidden="true"></i>


### PR DESCRIPTION
## Summary

Changes the default category for manually added shopping list items from **Fruits & Vegetables** to **Other**.

Closes #548  

## Changes

* Changed the default category for manually added shopping list items to **Other**.
* Preserved the existing category assignment for items imported from recipes or meal plans.
* Prevented unrelated manually added items from being incorrectly categorized as **Fruits & Vegetables**.

traduza