### PR TITLE
fix(caldav): keep an empty sync run out of the default log level

### DIFF
--- a/server/services/caldav-sync.js
+++ b/server/services/caldav-sync.js
@@ -436,7 +436,7 @@ async function sync({ createClient } = {}) {
 
   for (const account of accounts) {
     try {
-      log.info(`Syncing CalDAV account ${account.id} ("${account.name}")...`);
+      log.debug(`Syncing CalDAV account ${account.id} ("${account.name}")...`);
 
       // Create tsdav client (oder injizierte Test-Factory)
       const client = await makeClient(account);
@@ -663,7 +663,7 @@ async function sync({ createClient } = {}) {
       totalSyncedEvents += accountEventCount;
       successfulAccounts++;
 
-      log.info(
+      log.debug(
         `Account ${account.id} sync complete: ${accountEventCount} events` +
         `${deletedCount > 0 ? `, ${deletedCount} deleted` : ''}.`
       );
@@ -674,7 +674,13 @@ async function sync({ createClient } = {}) {
     }
   }
 
-  log.info(`CalDAV sync complete: ${successfulAccounts}/${accounts.length} accounts, ${totalSyncedEvents} events.`);
+  // Die Zusammenfassung gehört nur ins Standard-Log, wenn der Lauf tatsächlich
+  // etwas verarbeitet hat. Ein Tick ohne Ergebnis (keine aktivierten Kalender,
+  // leere Kalender, fehlgeschlagene Accounts) bleibt still; Fehler melden sich
+  // ohnehin einzeln über log.error.
+  const summary = `CalDAV sync complete: ${successfulAccounts}/${accounts.length} accounts, ${totalSyncedEvents} events.`;
+  if (totalSyncedEvents > 0) log.info(summary);
+  else log.debug(summary);
 
   return { success: true, syncedAccounts: successfulAccounts, syncedEvents: totalSyncedEvents };
 }

--- a/test/test-caldav-sync.js
+++ b/test/test-caldav-sync.js
@@ -788,24 +788,68 @@ describe('CalDAV: No-op-Syncs bleiben im Standard-Log-Level still', () => {
               VALUES ('Radicale', 'https://dav.example/', 'u', 'p');`);
     _setTestDatabase(d);
     try {
-      const createClient = async () => ({
-        fetchCalendars:       async () => [],
-        fetchCalendarObjects: async () => [],
-        createCalendarObject: async () => ({}),
-      });
+      let clientCalls = 0;
+      const createClient = async () => {
+        clientCalls++;
+        return {
+          fetchCalendars:       async () => [],
+          fetchCalendarObjects: async () => [],
+          createCalendarObject: async () => ({}),
+        };
+      };
       const lines = await captureConsole(async () => {
         const res = await sync({ createClient });
         assert.strictEqual(res.syncedEvents, 0);
       });
-      // Positivkontrolle: der Lauf hat den Account wirklich angefasst, der
-      // Skip-Pfad wurde also erreicht und nicht bloß übersprungen.
+      // Positivkontrolle ohne Umweg über das Log: die Account-Schleife lief
+      // wirklich, der Skip-Pfad wurde also erreicht statt übersprungen.
+      assert.strictEqual(clientCalls, 1, 'Account-Schleife wurde nicht durchlaufen');
+      assert.deepStrictEqual(lines.info, []);
+    } finally {
+      _resetTestDatabase();
+      d.close();
+    }
+  });
+
+  // Gegenprobe: der Sync darf nicht pauschal verstummen. Sobald er wirklich
+  // Events verarbeitet, gehört die Zusammenfassung ins Standard-Log.
+  it('meldet den Abschluss auf info, sobald Events verarbeitet wurden', async () => {
+    const CALENDAR_URL = 'https://dav.example/cal-1/';
+    const d = buildDb();
+    d.exec(`
+      INSERT INTO caldav_accounts (name, caldav_url, username, password)
+        VALUES ('Radicale', 'https://dav.example/', 'u', 'p');
+      INSERT INTO caldav_calendar_selection
+        (account_id, calendar_url, calendar_name, calendar_color, enabled)
+        VALUES (1, '${CALENDAR_URL}', 'Cal 1', '#4A90E2', 1);
+    `);
+    _setTestDatabase(d);
+    try {
+      const createClient = async () => ({
+        fetchCalendars:       async () => [{ url: CALENDAR_URL, displayName: 'Cal 1' }],
+        fetchCalendarObjects: async () => [{
+          data: [
+            'BEGIN:VCALENDAR', 'VERSION:2.0', 'BEGIN:VEVENT',
+            'UID:evt-1@test', 'SUMMARY:Event 1',
+            'DTSTART:20260101T100000Z', 'DTEND:20260101T110000Z',
+            'END:VEVENT', 'END:VCALENDAR',
+          ].join('\r\n'),
+        }],
+        createCalendarObject: async () => ({}),
+      });
+      const lines = await captureConsole(async () => {
+        const res = await sync({ createClient });
+        assert.strictEqual(res.syncedEvents, 1);
+      });
       assert.ok(
-        lines.info.some((l) => l.includes('Syncing CalDAV account')),
-        `Sync-Pfad wurde nicht durchlaufen: ${JSON.stringify(lines.info)}`
+        lines.info.some((l) => l.includes('CalDAV sync complete: 1/1 accounts, 1 events')),
+        `Zusammenfassung fehlt im Standard-Log: ${JSON.stringify(lines.info)}`
       );
-      assert.deepStrictEqual(
-        lines.info.filter((l) => l.includes('no enabled calendars')),
-        []
+      // Und zwar genau diese eine Zeile: der Fortschritt pro Account und die
+      // Detailbilanz gehören ins Debug-Log, nicht in jeden Scheduler-Tick.
+      assert.strictEqual(
+        lines.info.length, 1,
+        `nur die Zusammenfassung gehört auf info: ${JSON.stringify(lines.info)}`
       );
     } finally {
       _resetTestDatabase();


### PR DESCRIPTION
Nachzügler zu #601. Beim Schreiben der dortigen Verhaltenstests fiel auf, dass ein Scheduler-Tick gegen einen konfigurierten Account weiterhin drei `info`-Zeilen schrieb, auch wenn er nichts tat:

```
[CalDAV] Syncing CalDAV account 1 ("Radicale")...
[CalDAV] Account 1 sync complete: 0 events.
[CalDAV] CalDAV sync complete: 0/1 accounts, 0 events.
```

### Änderung

| Meldung | vorher | jetzt |
|---|---|---|
| `Syncing CalDAV account X ("Name")...` | `info` | `debug` |
| `Account X sync complete: N events` | `info` | `debug` |
| `CalDAV sync complete: N/M accounts, K events.` | immer `info` | `info` nur bei `K > 0`, sonst `debug` |

Ein ergebnisloser Lauf ist damit still. Fehler sind unberührt und melden sich einzeln über `log.error`.

### Was bewusst offen bleibt

Ein Kalender mit Terminen loggt seine Zusammenfassung weiter bei jedem Tick auf `info`. `accountEventCount` zählt alle vom Server gesehenen Events, nicht die geänderten, ist bei einem gefüllten Kalender also immer > 0.

Nur bei echten Änderungen zu loggen hieße, geänderte von unveränderten Events zu unterscheiden. Der billigste Weg wäre, das `UPDATE` um einen Spaltenvergleich in der `WHERE`-Klausel zu ergänzen (`... AND (title IS NOT ? OR start_datetime IS NOT ? OR ...)`), dann liefert SQLite `changes: 0` bei identischen Werten. Das spart nebenbei WAL-Writes, greift aber in den bewusst optimierten Hot-Path aus #519 ein und gehört deshalb in einen eigenen PR.

### Tests

`test:caldav` 38 grün. Neu ist unter anderem eine Gegenprobe, dass ein aktiver Sync nicht mitverstummt und genau eine `info`-Zeile pro Lauf schreibt. Die Positivkontrolle im No-op-Test läuft jetzt über einen Zähler in der Client-Factory statt über das Log, weil `debug` im Standard-Level gar nicht erst emittiert wird.

Gegenprobe per Mutation: jede der drei Änderungen einzeln zurückgedreht macht je einen Test rot (2 / 1 / 1 Fehlschläge).

Dazu grün: `caldav-recurrence`, `caldav-reminders`, `caldav-event-target`, `caldav-outbound`, `calendar`.
