### PR TITLE
fix(ui): Modul-Akzent folgt dem Theme-Wechsel zur Laufzeit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Switching between light and dark mode now recolours the whole app right away. The colour a module lends to its buttons, focus rings and the active navigation pill kept the shade of the theme that was active when the page was opened, so after switching to dark mode that text sat at 2.7:1 against the background - below the readable minimum. Reloading fixed it, which is why it was easy to miss. The same went for "Automatic": when the system moved to dark mode on its own, the accent stayed behind.
+
 ## [1.69.1] - 2026-08-01
 
 ### Fixed

--- a/public/router.js
+++ b/public/router.js
@@ -84,6 +84,14 @@ const isStandalone = window.matchMedia('(display-mode: standalone)').matches
   || navigator.standalone === true;
 
 /**
+ * System-Farbschema als langlebige MediaQueryList. Bewusst ein Modul-Binding
+ * und kein `window.matchMedia(...).addEventListener(...)` in einem Rutsch: ohne
+ * gehaltene Referenz darf die Engine die Liste einsammeln, und der Listener
+ * verstummt irgendwann still. Genutzt vom Auto-Modus-Nachzug des Modul-Akzents.
+ */
+const darkSchemeQuery = window.matchMedia?.('(prefers-color-scheme: dark)') ?? null;
+
+/**
  * Setzt die theme-color Meta-Tags (Light + Dark Variante).
  * @param {string} lightColor
  * @param {string} [darkColor] - Falls nicht angegeben, wird lightColor für beide gesetzt
@@ -102,6 +110,27 @@ function setThemeColor(lightColor, darkColor) {
 /** Liest eine CSS Custom Property vom :root */
 function getCSSToken(name) {
   return getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+}
+
+/**
+ * Setzt den Modul-Akzent der Route als Inline-Custom-Property auf <html>.
+ *
+ * Der Wert ist die AUFGELÖSTE Farbe, keine `var(--module-*)`-Kette: Dritt-
+ * anbieter-Module liefern einen literalen Hex-Wert, und ein nicht existierendes
+ * `--module-<name>` würde als var()-Kette „invalid at computed-value time"
+ * enden statt in den CSS-Fallback `var(--color-accent)` zu laufen.
+ *
+ * Preis dieser Auflösung: der Inline-Wert ist eine Momentaufnahme des aktuellen
+ * Themes. `--module-tasks` wechselt im Dark-Theme von #15803D auf #4ADE80 - die
+ * Momentaufnahme tut das nicht. Deshalb MUSS jeder Theme-Wechsel diese Funktion
+ * erneut aufrufen (applyTheme + der prefers-color-scheme-Listener für den
+ * Auto-Modus), sonst behält die ganze Shell den Akzent des alten Themes und
+ * Text darauf fiel im Dunkelmodus auf 2.71:1 statt 7.81:1 - unter WCAG AA.
+ */
+function applyModuleAccentForRoute(route) {
+  const accentToken = moduleAccentToken(route?.module);
+  const accent = route?.thirdPartyModule?.accent || (accentToken ? getCSSToken(accentToken) : '');
+  document.documentElement.style.setProperty('--active-module-accent', accent);
 }
 
 /** Setzt theme-color passend zum aktuellen Modul */
@@ -668,9 +697,7 @@ async function navigate(path, userOrPushState = true, pushState = true) {
     // Akzent. Sonst wechselte der 3px-Streifen der Tab-Leiste und der FAB beim
     // Tabwechsel die Farbe - dieselbe Botschaft wie ein echter Modulwechsel
     // (Critique 2026-07-29). Begründung am Token in tokens.css.
-    const accentToken = moduleAccentToken(route?.module);
-    const accent = route?.thirdPartyModule?.accent || (accentToken ? getCSSToken(accentToken) : '');
-    document.documentElement.style.setProperty('--active-module-accent', accent);
+    applyModuleAccentForRoute(route);
 
     // Optimistisches Chrome-Feedback: aktive Nav-Markierung + Indikator-Pille und
     // Statusbar-Farbe schon VOR dem Modul-Render setzen, sobald die Shell existiert.
@@ -802,6 +829,15 @@ function allRoutes() {
       thirdPartyModule: module,
     }));
   return [...ROUTES, ...moduleRoutes];
+}
+
+/**
+ * Die Route der gerade dargestellten Seite. Nötig für alles, was Chrome-Farben
+ * ausserhalb einer Navigation nachzieht (Theme-Wechsel, Rückkehr aus einem
+ * Overlay) - dort gibt es kein `route`-Objekt aus navigate() mehr.
+ */
+function currentRoute() {
+  return allRoutes().find((r) => r.path === currentPath);
 }
 
 // Bestätigter Logout, überall aus der Navigation erreichbar (Sidebar-Footer +
@@ -3180,7 +3216,15 @@ if (/iPhone|iPad|iPod/.test(navigator.userAgent)) {
     } else {
       document.documentElement.removeAttribute('data-theme');
     }
-    
+
+    // Theme „Automatisch" (kein data-theme) folgt prefers-color-scheme rein per
+    // CSS - applyTheme() feuert dabei nie. Der Modul-Akzent im Inline-Style
+    // bliebe also beim Sonnenuntergang des Systems auf dem Hellmodus-Wert
+    // stehen: derselbe Kontrast-Bruch wie beim manuellen Umschalten, nur ohne
+    // Nutzeraktion. Der Listener zieht ihn nach; bei explizitem Theme ist der
+    // Aufruf idempotent (dieselbe Farbe wird erneut aufgelöst).
+    darkSchemeQuery?.addEventListener?.('change', () => applyModuleAccentForRoute(currentRoute()));
+
     await initI18n();
     try {
       const v = await api.get('/version');
@@ -3211,7 +3255,6 @@ window.yuvomi = {
   refreshThirdPartyModules,
   isModuleDisabled,
   applyTheme: (value) => {
-    localStorage.setItem('yuvomi-theme', value);
     if (value === 'dark') {
       document.documentElement.setAttribute('data-theme', 'dark');
     } else if (value === 'light') {
@@ -3219,10 +3262,25 @@ window.yuvomi = {
     } else {
       document.documentElement.removeAttribute('data-theme');
     }
+    // Der Modul-Akzent liegt als aufgelöste Farbe im Inline-Style von <html> und
+    // folgt der CSS-Kaskade daher NICHT. Ohne dieses Nachziehen behielte die
+    // ganze Shell (Buttons, Fokusringe, FAB, aktive Nav-Pille) den Akzent des
+    // vorherigen Themes. Begründung an applyModuleAccentForRoute.
+    applyModuleAccentForRoute(currentRoute());
+    // Persistenz zuletzt und fehlertolerant: ein werfendes localStorage (Safari
+    // Privatmodus, Quota) darf das sichtbare Anwenden nicht abbrechen. Vorher
+    // stand diese Zeile zuerst - warf sie, fiel der Aufrufer in den
+    // Einstellungen auf ein direktes data-theme zurück und liess den Akzent
+    // stehen. Derselbe Schlüssel wird dort ohnehin über safeStorageSet
+    // geschrieben, hier geht also nichts verloren.
+    try {
+      localStorage.setItem('yuvomi-theme', value);
+    } catch {
+      // Theme gilt für diese Sitzung, überlebt den Reload aber nicht.
+    }
   },
   restoreThemeColor: () => {
-    const route = allRoutes().find((r) => r.path === currentPath);
-    updateThemeColorForRoute(route);
+    updateThemeColorForRoute(currentRoute());
   },
   // Client-seitigen Sitzungszustand nach einem bewussten Logout zurücksetzen,
   // damit die anschließende navigate('/login') nicht am currentUser-Guard

--- a/test/test-frontend-audit.js
+++ b/test/test-frontend-audit.js
@@ -3830,6 +3830,103 @@ test('module accents stay readable as text on the page background in both themes
   }
 });
 
+/**
+ * Der Test darueber prueft die Token-WERTE pro Theme. Er sagt nichts darueber,
+ * ob die App zur Laufzeit auch den Wert des aktiven Themes benutzt - und genau
+ * da lag die Luecke: `--active-module-accent` steht als AUFGELOESTE Farbe im
+ * Inline-Style von <html> (der Router liest --module-<name> beim Seitenwechsel
+ * aus). Ein Inline-Style folgt keiner Kaskade. Wer im Hellmodus /tasks oeffnete
+ * und dann auf Dunkel schaltete, behielt #15803D statt #4ADE80: Text in
+ * Modul-Akzentfarbe kam auf 2.71:1 statt 7.81:1 - unter WCAG AA. Betroffen war
+ * die ganze Shell (.btn--primary, .btn--secondary, --focus-ring-color, FAB,
+ * aktive Nav-Pille). Nach einem Reload im Zielmodus stimmte alles wieder,
+ * deshalb faellt es beim Testen im Zielmodus nicht auf.
+ *
+ * Der Guard formuliert die Regel, nicht die Fundstelle: die Momentaufnahme darf
+ * nur an EINER Stelle entstehen, und jeder Weg, der das Theme zur Laufzeit
+ * umschaltet, muss sie neu berechnen.
+ */
+test('module accent is recomputed on every runtime theme switch', () => {
+  const router = read('../public/router.js');
+
+  // 1. Genau ein Schreiber im ganzen Frontend. Ein zweiter waere eine zweite
+  //    Momentaufnahme, die dieser Guard nicht mitzoege.
+  const writers = walkJsFiles('../public/')
+    .filter((path) => !path.includes('/vendor/'))
+    .flatMap((path) => {
+      const hits = read(path).match(/setProperty\(\s*'--active-module-accent'/g) ?? [];
+      return hits.map(() => path);
+    });
+  assert.deepEqual(
+    writers,
+    ['../public/router.js'],
+    `--active-module-accent must be written in exactly one place, found: ${writers.join(', ')}`,
+  );
+
+  const helper = router.match(/function applyModuleAccentForRoute\([\s\S]*?\n\}/);
+  assert.ok(helper, 'expected applyModuleAccentForRoute to own the write');
+  assert.match(
+    helper[0],
+    /setProperty\(\s*'--active-module-accent'/,
+    'the single write must live inside applyModuleAccentForRoute',
+  );
+
+  // 2. Der Seitenwechsel geht durch denselben Helfer (keine Inline-Kopie).
+  assert.match(router, /applyModuleAccentForRoute\(route\)/, 'navigate() must use the helper');
+
+  // 3. Expliziter Theme-Wechsel (window.yuvomi.applyTheme) berechnet neu.
+  const applyTheme = router.match(/applyTheme:\s*\(value\) => \{[\s\S]*?\n {2}\},/);
+  assert.ok(applyTheme, 'expected the applyTheme export');
+  assert.match(
+    applyTheme[0],
+    /data-theme/,
+    'sanity: applyTheme is the function that flips the theme',
+  );
+  assert.match(
+    applyTheme[0],
+    /applyModuleAccentForRoute\(currentRoute\(\)\)/,
+    'applyTheme must recompute the module accent for the current route',
+  );
+
+  // 4. Theme "Automatisch" schaltet ohne applyTheme um - rein per CSS-Media-
+  //    Query. Ohne Listener liefe derselbe Kontrast-Bruch beim Sonnenuntergang
+  //    des Systems, nur ohne Nutzeraktion.
+  //
+  //    Die MediaQueryList muss dabei in einem Modul-Binding leben. Als
+  //    Wegwerf-Ausdruck (`matchMedia(...).addEventListener(...)`) darf die
+  //    Engine sie einsammeln - der Listener verstummt dann still, und der
+  //    Fehler kaeme genau in der Sitzung zurueck, die lange genug offen war.
+  assert.match(
+    router,
+    /const darkSchemeQuery = window\.matchMedia\??\.?\(\s*'\(prefers-color-scheme: dark\)'\s*\)/,
+    'the prefers-color-scheme query must be held in a module binding, not a throwaway expression',
+  );
+  assert.doesNotMatch(
+    router,
+    /matchMedia\??\.?\(\s*'\(prefers-color-scheme: dark\)'\s*\)\s*\??\.?\s*addEventListener/,
+    'do not attach the listener to an unreferenced MediaQueryList',
+  );
+
+  const listener = router.match(
+    /darkSchemeQuery\s*\??\.?\s*addEventListener[\s\S]{0,120}?'change'[\s\S]{0,200}?;/,
+  );
+  assert.ok(listener, 'expected a prefers-color-scheme change listener for auto mode');
+  assert.match(
+    listener[0],
+    /applyModuleAccentForRoute\(currentRoute\(\)\)/,
+    'the auto-mode listener must recompute the module accent too',
+  );
+
+  // 5. Das Anwenden darf nicht hinter einem werfenden localStorage haengen:
+  //    stand die Persistenz zuerst, brach ein Quota-Fehler ab, bevor der Akzent
+  //    neu berechnet war.
+  assert.ok(
+    applyTheme[0].indexOf('applyModuleAccentForRoute')
+      < applyTheme[0].indexOf("localStorage.setItem('yuvomi-theme'"),
+    'applyTheme must apply theme and accent before persisting the choice',
+  );
+});
+
 test('modal Enter submits the form instead of advancing to the next field (audit 1.4)', () => {
   const src = read('../public/components/modal.js');
   const enterBlock = src.match(/if \(e\.key === 'Enter'\) \{[\s\S]*?\n {4}\}/);


### PR DESCRIPTION
## Problem

Der Router löst `--module-<name>` beim Seitenwechsel auf und schreibt die fertige Farbe als Inline-Style auf `<html>`. Ein Inline-Style nimmt an keiner Kaskade teil, `applyTheme()` hat ihn nie angefasst - der Wert blieb eine Momentaufnahme des Themes, das beim letzten `navigate()` galt.

Repro: App im Hellmodus laden, `/tasks` öffnen, per Theme-Einstellung auf dunkel schalten. `--active-module-accent` steht danach weiter auf `#15803D`, obwohl `--module-tasks` korrekt auf `#4ADE80` wechselt. Text in Modul-Akzentfarbe kommt so auf **2,71:1 statt 7,81:1** - unter WCAG AA. Betroffen ist die ganze Shell: `.btn--primary`, `.btn--secondary`, Fokusringe (`--focus-ring-color`), FAB, aktive Nav-Pille. Nach einem Reload im Zielmodus stimmt alles wieder, deshalb fällt es beim Testen im Zielmodus nicht auf.

## Änderungen

- Die Schreibstelle wandert in `applyModuleAccentForRoute()`; `navigate()` und `applyTheme()` gehen beide durch den Helfer. Der Wert bleibt bewusst die aufgelöste Farbe statt einer `var(--module-*)`-Kette: Drittanbieter-Module liefern einen literalen Hex-Wert, und ein nicht existierendes Token würde als var()-Kette "invalid at computed-value time" enden statt in den CSS-Fallback zu laufen.
- Theme "Automatisch" schaltet ohne `applyTheme()` um, rein per `prefers-color-scheme`. Ein `change`-Listener zieht den Akzent auch dort nach - sonst liefe derselbe Kontrastbruch beim Sonnenuntergang des Systems, nur ohne Nutzeraktion. Die MediaQueryList liegt in einem Modul-Binding: als Wegwerf-Ausdruck darf die Engine sie einsammeln, dann verstummt der Listener still.
- `applyTheme()` begann mit `localStorage.setItem`. Warf das (Safari-Privatmodus, Quota), fiel `personal-appearance.js:224` auf ein direktes `data-theme` zurück und liess den Akzent stehen. Das Anwenden läuft jetzt zuerst, die Persistenz zuletzt und fehlertolerant - derselbe Schlüssel wird dort ohnehin über `safeStorageSet` geschrieben.

## Guard

Der Test in `test-frontend-audit.js` prüft die Regel, nicht die Fundstelle: genau ein Schreiber von `--active-module-accent` im ganzen Frontend, beide Pfade durch den Helfer, Auto-Listener mit gehaltener Referenz, Anwenden vor Persistenz. Gegen drei simulierte Regressionen geprüft - jede fällt durch.

## Verifikation

Live auf `/tasks`, Laufzeit-Wechsel hell→dunkel→hell: Inline-Wert und `--module-tasks` stimmen in allen drei Zuständen überein. `.btn--secondary` und die aktive Nav-Pille erreichen im Dunkelmodus 10,00:1 gegen `--color-bg`, der Fokusring folgt dem Akzent. Gesamtsuite grün.

Nicht live prüfbar war der Auto-Modus-Pfad: die Farbschema-Emulation des Test-Browsers feuert kein `change`-Event (Kontrollprobe mit eigener gehaltener Referenz zählte 0 Events trotz `matches`-Wechsel). Dieser Pfad ist nur quellseitig abgesichert.