### PR TITLE
feat(budget): add Malaysian Ringgit support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Add Malaysian Ringgit (MYR) throughout household preferences, subscriptions and split expenses, together with a Malaysia region preset.
+
 ## [1.57.0] - 2026-07-29
 
 ### Added

--- a/public/pages/subscriptions.js
+++ b/public/pages/subscriptions.js
@@ -33,7 +33,7 @@ let state = {
 let container = null;
 const CURRENCIES = [
   'AED', 'AUD', 'BRL', 'CAD', 'CHF', 'CLP', 'CNY', 'CZK', 'DKK', 'EUR', 'GBP', 'HUF',
-  'INR', 'JPY', 'KZT', 'NOK', 'PLN', 'RUB', 'SAR', 'SEK', 'TRY', 'UAH', 'USD', 'ZAR',
+  'INR', 'JPY', 'KZT', 'MYR', 'NOK', 'PLN', 'RUB', 'SAR', 'SEK', 'TRY', 'UAH', 'USD', 'ZAR',
 ];
 const DEFAULT_CATEGORY_LABELS = {
   Entertainment: 'budget.subcatSubscriptionEntertainment',

--- a/public/settings/currency.js
+++ b/public/settings/currency.js
@@ -4,7 +4,7 @@ import { getLocale } from '/i18n.js';
 // server/routes/preferences.js übereinstimmen (per Test abgesichert).
 export const SUPPORTED_CURRENCIES = [
   'AED', 'AUD', 'BRL', 'CAD', 'CHF', 'CLP', 'CNY', 'CZK', 'DKK', 'EUR', 'GBP',
-  'HUF', 'IDR', 'INR', 'IRR', 'JPY', 'KRW', 'KZT', 'NOK', 'PLN', 'RUB', 'SAR',
+  'HUF', 'IDR', 'INR', 'IRR', 'JPY', 'KRW', 'KZT', 'MYR', 'NOK', 'PLN', 'RUB', 'SAR',
   'SEK', 'TRY', 'UAH', 'USD', 'ZAR',
 ];
 

--- a/public/settings/region-presets.js
+++ b/public/settings/region-presets.js
@@ -39,6 +39,7 @@ export const REGION_PRESETS = {
   'ar-SA': { currency: 'SAR', date_format: 'dmy_slash', time_format: '12h' },
   'ko-KR': { currency: 'KRW', date_format: 'ymd', time_format: '12h' },
   'id-ID': { currency: 'IDR', date_format: 'dmy', time_format: '24h' },
+  'ms-MY': { currency: 'MYR', date_format: 'dmy_slash', time_format: '12h' },
   'fa-IR': { currency: 'IRR', date_format: 'ymd', time_format: '24h' },
 };
 

--- a/server/routes/preferences.js
+++ b/server/routes/preferences.js
@@ -17,7 +17,7 @@ const router = express.Router();
 const VALID_MEAL_TYPES = ['breakfast', 'lunch', 'dinner', 'snack'];
 const DEFAULT_MEAL_TYPES = VALID_MEAL_TYPES.join(',');
 
-const VALID_CURRENCIES = ['AED', 'AUD', 'BRL', 'CAD', 'CHF', 'CLP', 'CNY', 'CZK', 'DKK', 'EUR', 'GBP', 'HUF', 'IDR', 'INR', 'IRR', 'JPY', 'KRW', 'KZT', 'NOK', 'PLN', 'RUB', 'SAR', 'SEK', 'TRY', 'UAH', 'USD', 'ZAR'];
+const VALID_CURRENCIES = ['AED', 'AUD', 'BRL', 'CAD', 'CHF', 'CLP', 'CNY', 'CZK', 'DKK', 'EUR', 'GBP', 'HUF', 'IDR', 'INR', 'IRR', 'JPY', 'KRW', 'KZT', 'MYR', 'NOK', 'PLN', 'RUB', 'SAR', 'SEK', 'TRY', 'UAH', 'USD', 'ZAR'];
 const DEFAULT_CURRENCY = 'EUR';
 const DEFAULT_APP_NAME = 'Yuvomi';
 

--- a/server/routes/split-expenses.js
+++ b/server/routes/split-expenses.js
@@ -22,7 +22,7 @@ const GROUP_TYPES = ['household', 'couple', 'travel', 'event', 'shopping', 'gene
 const GROUP_ROLES = ['owner', 'admin', 'guest'];
 const SPLIT_METHODS = ['equal', 'exact', 'percentage', 'shares'];
 const CATEGORIES = ['groceries', 'rent', 'utilities', 'baby', 'pets', 'school', 'travel', 'shopping', 'subscriptions', 'health', 'home', 'general'];
-const CURRENCIES = ['AED', 'AUD', 'BRL', 'CAD', 'CHF', 'CLP', 'CNY', 'CZK', 'DKK', 'EUR', 'GBP', 'HUF', 'INR', 'JPY', 'KZT', 'NOK', 'PLN', 'RUB', 'SAR', 'SEK', 'TRY', 'UAH', 'USD', 'ZAR'];
+const CURRENCIES = ['AED', 'AUD', 'BRL', 'CAD', 'CHF', 'CLP', 'CNY', 'CZK', 'DKK', 'EUR', 'GBP', 'HUF', 'INR', 'JPY', 'KZT', 'MYR', 'NOK', 'PLN', 'RUB', 'SAR', 'SEK', 'TRY', 'UAH', 'USD', 'ZAR'];
 const FREQUENCIES = ['weekly', 'monthly', 'yearly'];
 const FAMILY_ROLES = ['dad', 'mom', 'parent', 'child', 'grandparent', 'relative', 'other'];
 

--- a/test/test-region-presets.js
+++ b/test/test-region-presets.js
@@ -107,6 +107,16 @@ test('numberLocaleFor yields a region tag that drives Intl number grouping (#521
   );
 });
 
+test('Malaysia preset formats MYR amounts with the local currency symbol', () => {
+  const locale = numberLocaleFor({ region: 'ms-MY', ...REGION_PRESETS['ms-MY'] });
+  const formatted = new Intl.NumberFormat(locale, { style: 'currency', currency: 'MYR' })
+    .format(1234.56);
+
+  assert.equal(locale, 'ms-MY');
+  assert.ok(formatted.includes('RM'));
+  assert.ok(formatted.includes('1,234.56'));
+});
+
 test('numberLocaleFor derives the tag even without a stored region, and empties for custom', () => {
   // Region nicht gesetzt, aber Formate entsprechen einem Preset → abgeleiteter Tag.
   assert.equal(numberLocaleFor({ ...REGION_PRESETS['de-CH'] }), 'de-CH');

--- a/test/test-split-expenses-routes.js
+++ b/test/test-split-expenses-routes.js
@@ -271,6 +271,7 @@ test('GET /meta liefert Enum-Listen + Default-Währung', async () => {
   const r = await call('GET', '/meta', { actor: { id: OWNER, role: 'member' } });
   assert.equal(r.status, 200);
   assert.ok(Array.isArray(r.body.data.currencies) && r.body.data.currencies.includes('EUR'));
+  assert.ok(r.body.data.currencies.includes('MYR'));
   assert.ok(r.body.data.split_methods.includes('equal'));
   assert.ok(r.body.data.frequencies.includes('monthly'));
   assert.equal(typeof r.body.data.default_currency, 'string');


### PR DESCRIPTION
## What changed

- add MYR to the household currency selector and preferences API validation
- add MYR to subscription and split-expense currency choices
- add an `ms-MY` region preset using Malaysian date, time, and number formatting
- document the new support in the changelog
- cover the Malaysia preset and split-expense metadata with regression tests

## Why

Malaysian households cannot currently select their local currency, so budget amounts must be recorded and displayed under an unrelated currency. MYR is an ISO 4217 currency with two minor-unit decimals, which fits the app's existing default money handling.

## User impact

Selecting the Malaysia region configures MYR and formats amounts with the local `RM` symbol. MYR is also available in subscriptions and split expenses.

## Validation

- `npm test`
- `npm run test:settings-navigation`
- `npm run test:region-presets`
- `npm run test:subscriptions`
- `npm run test:split-expenses-routes`
- `npm run test:frontend-audit`