### PR TITLE
fix(mcp): stop double-encoding the request body in the OpenAPI bridge

### DIFF
--- a/server/mcp/tools.js
+++ b/server/mcp/tools.js
@@ -309,6 +309,26 @@ function contentBytes(contentData) {
   return Buffer.from(raw, 'base64');
 }
 
+// Serialisiert den JSON-Body. MCP-Clients, die Tool-Argumente typkoerzieren,
+// schicken das Payload bereits als JSON-Text — der wird durchgereicht statt ein
+// zweites Mal kodiert, sonst käme beim Server ein String-Primitive an, das
+// `express.json({ strict: true })` ablehnt.
+function jsonBody(payload) {
+  if (typeof payload !== 'string') return JSON.stringify(payload ?? {});
+  const trimmed = payload.trim();
+  if (!trimmed) return '{}';
+  let parsed;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    throw new ToolError('payload must be a JSON object (or a string containing one).');
+  }
+  if (!parsed || typeof parsed !== 'object') {
+    throw new ToolError('payload must be a JSON object (or a string containing one).');
+  }
+  return JSON.stringify(parsed);
+}
+
 function internalBaseUrl() {
   return (
     process.env.MCP_INTERNAL_BASE_URL
@@ -394,7 +414,7 @@ async function internalApiRequest(ctx, method, path, { query, payload, contentDa
     options.body = contentBytes(contentData);
     headers['Content-Type'] = contentType || 'application/octet-stream';
   } else if (!['GET', 'HEAD'].includes(method.toUpperCase()) && payload !== undefined) {
-    options.body = JSON.stringify(payload ?? {});
+    options.body = jsonBody(payload);
     headers['Content-Type'] = 'application/json';
   }
 
@@ -579,7 +599,7 @@ const OPENAPI_TOOLS = [
         path: { type: 'string', description: 'OpenAPI path, used with method when operation_key is omitted.' },
         path_params: { type: 'object', description: 'Values for path template parameters.' },
         query: { type: 'object', description: 'Query string parameters.' },
-        payload: { description: 'JSON request body.' },
+        payload: { type: 'object', description: 'JSON request body.' },
         content_data: { type: 'string', description: 'Base64 or base64 data URL for binary uploads.' },
       },
     },

--- a/test/test-mcp.js
+++ b/test/test-mcp.js
@@ -124,6 +124,11 @@ test('tools/list: listet die sechs Kern-Tools plus die drei OpenAPI-Brücken-Too
   assert.equal(res.result.tools.length, TOOL_DEFINITIONS.length);
   for (const t of res.result.tools) {
     assert.equal(t.inputSchema.type, 'object', `${t.name} braucht ein object-Schema`);
+    // Issue #599: Properties ohne `type` werden von manchen Clients zu Strings
+    // koerziert — jede Property muss ihren Typ deklarieren.
+    for (const [prop, schema] of Object.entries(t.inputSchema.properties || {})) {
+      assert.ok(schema.type, `${t.name}.${prop} braucht ein deklariertes type`);
+    }
   }
 });
 
@@ -290,6 +295,41 @@ test('call_api_operation POST: sendet JSON-Payload mit Content-Type', async () =
     assert.equal(calls[0].options.method, 'POST');
     assert.equal(calls[0].options.headers['Content-Type'], 'application/json');
     assert.deepEqual(JSON.parse(calls[0].options.body), { title: 'Neu' });
+  } finally {
+    global.fetch = realFetch;
+  }
+});
+
+// Issue #599: Clients, die Tool-Argumente typkoerzieren, schicken das Payload als
+// JSON-String. Ohne Durchreichen entstünde ein doppelt kodiertes String-Primitive,
+// das `express.json({ strict: true })` mit „Invalid JSON in request body" ablehnt.
+test('call_api_operation POST: string-serialisiertes Payload wird nicht doppelt kodiert', async () => {
+  const calls = installFetchMock(() => jsonResponse({ data: { id: 8, title: 'Neu' } }));
+  try {
+    const res = await toolCallWithHeaders(
+      'call_api_operation',
+      { operation_key: 'post_tasks', payload: '{"title":"Neu"}' },
+      { authorization: 'Bearer test-token' },
+    );
+    assert.equal(res.result.isError, false, res.result.content?.[0]?.text);
+    assert.equal(calls[0].options.headers['Content-Type'], 'application/json');
+    assert.deepEqual(JSON.parse(calls[0].options.body), { title: 'Neu' });
+  } finally {
+    global.fetch = realFetch;
+  }
+});
+
+test('call_api_operation POST: unparsbares String-Payload → isError (kein fetch)', async () => {
+  const calls = installFetchMock(() => jsonResponse({}));
+  try {
+    const res = await toolCallWithHeaders(
+      'call_api_operation',
+      { operation_key: 'post_tasks', payload: 'Neu' },
+      { authorization: 'Bearer test-token' },
+    );
+    assert.equal(res.result.isError, true);
+    assert.match(res.result.content[0].text, /payload must be a JSON object/i);
+    assert.equal(calls.length, 0, 'ungültiges Payload darf keinen Request auslösen');
   } finally {
     global.fetch = realFetch;
   }


### PR DESCRIPTION
Closes #599

## Problem

`call_api_operation` could not perform any write (POST/PUT/PATCH) from MCP clients that type-coerce tool arguments. Every attempt failed with `Invalid JSON in request body`. GET operations were unaffected because they carry no body, and the curated core tools (`add_shopping_item`, `create_task`, ...) never touch the bridge, so only the generic OpenAPI bridge was blocked for writes.

The `payload` property declared no `type`, unlike every sibling property:

```js
path_params: { type: 'object', ... },
query:       { type: 'object', ... },
payload:     { description: 'JSON request body.' },   // no type
```

Clients that serialize untyped schema properties default them to strings, so the bridge received the body pre-stringified. `internalApiRequest` then applied a second `JSON.stringify`, producing a bare JSON string primitive that `express.json({ strict: true })` rejects.

## Fix

- **Declare the type:** `payload: { type: 'object', ... }`.
- **Defensive pass-through:** the new `jsonBody()` helper unwraps a string payload when it parses as an object or array, instead of encoding it a second time, so clients that still send a string keep working. Unparsable payloads and JSON primitives (`"Neu"`, `42`) now fail fast with a clear message rather than producing an opaque upstream error.

## Tests

Three new guards in `test/test-mcp.js`:

- a string-serialized payload is not double-encoded
- an unparsable payload returns `isError` and fires no loopback request
- `tools/list` now asserts that **every** property of **every** tool schema declares a `type`, so the untyped case cannot come back for any tool

Full suite green (`npm test`, exit 0).