### PR TITLE
feat(tasks): add subtask visualization on task cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-- Added subtask visualization on the tasks page, displaying related subtasks directly inside the main task cards. Tasks with subtasks now show their associated items within the task list, improving organization and making task relationships easier to view.
+### Added
+- Subtask visualization on the tasks page: related subtasks are loaded with the task list and can be expanded directly inside the main task cards via the progress toggle, so task relationships are visible without opening the task detail.
 
 ## [1.45.5] - 2026-07-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Added subtask visualization on the tasks page, displaying related subtasks directly inside the main task cards. Tasks with subtasks now show their associated items within the task list, improving organization and making task relationships easier to view.
+
 ## [1.45.5] - 2026-07-24
 
 ### Fixed

--- a/public/pages/tasks.js
+++ b/public/pages/tasks.js
@@ -295,9 +295,9 @@ function renderTaskCard(task, opts = {}) {
           <span class="subtask-progress__text">${task.subtask_done}/${task.subtask_total}</span>
         </button>` : ''}
 
-      ${task.subtasks !== undefined ? `
-        <div class="subtask-list ${expandedSubtasks ? 'subtask-list--visible' : ''}"
-             id="subtasks-${task.id}">
+      ${task.subtasks?.length ? `
+        <div class="subtask-list subtask-list--visible" id="subtasks-${task.id}">
+             
           ${subtasksHtml}
           <button class="subtask-item__add" data-action="add-subtask" data-parent="${task.id}">
             ${t('tasks.subtaskAdd')}

--- a/public/pages/tasks.js
+++ b/public/pages/tasks.js
@@ -296,8 +296,8 @@ function renderTaskCard(task, opts = {}) {
         </button>` : ''}
 
       ${task.subtasks?.length ? `
-        <div class="subtask-list subtask-list--visible" id="subtasks-${task.id}">
-             
+        <div class="subtask-list ${expandedSubtasks ? 'subtask-list--visible' : ''}"
+             id="subtasks-${task.id}">
           ${subtasksHtml}
           <button class="subtask-item__add" data-action="add-subtask" data-parent="${task.id}">
             ${t('tasks.subtaskAdd')}

--- a/server/routes/tasks.js
+++ b/server/routes/tasks.js
@@ -257,8 +257,7 @@ router.get('/', (req, res) => {
         u.avatar_color AS assigned_color,
         u.avatar_data AS assigned_avatar,
         ${ASSIGNED_USERS_SQL},
-        (SELECT COUNT(*) FROM tasks s WHERE s.parent_task_id = t.id)                           AS subtask_total,
-        (SELECT COUNT(*) FROM tasks s WHERE s.parent_task_id = t.id AND s.status = 'done')     AS subtask_done
+        (SELECT COUNT(*) FROM tasks s WHERE s.parent_task_id = t.id) AS subtask_total, (SELECT COUNT(*) FROM tasks s WHERE s.parent_task_id = t.id AND s.status = 'done') AS subtask_done, (SELECT json_group_array(json_object('id', s.id, 'title', s.title, 'status', s.status)) FROM tasks s WHERE s.parent_task_id = t.id) AS subtasks
       FROM tasks t
       LEFT JOIN users u ON t.assigned_to = u.id
       WHERE t.parent_task_id IS NULL
@@ -291,7 +290,7 @@ router.get('/', (req, res) => {
         t.created_at DESC
     `;
 
-    const rows = db.get().prepare(sql).all(...params).map(addAssignedUsers);
+    const rows = db.get().prepare(sql).all(...params).map(task => ({ ...task, subtasks: JSON.parse(task.subtasks || '[]') })).map(addAssignedUsers);
     res.json({ data: attachDocumentCounts(rows, me) });
   } catch (err) {
     log.error('GET / error:', err);

--- a/server/routes/tasks.js
+++ b/server/routes/tasks.js
@@ -257,7 +257,10 @@ router.get('/', (req, res) => {
         u.avatar_color AS assigned_color,
         u.avatar_data AS assigned_avatar,
         ${ASSIGNED_USERS_SQL},
-        (SELECT COUNT(*) FROM tasks s WHERE s.parent_task_id = t.id) AS subtask_total, (SELECT COUNT(*) FROM tasks s WHERE s.parent_task_id = t.id AND s.status = 'done') AS subtask_done, (SELECT json_group_array(json_object('id', s.id, 'title', s.title, 'status', s.status)) FROM tasks s WHERE s.parent_task_id = t.id) AS subtasks
+        (SELECT COUNT(*) FROM tasks s WHERE s.parent_task_id = t.id)                           AS subtask_total,
+        (SELECT COUNT(*) FROM tasks s WHERE s.parent_task_id = t.id AND s.status = 'done')     AS subtask_done,
+        (SELECT json_group_array(json_object('id', s.id, 'title', s.title, 'status', s.status))
+           FROM (SELECT id, title, status FROM tasks WHERE parent_task_id = t.id ORDER BY created_at ASC) s) AS subtasks
       FROM tasks t
       LEFT JOIN users u ON t.assigned_to = u.id
       WHERE t.parent_task_id IS NULL


### PR DESCRIPTION
## Summary

Adds subtask visualization on the Tasks page by displaying related subtasks directly inside the main task cards. Users can now see the hierarchy between parent tasks and their subtasks without opening the task details.

<img width="1365" height="767" alt="image" src="https://github.com/user-attachments/assets/88165992-31d9-4bd4-b7ec-c39bd221129b" />

## Changes

- Show related subtask items directly in the task list.
- Preserve individual subtask status visualization.
- Update CHANGELOG.md with the new subtask visibility improvement.