### PR TITLE
ci: Claude-Workflows dürfen ihr Ergebnis posten

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -24,7 +24,10 @@ jobs:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
     permissions:
       contents: read
-      pull-requests: read
+      # write, sonst läuft das Review durch und kann sein Ergebnis nicht posten:
+      # das Plugin schreibt über `gh pr comment`. Mit `read` endete der Job grün,
+      # aber ohne jeden Kommentar (permission_denials_count: 1).
+      pull-requests: write
       issues: read
       id-token: write
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -20,8 +20,12 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      # Beides write, sonst kann auf ein @claude nicht geantwortet werden. Getaggt
+      # werden kann in einem Issue (issues) wie in einem PR-Kommentar oder -Review
+      # (pull-requests), also braucht die Antwort beide Wege. Vgl. den gleichen
+      # Fehler in claude-code-review.yml: Job grün, Ergebnis nie gepostet.
+      pull-requests: write
+      issues: write
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:


### PR DESCRIPTION
Beide Claude-Workflows liefen bisher vollständig durch und konnten ihr Ergebnis nicht zurückschreiben. Der grüne Haken bedeutete "Job beendet", nicht "Code geprüft".

## Befund

Aufgefallen an PR #627. Der Job `claude-review` lief 5 Turns, rund 40 s, etwa 0,16 USD, beendete sich mit `is_error: false` und hinterließ null Reviews, null Inline-Kommentare, null Issue-Kommentare. Im Ergebnis stand `permission_denials_count: 1`.

Ursache: das `code-review`-Plugin schreibt sein Ergebnis über `gh pr comment` (steht so in seinen `allowed-tools`), die Job-Permission stand aber auf `pull-requests: read`.

Das ist nicht spezifisch für #627. Bei den PRs, die sich einsehen lassen, hat `claude-review` noch nie etwas hinterlassen: #626 hat 17 Inline-Kommentare, die stammen alle aus dem Codex-Durchgang, #623 hat null.

`claude.yml` hatte denselben Block und damit dasselbe Problem an der anderen Stelle: ein `@claude` konnte verarbeitet, aber nicht beantwortet werden.

## Änderung

| Workflow | vorher | nachher |
|---|---|---|
| `claude-code-review.yml` | `pull-requests: read` | `pull-requests: write` |
| `claude.yml` | `pull-requests: read`, `issues: read` | beide `write` |

Bei `claude-code-review.yml` wird nur `pull-requests` angehoben. `issues` bleibt lesend, weil das Plugin Issues ausschließlich liest (`gh issue view`, `gh issue list`) und der Workflow ohnehin nur auf `pull_request` feuert.

Bei `claude.yml` sind beide Rechte nötig. Seine Trigger sind `issue_comment`, `pull_request_review_comment`, `pull_request_review` und `issues`, getaggt werden kann also in einem Issue wie in einem PR, und die Antwort läuft je nach Kontext über einen anderen Endpunkt.

Beide Stellen tragen jetzt einen Kommentar mit der Begründung, damit sie beim nächsten Aufräumen nicht wieder auf `read` zurückfallen.

## Sicherheit

`claude.yml` hat keinen Absender-Guard im `if:`, er feuert auf jedes `@claude`. Das war vorher schon so, wiegt mit Schreibrechten aber schwerer.

Die Action prüft den Auslöser allerdings selbst: im Log des Review-Laufs steht `Checking permissions for actor` und `Permission level retrieved: admin`, bevor `Trigger result: true` folgt. Beide Workflows nutzen dieselbe Version `anthropics/claude-code-action@v1`. Beobachtet wurde das im Review-Workflow, nicht in einem echten `@claude`-Lauf.

## Wirksamkeit

Der Fix greift erst nach dem Merge in `main`. GitHub liest die Workflow-Permissions bei `pull_request`-Triggern aus dem Basis-Branch, nicht aus dem PR-Branch. Dieser PR wird also selbst noch mit den alten `read`-Rechten geprüft und bleibt stumm; das ist erwartbar.

Nach dem Merge lässt sich die Wirkung direkt an #627 nachsehen: ein weiterer Push dorthin löst ein Review aus, das dann auch etwas hinterlässt.
