### PR TITLE
Fix: shopping item deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Deleting an individual shopping item or using "Remove checked" now permanently removes the item instead of showing an error and restoring it on refresh. Both actions used the shared undo-delete helper without importing it, so the browser stopped before scheduling the server request (#558).
+
 ## [1.44.4] - 2026-07-23
 
 ### Fixed

--- a/public/pages/shopping.js
+++ b/public/pages/shopping.js
@@ -5,7 +5,7 @@
  */
 
 import { api } from '/api.js';
-import { stagger, vibrate } from '/utils/ux.js';
+import { stagger, vibrate, scheduleUndoableDelete } from '/utils/ux.js';
 import { t } from '/i18n.js';
 import { esc } from '/utils/html.js';
 import { promptModal, openModal, closeModal, confirmModal } from '/components/modal.js';

--- a/test/test-shopping.js
+++ b/test/test-shopping.js
@@ -42,6 +42,16 @@ test('Einkaufslisten-Zeilen toggeln nur außerhalb interaktiver Controls', () =>
   assert(/data-item-id/.test(source), 'Zeilen-Toggle muss die Artikel-ID aus data-item-id lesen');
 });
 
+test('Shopping-Löschaktionen importieren den gemeinsamen Undo-Helper', () => {
+  const source = readFileSync(new URL('../public/pages/shopping.js', import.meta.url), 'utf8');
+  assert(
+    /import\s*\{[^}]*\bscheduleUndoableDelete\b[^}]*\}\s*from\s*'\/utils\/ux\.js'/.test(source),
+    'scheduleUndoableDelete muss aus /utils/ux.js importiert werden',
+  );
+  const calls = source.match(/\bscheduleUndoableDelete\s*\(/g) ?? [];
+  assert(calls.length === 2, `Einzel- und Sammellöschung müssen den Undo-Helper nutzen, gefunden: ${calls.length}`);
+});
+
 // --------------------------------------------------------
 // Kategorie-Verwaltung wandert nach Shopping (Task 7)
 // --------------------------------------------------------


### PR DESCRIPTION
### Summary

Fixes shopping item deletion by restoring the missing shared undo-delete helper import. Individual items and checked items are now permanently deleted instead of reappearing after refresh.

Fixes: https://github.com/ulsklyc/yuvomi/issues/558

### Changes

- Import scheduleUndoableDelete in the Shopping page.
- Add regression coverage for individual and checked-item deletion paths.
- Document the fix in CHANGELOG.md.

### Checklist

- [x] npm test passes
- [x] Follows [CONTRIBUTING.md](https://github.com/ulsklyc/yuvomi/compare/CONTRIBUTING.md)
- [x] No new frontend dependencies (vanilla JS, no frameworks)
- [x] UI strings use t('key') (no hardcoded text)
- [x] CHANGELOG.md updated (if user-facing change)