### PR TITLE
fix(caldav): skip writes for unchanged events and log only real changes

### DIFF
--- a/server/services/caldav-sync.js
+++ b/server/services/caldav-sync.js
@@ -399,6 +399,10 @@ async function sync({ createClient } = {}) {
   const makeClient = createClient || defaultClientFactory;
 
   let totalSyncedEvents = 0;
+  // Getrennt von totalSyncedEvents: gesehen ist nicht geändert. Ein Kalender mit
+  // 47 Terminen liefert bei jedem Lauf 47 gesehene Events, aber im Regelfall
+  // null geänderte - und nur letzteres ist eine Meldung im Standard-Log wert.
+  let totalChangedEvents = 0;
   let successfulAccounts = 0;
 
   // Hot-Path-Statements einmal vorbereiten statt pro Event neu (#519): das spart bei
@@ -409,6 +413,15 @@ async function sync({ createClient } = {}) {
   );
   // Offene Löschungen einmal je Lauf, nicht je eingehendem Termin.
   const pendingDeletionUids = outbound.pendingDeletionUids('caldav');
+  // Der Vergleich in der WHERE-Klausel hält das Statement von Schreibvorgängen
+  // ab, die nichts ändern: ohne ihn meldet SQLite auch bei identischen Werten
+  // changes = 1, sodass sich ein Tick über einen unveränderten Kalender nicht
+  // von einem mit echten Änderungen unterscheiden lässt. Nebeneffekt: der
+  // Normalfall (nichts hat sich geändert) erzeugt keine WAL-Writes mehr.
+  // `IS NOT` statt `<>`, weil der Vergleich NULL-sicher sein muss, und die
+  // beiden abgeleiteten Spalten wiederholen ihren SET-Ausdruck, damit eine
+  // lokale Umfärbung (user_modified) bzw. ein fehlendes obj.url nicht als
+  // Unterschied zählt. Die Bindings der SET-Liste kommen dafür ein zweites Mal.
   const updEvent = conn.prepare(`
     UPDATE calendar_events
     SET title = ?, description = ?, start_datetime = ?, end_datetime = ?,
@@ -417,6 +430,18 @@ async function sync({ createClient } = {}) {
         calendar_ref_id = ?,
         external_object_url = COALESCE(?, external_object_url)
     WHERE id = ?
+      AND (   title               IS NOT ?
+           OR description         IS NOT ?
+           OR start_datetime      IS NOT ?
+           OR end_datetime        IS NOT ?
+           OR all_day             IS NOT ?
+           OR location            IS NOT ?
+           OR recurrence_rule     IS NOT ?
+           OR tzid                IS NOT ?
+           OR color               IS NOT CASE WHEN user_modified = 0 THEN ? ELSE color END
+           OR calendar_ref_id     IS NOT ?
+           OR external_object_url IS NOT COALESCE(?, external_object_url)
+          )
   `);
   const insEvent = conn.prepare(`
     INSERT INTO calendar_events
@@ -458,6 +483,7 @@ async function sync({ createClient } = {}) {
 
       // Inbound sync: CalDAV → Yuvomi
       let accountEventCount = 0;
+      let accountChangedCount = 0;
       let processedObjects = 0; // Zähler für den Event-Loop-Yield (#519)
 
       // Für die Löschphase: pro erfolgreich abgerufenem Kalender die gesehenen UIDs.
@@ -538,14 +564,20 @@ async function sync({ createClient } = {}) {
               }
 
               let eventId;
+              // Ob dieser Termin den lokalen Stand wirklich verändert hat. Nur
+              // das zählt als Änderung, nicht das bloße Wiedersehen.
+              let changed = false;
               if (existing) {
                 // Update: color nur überschreiben, solange der Nutzer nicht lokal
                 // umgefärbt hat (user_modified = 0); Titel/Zeit bleiben remote-geführt.
-                updEvent.run(
+                // Dieselben Werte binden die SET-Liste und den Vergleich in der
+                // WHERE-Klausel, weshalb sie zweimal übergeben werden.
+                const values = [
                   ev.summary, ev.description, ev.dtstart, ev.dtend,
                   ev.allDay ? 1 : 0, ev.location, ev.rrule, ev.tzid ?? null, evColor, calRefId,
-                  obj.url ?? null, existing.id
-                );
+                  obj.url ?? null,
+                ];
+                changed = updEvent.run(...values, existing.id, ...values).changes > 0;
                 eventId = existing.id;
               } else {
                 // Insert
@@ -555,17 +587,23 @@ async function sync({ createClient } = {}) {
                   obj.url ?? null
                 );
                 eventId = Number(inserted.lastInsertRowid);
+                changed = true;
                 // Standard-Zuweisung dieses Kalenders (#459) auf den neuen Termin.
                 assignDefaultToEvent(db.get(), eventId, calDefaultAssignee);
               }
 
               // EXDATE + ersetzte Override-Termine als Instanz-Ausnahmen ablegen,
               // damit die Expansion diese Vorkommen überspringt (#489/#549).
+              // INSERT OR IGNORE meldet changes = 0, wenn die Ausnahme schon
+              // steht, sodass auch hier nur echter Zuwachs als Änderung zählt.
               if (ev.rrule && Array.isArray(ev.exdates)) {
-                for (const exDate of ev.exdates) insException.run(eventId, exDate);
+                for (const exDate of ev.exdates) {
+                  if (insException.run(eventId, exDate).changes > 0) changed = true;
+                }
               }
 
               accountEventCount++;
+              if (changed) accountChangedCount++;
             } catch (err) {
               log.error(`Failed to upsert event UID ${ev.uid}:`, err.message);
             }
@@ -650,6 +688,7 @@ async function sync({ createClient } = {}) {
           `).run(uid, objectUrl, calRefId, event.id);
 
           accountEventCount++;
+          accountChangedCount++;
         } catch (err) {
           log.error(`Failed to upload event ${event.id} to CalDAV:`, err.message);
         }
@@ -660,12 +699,17 @@ async function sync({ createClient } = {}) {
         UPDATE caldav_accounts SET last_sync = ? WHERE id = ?
       `).run(new Date().toISOString(), account.id);
 
-      totalSyncedEvents += accountEventCount;
+      // Serverseitige Löschungen sind ebenfalls echte Änderungen am lokalen Stand.
+      accountChangedCount += deletedCount;
+
+      totalSyncedEvents  += accountEventCount;
+      totalChangedEvents += accountChangedCount;
       successfulAccounts++;
 
       log.debug(
-        `Account ${account.id} sync complete: ${accountEventCount} events` +
-        `${deletedCount > 0 ? `, ${deletedCount} deleted` : ''}.`
+        `Account ${account.id} sync complete: ${accountEventCount} events seen, ` +
+        `${accountChangedCount} changed` +
+        `${deletedCount > 0 ? ` (${deletedCount} deleted)` : ''}.`
       );
 
     } catch (err) {
@@ -674,12 +718,13 @@ async function sync({ createClient } = {}) {
     }
   }
 
-  // Die Zusammenfassung gehört nur ins Standard-Log, wenn der Lauf tatsächlich
-  // etwas verarbeitet hat. Ein Tick ohne Ergebnis (keine aktivierten Kalender,
-  // leere Kalender, fehlgeschlagene Accounts) bleibt still; Fehler melden sich
-  // ohnehin einzeln über log.error.
-  const summary = `CalDAV sync complete: ${successfulAccounts}/${accounts.length} accounts, ${totalSyncedEvents} events.`;
-  if (totalSyncedEvents > 0) log.info(summary);
+  // Die Zusammenfassung gehört nur ins Standard-Log, wenn der Lauf den lokalen
+  // Stand tatsächlich verändert hat. Ein Tick, der einen unveränderten Kalender
+  // bloß erneut abruft, bleibt damit ebenso still wie einer ohne aktivierte
+  // Kalender; Fehler melden sich ohnehin einzeln über log.error.
+  const summary = `CalDAV sync complete: ${successfulAccounts}/${accounts.length} accounts, `
+    + `${totalSyncedEvents} events seen, ${totalChangedEvents} changed.`;
+  if (totalChangedEvents > 0) log.info(summary);
   else log.debug(summary);
 
   return { success: true, syncedAccounts: successfulAccounts, syncedEvents: totalSyncedEvents };

--- a/test/test-caldav-sync.js
+++ b/test/test-caldav-sync.js
@@ -856,4 +856,82 @@ describe('CalDAV: No-op-Syncs bleiben im Standard-Log-Level still', () => {
       d.close();
     }
   });
+
+  // --- Wiederholte Läufe über unveränderte Termine ---------------------------
+  // Der Regelfall im Betrieb: der Scheduler ruft denselben Kalender immer
+  // wieder ab, ohne dass sich etwas geändert hat.
+
+  const CALENDAR_URL = 'https://dav.example/cal-1/';
+
+  function seedAccountWithCalendar(d) {
+    d.exec(`
+      INSERT INTO caldav_accounts (name, caldav_url, username, password)
+        VALUES ('Radicale', 'https://dav.example/', 'u', 'p');
+      INSERT INTO caldav_calendar_selection
+        (account_id, calendar_url, calendar_name, calendar_color, enabled)
+        VALUES (1, '${CALENDAR_URL}', 'Cal 1', '#4A90E2', 1);
+    `);
+  }
+
+  // Client, der einen einzelnen Termin mit steuerbarem Titel liefert.
+  function clientWith(summary) {
+    return async () => ({
+      fetchCalendars:       async () => [{ url: CALENDAR_URL, displayName: 'Cal 1' }],
+      fetchCalendarObjects: async () => [{
+        data: [
+          'BEGIN:VCALENDAR', 'VERSION:2.0', 'BEGIN:VEVENT',
+          'UID:evt-1@test', `SUMMARY:${summary}`,
+          'DTSTART:20260101T100000Z', 'DTEND:20260101T110000Z',
+          'END:VEVENT', 'END:VCALENDAR',
+        ].join('\r\n'),
+      }],
+      createCalendarObject: async () => ({}),
+    });
+  }
+
+  it('bleibt still, wenn ein zweiter Lauf denselben Termin unverändert sieht', async () => {
+    const d = buildDb();
+    seedAccountWithCalendar(d);
+    _setTestDatabase(d);
+    try {
+      const createClient = clientWith('Event 1');
+      await captureConsole(() => sync({ createClient })); // erster Lauf legt an
+
+      const lines = await captureConsole(async () => {
+        const res = await sync({ createClient });
+        // Der Termin wird weiterhin gesehen, er ändert nur nichts mehr.
+        assert.strictEqual(res.syncedEvents, 1);
+      });
+      assert.deepStrictEqual(lines.info, [], 'unveränderter Lauf muss schweigen');
+      const row = d.prepare('SELECT COUNT(*) AS n FROM calendar_events').get();
+      assert.strictEqual(row.n, 1, 'kein Duplikat angelegt');
+    } finally {
+      _resetTestDatabase();
+      d.close();
+    }
+  });
+
+  // Gegenprobe zur WHERE-Klausel: sie darf echte Änderungen nicht wegfiltern.
+  // Ein falsches Negativ hier wäre Datenverlust, nicht bloß fehlendes Logging.
+  it('übernimmt und meldet einen Termin, dessen Titel sich geändert hat', async () => {
+    const d = buildDb();
+    seedAccountWithCalendar(d);
+    _setTestDatabase(d);
+    try {
+      await captureConsole(() => sync({ createClient: clientWith('Event 1') }));
+
+      const lines = await captureConsole(() =>
+        sync({ createClient: clientWith('Event 1 geändert') })
+      );
+      assert.ok(
+        lines.info.some((l) => l.includes('1 events seen, 1 changed')),
+        `Änderung nicht gemeldet: ${JSON.stringify(lines.info)}`
+      );
+      const row = d.prepare('SELECT title FROM calendar_events').get();
+      assert.strictEqual(row.title, 'Event 1 geändert', 'Änderung nicht übernommen');
+    } finally {
+      _resetTestDatabase();
+      d.close();
+    }
+  });
 });


### PR DESCRIPTION
Löst den Punkt ein, der in #602 bewusst offen blieb.

Der Inbound-Upsert schrieb jeden Termin bei jedem Tick neu. SQLite meldet `changes = 1` auch bei identischen Werten, es gab also kein Signal, das einen Lauf mit echten Änderungen von einem bloßen Wiedereinlesen unterscheidet. Entsprechend behauptete die Zusammenfassung bei einem unberührten Kalender in jedem Scheduler-Tick "47 events".

### Änderung

Das `UPDATE` bekommt dieselben Werte ein zweites Mal als NULL-sicheren `IS NOT`-Vergleich in die `WHERE`-Klausel und schreibt nur noch bei echter Abweichung. Die beiden abgeleiteten Spalten wiederholen ihren SET-Ausdruck, damit eine lokale Umfärbung (`user_modified`) und ein fehlendes `obj.url` nicht als Unterschied durchgehen:

```sql
OR color               IS NOT CASE WHEN user_modified = 0 THEN ? ELSE color END
OR external_object_url IS NOT COALESCE(?, external_object_url)
```

Die Zählung ist getrennt:

- `totalSyncedEvents` behält seine Bedeutung für den Rückgabewert (gesehene Events), damit der #519-Test und alle Aufrufer unverändert bleiben.
- Ein zweiter Zähler erfasst, was den lokalen Stand wirklich verändert hat: Inserts, Updates mit `changes > 0`, neue EXDATE-Ausnahmen, Outbound-Uploads, serverseitige Löschungen. Nur er hebt die Zusammenfassung auf `info`.

Die Zeile lautet dadurch `... 47 events seen, 3 changed.` statt der irreführenden `47 events`.

Nebeneffekt: ein unveränderter Kalender erzeugt keine WAL-Writes mehr.

### Tests

Zwei neue Tests decken genau diese Änderung ab:

1. Ein zweiter Lauf über identische Daten bleibt still und legt nichts an.
2. Gegenprobe: ein geänderter Titel muss weiterhin ankommen. Ein falsches Negativ wäre hier Datenverlust, nicht bloß fehlendes Logging.

Mutationsprobe, jeweils einzeln zurückgedreht:

| Mutation | rote Tests |
|---|---|
| Vergleich auf immer-wahr aufweichen (alter Stand) | 1 |
| Zusammenfassung wieder an "gesehen" statt "geändert" hängen | 1 |
| Titelvergleich invertieren (`IS NOT` → `IS`) | 2 |

`test:caldav` 40 grün, volle `npm test`-Kette durchgelaufen.

### Nicht enthalten

Dasselbe Schreibmuster steckt vermutlich auch in `google-calendar`, `cardav-sync` und `ics-subscription`. Hier ist nur CalDAV angefasst.
