### PR TITLE
fix(ics): stop rewriting unchanged subscription events

### DIFF
--- a/server/services/ics-subscription.js
+++ b/server/services/ics-subscription.js
@@ -166,32 +166,41 @@ async function syncOne(sub) {
         .all(sub.id).map((r) => r.external_calendar_id)
     );
 
-    const upsert = db.get().prepare(`
+    // Bekannte UIDs werden nachgeschlagen statt blind eingefügt: ein INSERT mit
+    // ON CONFLICT reserviert bei AUTOINCREMENT auch dann eine neue Rowid und
+    // schreibt sqlite_sequence fort, wenn das DO UPDATE per WHERE unterdrückt
+    // wird. Ein unveränderter Lauf würde also weiterhin schreiben, nur für
+    // changes und total_changes() unsichtbar.
+    const findExisting = db.get().prepare(`
+      SELECT id FROM calendar_events
+      WHERE subscription_id = ? AND external_calendar_id = ?
+    `);
+
+    const insertEvent = db.get().prepare(`
       INSERT INTO calendar_events
         (title, description, start_datetime, end_datetime, all_day, location,
          color, external_calendar_id, external_source, subscription_id, recurrence_rule, user_modified, created_by)
       VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'ics', ?, ?, 0, ?)
-      ON CONFLICT(subscription_id, external_calendar_id) DO UPDATE SET
-        title          = excluded.title,
-        description    = excluded.description,
-        start_datetime = excluded.start_datetime,
-        end_datetime   = excluded.end_datetime,
-        all_day        = excluded.all_day,
-        location       = excluded.location,
-        color          = excluded.color
-      -- Der Wertvergleich hält Schreibvorgänge ab, die nichts ändern. Liefert
-      -- ein Server kein ETag, kommt bei jedem Lauf der komplette Kalender neu
-      -- an, und ohne ihn würde davon jede Zeile neu geschrieben. IS NOT statt
-      -- Ungleich wegen der NULL-Sicherheit; die Gegenwerte stehen bereits als
-      -- excluded.* bereit, es braucht also keine zweiten Bindings.
-      WHERE user_modified = 0
-        AND (   title          IS NOT excluded.title
-             OR description    IS NOT excluded.description
-             OR start_datetime IS NOT excluded.start_datetime
-             OR end_datetime   IS NOT excluded.end_datetime
-             OR all_day        IS NOT excluded.all_day
-             OR location       IS NOT excluded.location
-             OR color          IS NOT excluded.color
+    `);
+
+    // Der Wertvergleich hält Schreibvorgänge ab, die nichts ändern: liefert ein
+    // Server kein ETag, kommt bei jedem Lauf der komplette Kalender erneut an.
+    // IS NOT statt Ungleich wegen der NULL-Sicherheit. Verglichen wird genau
+    // über die Spalten, die auch gesetzt werden - recurrence_rule bleibt beim
+    // Update außen vor, wie zuvor beim ON CONFLICT, und darf deshalb auch den
+    // Vergleich nicht auslösen.
+    const updateEvent = db.get().prepare(`
+      UPDATE calendar_events
+      SET title = ?, description = ?, start_datetime = ?, end_datetime = ?,
+          all_day = ?, location = ?, color = ?
+      WHERE id = ? AND user_modified = 0
+        AND (   title          IS NOT ?
+             OR description    IS NOT ?
+             OR start_datetime IS NOT ?
+             OR end_datetime   IS NOT ?
+             OR all_day        IS NOT ?
+             OR location       IS NOT ?
+             OR color          IS NOT ?
             )
     `);
 
@@ -211,8 +220,20 @@ async function syncOne(sub) {
       for (const ev of flatEvents) {
         try {
           // Event-Eigenfarbe (RFC 7986) hat Vorrang, sonst die Abo-Farbe.
-          changedEvents += upsert.run(ev.summary, ev.description, ev.dtstart, ev.dtend,
-            ev.allDay ? 1 : 0, ev.location, ev.color || sub.color, ev.uid, sub.id, ev.rrule, createdBy).changes;
+          const color    = ev.color || sub.color;
+          const existing = findExisting.get(sub.id, ev.uid);
+          if (existing) {
+            // Dieselben Werte binden die SET-Liste und den Vergleich.
+            const values = [
+              ev.summary, ev.description, ev.dtstart, ev.dtend,
+              ev.allDay ? 1 : 0, ev.location, color,
+            ];
+            changedEvents += updateEvent.run(...values, existing.id, ...values).changes;
+          } else {
+            insertEvent.run(ev.summary, ev.description, ev.dtstart, ev.dtend,
+              ev.allDay ? 1 : 0, ev.location, color, ev.uid, sub.id, ev.rrule, createdBy);
+            changedEvents++;
+          }
         } catch (err) { log.error(`Upsert UID ${ev.uid}: ${err.message}`); }
       }
       changedEvents += deleteStale.run(sub.id, JSON.stringify([...seenUids])).changes;

--- a/server/services/ics-subscription.js
+++ b/server/services/ics-subscription.js
@@ -179,7 +179,20 @@ async function syncOne(sub) {
         all_day        = excluded.all_day,
         location       = excluded.location,
         color          = excluded.color
+      -- Der Wertvergleich hält Schreibvorgänge ab, die nichts ändern. Liefert
+      -- ein Server kein ETag, kommt bei jedem Lauf der komplette Kalender neu
+      -- an, und ohne ihn würde davon jede Zeile neu geschrieben. IS NOT statt
+      -- Ungleich wegen der NULL-Sicherheit; die Gegenwerte stehen bereits als
+      -- excluded.* bereit, es braucht also keine zweiten Bindings.
       WHERE user_modified = 0
+        AND (   title          IS NOT excluded.title
+             OR description    IS NOT excluded.description
+             OR start_datetime IS NOT excluded.start_datetime
+             OR end_datetime   IS NOT excluded.end_datetime
+             OR all_day        IS NOT excluded.all_day
+             OR location       IS NOT excluded.location
+             OR color          IS NOT excluded.color
+            )
     `);
 
     const deleteStale = db.get().prepare(`
@@ -189,15 +202,20 @@ async function syncOne(sub) {
         AND user_modified = 0
     `);
 
+    // Zählt, was den lokalen Stand wirklich verändert hat. Gesehen ist nicht
+    // geändert: ein Abo mit 200 Terminen liefert bei jedem Lauf 200 Events,
+    // im Regelfall aber keine einzige Änderung.
+    let changedEvents = 0;
+
     db.get().transaction(() => {
       for (const ev of flatEvents) {
         try {
           // Event-Eigenfarbe (RFC 7986) hat Vorrang, sonst die Abo-Farbe.
-          upsert.run(ev.summary, ev.description, ev.dtstart, ev.dtend,
-            ev.allDay ? 1 : 0, ev.location, ev.color || sub.color, ev.uid, sub.id, ev.rrule, createdBy);
+          changedEvents += upsert.run(ev.summary, ev.description, ev.dtstart, ev.dtend,
+            ev.allDay ? 1 : 0, ev.location, ev.color || sub.color, ev.uid, sub.id, ev.rrule, createdBy).changes;
         } catch (err) { log.error(`Upsert UID ${ev.uid}: ${err.message}`); }
       }
-      deleteStale.run(sub.id, JSON.stringify([...seenUids]));
+      changedEvents += deleteStale.run(sub.id, JSON.stringify([...seenUids])).changes;
 
       // #459: neu importierte Termine der Standard-Person zuweisen.
       if (sub.default_assignee_user_id) {
@@ -214,7 +232,11 @@ async function syncOne(sub) {
         .run(new Date().toISOString(), newEtag, newLastModified, sub.id);
     })();
 
-    log.info(`Subscription ${sub.id} (${sub.name}): ${flatEvents.length} events synced.`);
+    // Ein Lauf, der nichts verändert hat, gehört nicht ins Standard-Log: er
+    // wiederholt sich bei jedem Scheduler-Tick.
+    const summary = `Subscription ${sub.id} (${sub.name}): ${flatEvents.length} events seen, ${changedEvents} changed.`;
+    if (changedEvents > 0) log.info(summary);
+    else log.debug(summary);
   } finally { syncingNow.delete(sub.id); }
 }
 

--- a/test/test-ics-subscription.js
+++ b/test/test-ics-subscription.js
@@ -238,5 +238,115 @@ await (async () => {
   });
 })();
 
+// ---------------------------------------------------------------------------
+// Wiederholte Läufe über einen unveränderten Kalender.
+// Der ETag-Kurzschluss (notModified) greift nur, wenn der Server einen ETag
+// mitschickt. Ohne ihn kommt bei jedem Lauf der komplette Kalender erneut an
+// und lief bis dahin ungebremst in den Upsert.
+// ---------------------------------------------------------------------------
+
+console.log('\n[ICS-Subscription-Test] Unveränderte Läufe schreiben nicht\n');
+
+await (async () => {
+  const { MIGRATIONS } = await import('../server/db.js');
+  const dbModule = await import('../server/db.js');
+  const { sync } = await import('../server/services/ics-subscription.js');
+
+  // Eigene, voll migrierte DB: der Upsert braucht den UNIQUE-Index aus
+  // Migration 12, damit ON CONFLICT überhaupt greift. Hier better-sqlite3
+  // statt node:sqlite, weil syncOne() db.get().transaction() nutzt - die
+  // Methode gibt es nur im Produktionstreiber.
+  const { default: Database } = await import('better-sqlite3-multiple-ciphers');
+  const syncDb = new Database(':memory:');
+  syncDb.pragma('foreign_keys = ON');
+  syncDb.exec(`CREATE TABLE IF NOT EXISTS schema_migrations (
+    version INTEGER PRIMARY KEY, description TEXT NOT NULL,
+    applied_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now')))`);
+  for (const m of MIGRATIONS) {
+    if (typeof m.up === 'function') m.up(syncDb); else syncDb.exec(m.up);
+    if (typeof m.afterUp === 'function') m.afterUp(syncDb);
+    syncDb.prepare('INSERT INTO schema_migrations (version, description) VALUES (?, ?)')
+      .run(m.version, m.description);
+  }
+  syncDb.prepare(`INSERT INTO users (username, display_name, password_hash, role)
+                  VALUES ('owner', 'Owner', 'x', 'admin')`).run();
+
+  const icsWith = (summary) => [
+    'BEGIN:VCALENDAR', 'VERSION:2.0', 'PRODID:-//Test//EN',
+    'BEGIN:VEVENT', 'UID:sync-1@test', 'DTSTART:20260714T090000Z',
+    'DTEND:20260714T100000Z', `SUMMARY:${summary}`, 'END:VEVENT',
+    'END:VCALENDAR', '',
+  ].join('\r\n');
+
+  // Server ohne ETag/Last-Modified: erzwingt den vollen Durchlauf pro Sync.
+  let body = icsWith('Zahnarzt');
+  const server = http.createServer((req, res) => {
+    res.writeHead(200, { 'Content-Type': 'text/calendar; charset=utf-8' });
+    res.end(Buffer.from(body, 'utf8'));
+  });
+  await new Promise((r) => server.listen(0, '127.0.0.1', r));
+  const { port } = server.address();
+
+  process.env[ENV_FLAG] = '1';
+  dbModule._setTestDatabase(syncDb);
+  try {
+    const subId = syncDb.prepare(`
+      INSERT INTO ics_subscriptions (name, url, color, created_by)
+      VALUES ('Testabo', ?, '#123456', 1)
+    `).run(`http://127.0.0.1:${port}/cal.ics`).lastInsertRowid;
+
+    await atest('Erster Sync legt den Termin an', async () => {
+      await sync(subId);
+      const n = syncDb.prepare(
+        'SELECT COUNT(*) AS n FROM calendar_events WHERE subscription_id = ?'
+      ).get(subId).n;
+      assert(n === 1, `erwartet 1 Termin, waren ${n}`);
+    });
+
+    await atest('Zweiter Sync über unveränderte Daten fasst keine Zeile an', async () => {
+      // last_sync/etag-Update der Subscription zählt mit, deshalb nur die
+      // Termin-Tabelle betrachten: ihre Zeilen dürfen unangetastet bleiben.
+      const before = syncDb.prepare(
+        'SELECT id, title, start_datetime, color FROM calendar_events WHERE subscription_id = ? ORDER BY id'
+      ).all(subId);
+      const changesBefore = syncDb.prepare('SELECT total_changes() AS n').get().n;
+
+      // Der Logger schreibt info über console.info (server/logger.js) - ein
+      // leerer Kanal beweist, dass die Zusammenfassung auf debug bleibt.
+      const realInfo = console.info;
+      const infoLines = [];
+      console.info = (...args) => infoLines.push(args.join(' '));
+      try { await sync(subId); } finally { console.info = realInfo; }
+      assert(infoLines.length === 0,
+        `unveränderter Sync meldete sich auf info: ${JSON.stringify(infoLines)}`);
+
+      const after = syncDb.prepare(
+        'SELECT id, title, start_datetime, color FROM calendar_events WHERE subscription_id = ? ORDER BY id'
+      ).all(subId);
+      const delta = syncDb.prepare('SELECT total_changes() AS n').get().n - changesBefore;
+
+      assert(before.length === 1, 'Vorbedingung: der Termin muss vorliegen');
+      assert(JSON.stringify(before) === JSON.stringify(after), 'Termin wurde verändert');
+      // Genau eine Änderung ist erlaubt: das last_sync/etag-UPDATE der Subscription.
+      assert(delta <= 1, `unveränderter Sync schrieb ${delta} Zeilen statt höchstens 1`);
+    });
+
+    // Gegenprobe: der Vergleich darf echte Änderungen nicht wegfiltern.
+    await atest('Geänderter Titel kommt weiterhin an', async () => {
+      body = icsWith('Zahnarzt (verschoben)');
+      await sync(subId);
+      const row = syncDb.prepare(
+        'SELECT title FROM calendar_events WHERE subscription_id = ?'
+      ).get(subId);
+      assert(row.title === 'Zahnarzt (verschoben)', `Titel blieb "${row.title}"`);
+    });
+  } finally {
+    dbModule._resetTestDatabase();
+    delete process.env[ENV_FLAG];
+    await new Promise((r) => server.close(r));
+    syncDb.close();
+  }
+})();
+
 console.log(`\n${passed} passed, ${failed} failed`);
 if (failed > 0) process.exit(1);

--- a/test/test-ics-subscription.js
+++ b/test/test-ics-subscription.js
@@ -271,10 +271,20 @@ await (async () => {
   syncDb.prepare(`INSERT INTO users (username, display_name, password_hash, role)
                   VALUES ('owner', 'Owner', 'x', 'admin')`).run();
 
+  // Datum relativ zum Testlauf: syncOne() importiert nur das Fenster von sechs
+  // Monaten zurück bis zwölf Monate voraus. Ein fest verdrahtetes Datum fiele
+  // irgendwann hinten heraus und ließe die Tests scheitern, ohne dass sich am
+  // Produktionscode etwas geändert hätte.
+  const inDays = (n) => {
+    const d = new Date(Date.now() + n * 24 * 60 * 60 * 1000);
+    return d.toISOString().slice(0, 10).replace(/-/g, '');
+  };
+  const DAY = inDays(30);
+
   const icsWith = (summary) => [
     'BEGIN:VCALENDAR', 'VERSION:2.0', 'PRODID:-//Test//EN',
-    'BEGIN:VEVENT', 'UID:sync-1@test', 'DTSTART:20260714T090000Z',
-    'DTEND:20260714T100000Z', `SUMMARY:${summary}`, 'END:VEVENT',
+    'BEGIN:VEVENT', 'UID:sync-1@test', `DTSTART:${DAY}T090000Z`,
+    `DTEND:${DAY}T100000Z`, `SUMMARY:${summary}`, 'END:VEVENT',
     'END:VCALENDAR', '',
   ].join('\r\n');
 
@@ -310,6 +320,12 @@ await (async () => {
         'SELECT id, title, start_datetime, color FROM calendar_events WHERE subscription_id = ? ORDER BY id'
       ).all(subId);
       const changesBefore = syncDb.prepare('SELECT total_changes() AS n').get().n;
+      // total_changes() allein genügt nicht: ein INSERT mit ON CONFLICT, dessen
+      // DO UPDATE unterdrückt wird, meldet changes = 0, verbraucht aber trotzdem
+      // eine AUTOINCREMENT-Rowid und schreibt sqlite_sequence fort.
+      const seqBefore = syncDb.prepare(
+        "SELECT seq FROM sqlite_sequence WHERE name = 'calendar_events'"
+      ).get()?.seq ?? null;
 
       // Der Logger schreibt info über console.info (server/logger.js) - ein
       // leerer Kanal beweist, dass die Zusammenfassung auf debug bleibt.
@@ -325,10 +341,16 @@ await (async () => {
       ).all(subId);
       const delta = syncDb.prepare('SELECT total_changes() AS n').get().n - changesBefore;
 
+      const seqAfter = syncDb.prepare(
+        "SELECT seq FROM sqlite_sequence WHERE name = 'calendar_events'"
+      ).get()?.seq ?? null;
+
       assert(before.length === 1, 'Vorbedingung: der Termin muss vorliegen');
       assert(JSON.stringify(before) === JSON.stringify(after), 'Termin wurde verändert');
       // Genau eine Änderung ist erlaubt: das last_sync/etag-UPDATE der Subscription.
       assert(delta <= 1, `unveränderter Sync schrieb ${delta} Zeilen statt höchstens 1`);
+      assert(seqAfter === seqBefore,
+        `Rowid verbraucht, obwohl nichts zu tun war: ${seqBefore} -> ${seqAfter}`);
     });
 
     // Gegenprobe: der Vergleich darf echte Änderungen nicht wegfiltern.


### PR DESCRIPTION
Letzter der Sync-Services, nach #603 (CalDAV) und #604 (Google, CardDAV).

> Der ursprüngliche Ansatz dieses PRs (Wertvergleich in der `ON CONFLICT`-Klausel) hat das Problem **nicht** gelöst. Siehe „Nachbesserung" unten, der Codex-Review hat das aufgedeckt.

### Ausgangslage

ics-subscription hat als einziger Service bereits einen Schutz, den die anderen nicht haben: liefert der Server einen ETag, endet der Lauf bei `notModified`, bevor überhaupt ein Upsert läuft. Das Muster greift also nur bei Servern ohne ETag, dann aber vollständig: jeder Tick zieht den kompletten Kalender und schob ihn ungebremst durch den Upsert.

### Änderung

Der Lauf schlägt bekannte UIDs jetzt nach und geht explizit in den Update- oder den Insert-Zweig, wie es `caldav-sync` und `google-calendar` bereits tun. Das Update trägt seine Werte ein zweites Mal als NULL-sicheren `IS NOT`-Vergleich und schreibt nur bei echter Abweichung.

Verglichen wird über exakt die Spalten, die das Update auch setzt. `recurrence_rule` bleibt in beiden außen vor, genau wie zuvor unter `ON CONFLICT`: stünde es im Vergleich, löste eine RRULE-Abweichung ein Update aus, das sie gar nicht anwendet, und der Termin gälte bei jedem Lauf erneut als geändert.

Der Lauf zählt, was Update, Insert und Stale-Delete tatsächlich verändert haben. Die Zusammenfassung lautet damit `N events seen, M changed` statt `N events synced` und erreicht `info` nur bei `M > 0`.

### Nachbesserung nach dem Codex-Review

**1. Der unterdrückte Upsert schrieb weiterhin.** `calendar_events.id` ist `INTEGER PRIMARY KEY AUTOINCREMENT`. SQLite reserviert die Rowid und schreibt `sqlite_sequence` fort, bevor es die `DO UPDATE`-Bedingung auswertet. Ein unveränderter Termin erzeugte also weiter einen Schreibvorgang, meldete dabei aber `changes = 0`. Isoliert nachgemessen:

```
insert:        changes = 1 | seq = 1
unverändert:   changes = 0 | seq = 2
unverändert:   changes = 0 | seq = 3
```

Der ursprüngliche Test war dafür blind, weil `total_changes()` diese Buchführung nicht erfasst. Deshalb der Umbau auf den Lookup, und deshalb prüft der Test jetzt `sqlite_sequence` direkt.

**2. Zeitbombe im Fixture.** Das Testdatum war fest auf `2026-07-14` verdrahtet, übernommen aus dem vorhandenen `SAMPLE_ICS`. Dort ist es harmlos, weil `fetchAndParse` nicht filtert, aber `syncOne()` importiert nur sechs Monate zurück bis zwölf voraus. Ab Mitte Januar 2027 wären alle drei Tests rot geworden, ohne jede Änderung am Produktionscode. Das Datum wird jetzt vom Laufdatum abgeleitet.

### Tests

Drei Tests gegen einen lokalen HTTP-Server, der bewusst **ohne** ETag antwortet, damit der Kurzschluss nicht greift und der Schreibpfad wirklich läuft:

1. Erster Sync legt den Termin an.
2. Zweiter Sync über unveränderte Daten lässt jede Zeile unangetastet, verbraucht keine Rowid und bleibt vom info-Kanal weg.
3. Ein geänderter Titel kommt weiterhin an.

Der Test baut seine Datenbank mit better-sqlite3 statt `node:sqlite`, weil `syncOne()` `db.get().transaction()` benutzt und `DatabaseSync` diese Methode nicht kennt.

Gegenprobe zur Rowid-Assertion: der vorherige `ON CONFLICT`-Stand fällt damit durch, mit `Rowid verbraucht, obwohl nichts zu tun war: 1 -> 2`.

Mutationsproben, jeweils einzeln zurückgedreht:

| Mutation | rote Tests |
|---|---|
| Wertvergleich auf immer-wahr | 1 |
| Titelvergleich invertiert | 2 |
| Zusammenfassung wieder unbedingt auf info | 1 |

Volle `npm test`-Suite grün (Exit 0, explizit geprüft).

### Nebenbefund, hier nicht behoben

`db.js` ruft `init()` beim Import auf (`server/db.js:4256`). Suiten ohne `DB_PATH=:memory:` legen dadurch eine echte `yuvomi.db` im Repo-Wurzelverzeichnis an, `test:ics-sub` ist eine davon. Eine so entstandene Datei hat lokal einen kompletten `npm test`-Lauf mit "file is not a database" abbrechen lassen. In CI fällt das nicht auf, weil der Checkout frisch ist. Betrifft nur die Testinfrastruktur, nicht die Anwendung.
