### PR TITLE
fix(layout): preserve sidebar scroll position

### DIFF
--- a/public/router.js
+++ b/public/router.js
@@ -3054,10 +3054,20 @@ function rebuildNavigation({ updateLabels = true } = {}) {
   }
 
   if (navSidebarItems) {
+    // replaceChildren recria toda a árvore da navegação (por exemplo, após
+    // mudança de rota, idioma ou módulos) e o browser zera a rolagem do
+    // container. Preservamos a posição manual antes e depois do re-render.
+    const previousScrollTop = navSidebarItems.scrollTop;
     const sidebarEls = sidebarNavItems();
     navSidebarItems.replaceChildren(...sidebarEls);
     if (window.lucide) window.lucide.createIcons({ el: navSidebarItems });
-    requestAnimationFrame(() => positionSidebarIndicator());
+    requestAnimationFrame(() => {
+      navSidebarItems.scrollTop = Math.min(
+        previousScrollTop,
+        Math.max(0, navSidebarItems.scrollHeight - navSidebarItems.clientHeight),
+      );
+      positionSidebarIndicator();
+    });
   }
   if (bottomItems) {
     const moreBtn = bottomItems.querySelector('#more-btn') ?? moreNavButtonEl();

--- a/public/router.js
+++ b/public/router.js
@@ -2578,14 +2578,7 @@ function positionSidebarIndicator() {
   // Liste lagen Item UND Pille sonst unsichtbar unterhalb der Falte — die
   // Navigation verlor ihren „Du bist hier"-Anker. Manuelles Scrollen statt
   // scrollIntoView, damit garantiert nur dieser Container scrollt.
-  const margin = 8;
   const top = active.offsetTop;
-  const bottom = top + active.offsetHeight;
-  if (top < container.scrollTop + margin) {
-    container.scrollTop = Math.max(0, top - margin);
-  } else if (bottom > container.scrollTop + container.clientHeight - margin) {
-    container.scrollTop = bottom - container.clientHeight + margin;
-  }
   // Pille vertikal im Item zentrieren — aus realen Höhen, token-unabhängig.
   // offsetTop ist scroll-unabhängig relativ zum (position:relative) Container.
   const centerOffset = (active.offsetHeight - indicator.getBoundingClientRect().height) / 2;

--- a/public/styles/layout.css
+++ b/public/styles/layout.css
@@ -1466,6 +1466,8 @@ p.field-hint--warn[hidden] {
     top: 0;
     left: 0;
     bottom: 0;
+    height: 100dvh;
+    max-height: 100dvh;
     width: var(--sidebar-width);
     background: var(--sidebar-bg);
     border-right: 1px solid var(--color-border-subtle);
@@ -1552,7 +1554,10 @@ p.field-hint--warn[hidden] {
      * die Footer-Haarlinie stößt. */
     padding: 0 0 var(--space-2);
     flex: 1;
+    min-height: 0;
     overflow-y: auto;
+    overscroll-behavior-y: contain;
+    -webkit-overflow-scrolling: touch;
     scrollbar-width: none;
   }
   .nav-sidebar__items::-webkit-scrollbar { display: none; }


### PR DESCRIPTION
## Changes

- Fixed: the sidebar no longer forces scrolling back to the active item.
- The sidebar now preserves the user's scroll position when selecting an item, preventing it from jumping between the first and last items after reaching either end of the list.
