### PR TITLE
fix(sync): skip unchanged writes in Google and CardDAV, fix a CardDAV duplicate

### DIFF
--- a/server/services/cardav-sync.js
+++ b/server/services/cardav-sync.js
@@ -1311,14 +1311,53 @@ function updateContact(contactId, vcard, fillAll = false) {
  * @param {Object} vcard - Parsed vCard object
  */
 function updateContactMultiValues(contactId, vcard) {
-  const transaction = db.get().transaction(() => {
+  const conn = db.get();
+
+  const phones    = conn.prepare('SELECT label, value, is_primary FROM contact_phones WHERE contact_id = ? ORDER BY id').all(contactId);
+  const emails    = conn.prepare('SELECT label, value, is_primary FROM contact_emails WHERE contact_id = ? ORDER BY id').all(contactId);
+  const addresses = conn.prepare(`SELECT label, street, city, state, postal_code, country, is_primary
+                                  FROM contact_addresses WHERE contact_id = ? ORDER BY id`).all(contactId);
+
+  // Ein primärer Eintrag überlebt die Löschung unten. Steht sein Wert auch in
+  // der vCard, legte der anschließende Insert ihn ein zweites Mal als
+  // nicht-primäre Kopie an - bei jedem Sync aufs Neue. Deshalb fällt er hier
+  // aus der Einfügeliste heraus.
+  const keyOf        = (r) => `${r.label ?? ''} ${r.value ?? ''}`;
+  const addressKeyOf = (r) => [
+    r.label, r.street, r.city, r.state, r.postal_code ?? r.postalCode, r.country,
+  ].map((v) => v ?? '').join(' ');
+
+  const primaryKeys = (rows, key) => new Set(rows.filter((r) => r.is_primary).map(key));
+  const without     = (list, taken, key) => (list ?? []).filter((e) => !taken.has(key(e)));
+
+  const incoming = {
+    ...vcard,
+    phones:    without(vcard.phones,    primaryKeys(phones, keyOf),           keyOf),
+    emails:    without(vcard.emails,    primaryKeys(emails, keyOf),           keyOf),
+    addresses: without(vcard.addresses, primaryKeys(addresses, addressKeyOf), addressKeyOf),
+  };
+
+  // Steht der gewünschte Bestand schon so in der Datenbank, gar nicht erst
+  // schreiben: der Regelfall im Betrieb ist der unveränderte Kontakt.
+  const sameSet = (rows, list, key) => {
+    const a = rows.filter((r) => !r.is_primary).map(key).sort();
+    const b = (list ?? []).map(key).sort();
+    return a.length === b.length && a.every((v, i) => v === b[i]);
+  };
+  if (sameSet(phones,    incoming.phones,    keyOf) &&
+      sameSet(emails,    incoming.emails,    keyOf) &&
+      sameSet(addresses, incoming.addresses, addressKeyOf)) {
+    return;
+  }
+
+  const transaction = conn.transaction(() => {
     // Delete non-primary entries
-    db.get().prepare('DELETE FROM contact_phones WHERE contact_id = ? AND is_primary = 0').run(contactId);
-    db.get().prepare('DELETE FROM contact_emails WHERE contact_id = ? AND is_primary = 0').run(contactId);
-    db.get().prepare('DELETE FROM contact_addresses WHERE contact_id = ? AND is_primary = 0').run(contactId);
+    conn.prepare('DELETE FROM contact_phones WHERE contact_id = ? AND is_primary = 0').run(contactId);
+    conn.prepare('DELETE FROM contact_emails WHERE contact_id = ? AND is_primary = 0').run(contactId);
+    conn.prepare('DELETE FROM contact_addresses WHERE contact_id = ? AND is_primary = 0').run(contactId);
 
     // Insert new entries from vCard
-    insertContactMultiValues(contactId, vcard);
+    insertContactMultiValues(contactId, incoming);
   });
 
   transaction();

--- a/server/services/google-calendar.js
+++ b/server/services/google-calendar.js
@@ -639,7 +639,11 @@ async function sync() {
         log.error(`Outbound error for event ${event.id}:`, err.message);
       }
     }
-    log.info(`Sync completed - ${localEvents.length} candidate local → Google.`);
+    // Ohne Kandidaten hat der Outbound nichts getan - das gehört nicht in jeden
+    // Scheduler-Tick des Standard-Logs.
+    const outboundSummary = `Sync completed - ${localEvents.length} candidate local → Google.`;
+    if (localEvents.length > 0) log.info(outboundSummary);
+    else log.debug(outboundSummary);
   }
 
   cfgSet('google_last_sync', new Date().toISOString());
@@ -801,6 +805,16 @@ function upsertGoogleEvents(items, calRefId = null, calColor = GOOGLE_COLOR, col
       // (user_modified = 0). Dadurch bleiben benutzerdefinierte Event-Farben über
       // Syncs hinweg erhalten (Issue #219), während echte Google-Farbänderungen
       // weiterhin durchkommen. Titel/Zeit bleiben unverändert remote-geführt.
+      // Der Vergleich in der WHERE-Klausel hält Schreibvorgänge ab, die nichts
+      // ändern: ein Full-Resync (abgelaufener syncToken) liefert den kompletten
+      // Kalender erneut, und ohne den Vergleich würde jede Zeile davon neu
+      // geschrieben. `IS NOT` statt `<>`, weil der Vergleich NULL-sicher sein
+      // muss; die Farbspalte wiederholt ihren SET-Ausdruck, damit eine lokale
+      // Umfärbung (user_modified) nicht als Unterschied zählt. Die Bindings der
+      // SET-Liste kommen dafür ein zweites Mal.
+      const values = [
+        title, description, startDt, endDt, allDay ? 1 : 0, location, rrule, evColor, calRefId,
+      ];
       db.get().prepare(`
         UPDATE calendar_events
         SET title = ?, description = ?, start_datetime = ?, end_datetime = ?,
@@ -808,7 +822,17 @@ function upsertGoogleEvents(items, calRefId = null, calColor = GOOGLE_COLOR, col
             color = CASE WHEN user_modified = 0 THEN ? ELSE color END,
             calendar_ref_id = ?
         WHERE id = ?
-      `).run(title, description, startDt, endDt, allDay ? 1 : 0, location, rrule, evColor, calRefId, existing.id);
+          AND (   title           IS NOT ?
+               OR description     IS NOT ?
+               OR start_datetime  IS NOT ?
+               OR end_datetime    IS NOT ?
+               OR all_day         IS NOT ?
+               OR location        IS NOT ?
+               OR recurrence_rule IS NOT ?
+               OR color           IS NOT CASE WHEN user_modified = 0 THEN ? ELSE color END
+               OR calendar_ref_id IS NOT ?
+              )
+      `).run(...values, existing.id, ...values);
     } else {
       const inserted = db.get().prepare(`
         INSERT INTO calendar_events

--- a/test/test-carddav.js
+++ b/test/test-carddav.js
@@ -3192,6 +3192,81 @@ describe('parseAndMergeContact scalar + category wiring (#531 DB integration)', 
     assert.strictEqual(c.name, 'Mein eigener Name', 'lokaler Name bleibt erhalten');
     assert.strictEqual(c.last_name, 'Schmidt', 'Struktur wird trotzdem nachgetragen');
   });
+
+  // --- Wiederholte Syncs derselben vCard ------------------------------------
+  // updateContactMultiValues nimmt den primären Eintrag von der Löschung aus,
+  // fügte aber die komplette vCard erneut ein. Der primäre Wert landete damit
+  // bei jedem Sync zusätzlich als nicht-primäre Kopie in der Tabelle.
+
+  const phonesOf = (id) => database.prepare(
+    'SELECT label, value, is_primary FROM contact_phones WHERE contact_id = ? ORDER BY id'
+  ).all(id);
+
+  it('legt bei wiederholtem Sync derselben vCard keine Dubletten an', async () => {
+    const card = vcf('dup-1', 'FN:Alex Beispiel',
+      'TEL;TYPE=CELL:+49 170 1234567', 'TEL;TYPE=WORK:+49 30 9876543',
+      'EMAIL;TYPE=HOME:alex@example.org');
+
+    const id = await parseAndMergeContact(card, accountId, abUrl);
+    await parseAndMergeContact(card, accountId, abUrl);
+    await parseAndMergeContact(card, accountId, abUrl);
+
+    assert.deepStrictEqual(phonesOf(id), [
+      { label: 'cell', value: '+49 170 1234567', is_primary: 1 },
+      { label: 'work', value: '+49 30 9876543',  is_primary: 0 },
+    ]);
+    const mails = database.prepare(
+      'SELECT COUNT(*) AS n FROM contact_emails WHERE contact_id = ?'
+    ).get(id).n;
+    assert.strictEqual(mails, 1, 'die Mailadresse darf sich nicht vervielfachen');
+  });
+
+  it('räumt eine bereits vorhandene Dublette beim nächsten Sync ab', async () => {
+    const card = vcf('dup-2', 'FN:Bea Beispiel', 'TEL;TYPE=CELL:+49 170 2222222');
+    const id = await parseAndMergeContact(card, accountId, abUrl);
+
+    // Zustand, den der alte Code hinterlassen hat: der primäre Wert steht ein
+    // zweites Mal als nicht-primäre Zeile daneben.
+    database.prepare(
+      'INSERT INTO contact_phones (contact_id, label, value, is_primary) VALUES (?, ?, ?, 0)'
+    ).run(id, 'cell', '+49 170 2222222');
+    assert.strictEqual(phonesOf(id).length, 2, 'Vorbedingung: Dublette liegt vor');
+
+    await parseAndMergeContact(card, accountId, abUrl);
+
+    assert.deepStrictEqual(phonesOf(id), [
+      { label: 'cell', value: '+49 170 2222222', is_primary: 1 },
+    ]);
+  });
+
+  it('schreibt beim Sync einer unveränderten vCard gar nicht mehr', async () => {
+    const card = vcf('dup-3', 'FN:Cem Beispiel',
+      'TEL;TYPE=CELL:+49 170 3333333', 'TEL;TYPE=WORK:+49 30 3333333');
+    await parseAndMergeContact(card, accountId, abUrl);
+    await parseAndMergeContact(card, accountId, abUrl); // Bestand einschwingen lassen
+
+    const changes = () => database.prepare('SELECT total_changes() AS n').get().n;
+    const before = changes();
+    await parseAndMergeContact(card, accountId, abUrl);
+    assert.strictEqual(changes() - before, 0, 'unveränderter Kontakt darf nichts schreiben');
+  });
+
+  // Gegenprobe: der Vergleich darf echte Änderungen nicht verschlucken.
+  it('übernimmt eine neu hinzugekommene Nummer', async () => {
+    const id = await parseAndMergeContact(
+      vcf('dup-4', 'FN:Dana Beispiel', 'TEL;TYPE=CELL:+49 170 4444444'), accountId, abUrl
+    );
+    await parseAndMergeContact(
+      vcf('dup-4', 'FN:Dana Beispiel', 'TEL;TYPE=CELL:+49 170 4444444',
+        'TEL;TYPE=WORK:+49 30 4444444'),
+      accountId, abUrl
+    );
+
+    assert.deepStrictEqual(phonesOf(id), [
+      { label: 'cell', value: '+49 170 4444444', is_primary: 1 },
+      { label: 'work', value: '+49 30 4444444',  is_primary: 0 },
+    ]);
+  });
 });
 
 // --------------------------------------------------------

--- a/test/test-google-calendar.js
+++ b/test/test-google-calendar.js
@@ -506,5 +506,40 @@ await testAsync('Zweiter Aufruf trifft den Cache (kein weiterer colors.get)', as
 });
 
 // --------------------------------------------------------
+// Wiederholte Läufe über unveränderte Events. Ein abgelaufener syncToken
+// zwingt zum Full-Resync, der den kompletten Kalender erneut liefert - ohne
+// Wertvergleich im UPDATE würde davon jede Zeile neu geschrieben.
+// --------------------------------------------------------
+
+// Zählt alle Zeilenänderungen seit dem Öffnen der Verbindung.
+const totalChanges = () => db.prepare('SELECT total_changes() AS n').get().n;
+
+test('Re-Sync unveränderter Events fasst keine Zeile an', () => {
+  const item     = { ...gEvent, id: 'evt-unchanged' };
+  const calRefId = upsertExternalCalendar('google', 'primary', 'Mein Kalender', '#FF0000');
+  upsertGoogleEvents([item], calRefId, '#FF0000', COLOR_MAP);
+
+  const before = totalChanges();
+  upsertGoogleEvents([item], calRefId, '#FF0000', COLOR_MAP);
+  assertEqual(totalChanges() - before, 0, 'unveränderter Re-Sync darf nichts schreiben');
+});
+
+// Gegenprobe: der Vergleich darf echte Änderungen nicht wegfiltern. Ein
+// falsches Negativ wäre hier Datenverlust, nicht bloß gesparte Schreiblast.
+test('Re-Sync mit geändertem Titel kommt weiterhin an', () => {
+  const item     = { ...gEvent, id: 'evt-changed' };
+  const calRefId = upsertExternalCalendar('google', 'primary', 'Mein Kalender', '#FF0000');
+  upsertGoogleEvents([item], calRefId, '#FF0000', COLOR_MAP);
+
+  upsertGoogleEvents(
+    [{ ...item, summary: 'Team-Meeting (verschoben)' }], calRefId, '#FF0000', COLOR_MAP
+  );
+  const row = db.prepare(
+    'SELECT title FROM calendar_events WHERE external_calendar_id = ?'
+  ).get('evt-changed');
+  assertEqual(row.title, 'Team-Meeting (verschoben)', 'Titeländerung muss ankommen');
+});
+
+// --------------------------------------------------------
 console.log(`\n  ${passed} passed, ${failed} failed\n`);
 if (failed > 0) process.exit(1);


### PR DESCRIPTION
Zieht das Muster aus #603 auf die übrigen Sync-Services nach. Bei CardDAV kam dabei ein echter Datenfehler zum Vorschein, der nichts mit dem Muster zu tun hat.

## 1. google-calendar: dasselbe Muster wie CalDAV

Der Inbound-Upsert schrieb jedes empfangene Event neu. Besonders teuer nach einem abgelaufenen syncToken: der erzwungene Full-Resync liefert den kompletten Kalender und schrieb ihn bisher komplett neu, auch ohne jede Änderung.

Das `UPDATE` führt seine Werte jetzt ein zweites Mal als NULL-sicheren `IS NOT`-Vergleich und schreibt nur bei echter Abweichung. Die Farbspalte wiederholt ihren SET-Ausdruck, damit eine lokale Umfärbung (`user_modified`) nicht als Unterschied zählt.

Dazu die Outbound-Zusammenfassung: `Sync completed - 0 candidate local → Google.` feuerte bei jedem Tick, jetzt nur noch auf `info`, wenn es mindestens einen Kandidaten gibt.

## 2. cardav-sync: nicht das Muster, sondern eine Dublette

Der Skalarpfad hatte das Problem gar nicht. `updateContact()` baut seine SET-Liste über `maybeUpdate` dynamisch und bricht bei `updates.length === 0` ab, schreibt also längst nur bei Bedarf.

`updateContactMultiValues()` dagegen nimmt primäre Zeilen von der Löschung aus und reichte anschließend die **komplette** vCard an den Insert weiter. Stand ein vCard-Wert bereits als primäre Zeile, legte der Insert ihn ein zweites Mal als nicht-primäre Kopie an. Gemessen gegen eine migrierte In-Memory-DB, dreimal dieselbe unveränderte vCard:

```
Lauf 1: phones=2  [cell +49 170 1234567 (primary), work +49 30 9876543]
Lauf 2: phones=3  [cell (primary), cell (Kopie), work]
Lauf 3: phones=3  (stabil, aber die Dublette bleibt)
```

`contact_phones` hat keinen UNIQUE-Constraint, der das abfängt. Die doppelte Nummer ist im UI sichtbar und entsteht auf jeder CardDAV-Installation, gleiches gilt für Mails und Adressen.

Werte, die bereits als primäre Zeile stehen, fallen jetzt aus der Einfügeliste. Das repariert bestehende Dubletten beim nächsten Sync, ohne Migration. Und wenn der gespeicherte Satz dem Zielzustand schon entspricht, kehrt die Funktion vor der Transaktion zurück, ein unveränderter Kontakt schreibt also gar nicht mehr.

## Tests

google-calendar (2): ein zweiter Upsert unveränderter Daten fasst keine Zeile an (gemessen über `total_changes()`), ein geänderter Titel kommt weiterhin an.

cardav-sync (4): keine Dubletten über wiederholte Syncs, eine bestehende Dublette wird abgeräumt, ein unveränderter Sync schreibt nichts, eine neu hinzugekommene Nummer kommt an.

Mutationsproben, jeweils einzeln zurückgedreht:

| Mutation | rote Tests |
|---|---|
| Google: Vergleich auf immer-wahr | 1 |
| Google: Titelvergleich invertiert | 3 |
| CardDAV: ungefilterte vCard zurück in den Insert | 2 |
| CardDAV: Early-Return entfernt | 1 |

Volle `npm test`-Suite grün (Exit 0, explizit geprüft).

## Nicht enthalten

`ics-subscription` ist nicht angefasst. Ebenso unverändert bleibt das Altverhalten, dass ein lokal ergänzter nicht-primärer Eintrag beim nächsten Sync verschwindet, das ist kein Teil dieses Bugs.
