### PR TITLE
fix(housekeeping,birthdays): serverseitig geschriebene Termine erreichten den Provider nicht

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Changes to a birthday now reach the calendar you sync it to. Editing one detached its appointment from the copy in iCloud, Google or Nextcloud: the new name showed up in Yuvomi while the external calendar kept the old one forever. Deleting a birthday, or setting its reminder to "none", now removes the appointment there too instead of leaving it behind for the next sync to bring back.
+- Moving or deleting a housekeeping visit reaches the external calendar as well. A visit shifted to another day showed the new date in Yuvomi and the old one everywhere else.
+- Visit and payment entries that Yuvomi writes for you now follow the household data language, with the amount formatted as currency and the date in your chosen format. Only the app sent translated text before; anything else - the API, scripts, integrations - got English and a raw date.
+
 ## [1.71.0] - 2026-08-01
 
 ### Fixed

--- a/docs/test-suites.md
+++ b/docs/test-suites.md
@@ -124,7 +124,7 @@ npm run test:calendar-outbound-migration   # Migrationen v103-v106 gegen befüll
 npm run test:caldav-outbound   # Löschen + Ändern + Umziehen Yuvomi → CalDAV/Apple (#593): ICS-Patcher (Teilnehmer/Alarme/Overrides bleiben), Objekt-URL-Auflösung, Umzug = create+delete, Sofortversuch ohne Kalenderabruf
 npm run test:google-calendar   # Google: Datumskonvertierung, Farbauflösung (#427/#219), unveränderte Events werden beim Full-Resync nicht neu geschrieben
 npm run test:housekeeping
-npm run test:housekeeping-routes   # Housekeeping-Routen: Worker-Anlage (Admin-Gate), Check-in/out-Lifecycle + Doppelbuchungs-Guard, Pay/Delete, Decay-CRUD, Supply-Requests, Maintenance-Log
+npm run test:housekeeping-routes   # Housekeeping-Routen: Worker-Anlage (Admin-Gate), Check-in/out-Lifecycle + Doppelbuchungs-Guard, Pay/Delete, Decay-CRUD, Supply-Requests, Maintenance-Log; dazu die Besuchs-Artefakte: Fallback-Titel folgen der Datensprache (ohne gesetzte Sprache bleibt Englisch), ein verschobener Besuch wird für den Provider-Push vorgemerkt und ein gelöschter räumt die Kopie beim Provider mit ab - beides nur bei gespiegelten Terminen
 npm run test:documents          # Dokument-Preview: CSP-Header je MIME-Typ
 npm run test:documents-ux       # Dokumente-UX-Verträge: Leerzustände, Kategorie-Facetten, Upload-Modal, Auswahlmodus, Popover-Menü
 npm run test:document-storage   # Dokument-Storage-Migration und Invarianten

--- a/server/routes/housekeeping.js
+++ b/server/routes/housekeeping.js
@@ -12,6 +12,14 @@ import * as db from '../db.js';
 import { normalizeAvatarData, syncFamilyMemberArtifacts } from '../auth.js';
 import { collectErrors, color, date, datetime, month, num, oneOf, str, id as validateId, MAX_SHORT, MAX_TEXT, MAX_TITLE } from '../middleware/validate.js';
 import { minutesBetween, computeHourlyAmount } from '../services/housekeeping-billing.js';
+import {
+  formatDateKey,
+  formatMoney,
+  householdRegion,
+  resolveHouseholdFormats,
+  translate,
+} from '../utils/i18n.js';
+import { markEventOutbound, queueEventDeletion } from '../services/calendar-outbound.js';
 
 const log = createLogger('Housekeeping');
 const router = express.Router();
@@ -236,6 +244,31 @@ function loadWorkers() {
   `).all();
 }
 
+// Die Oberfläche schickt Titel und Beschreibung fertig übersetzt mit
+// (`visitTextPayload` in public/pages/housekeeping.js). Diese Fallbacks greifen
+// für alles, was die API direkt anspricht - MCP, Skripte, Integrationen. Sie
+// standen fest auf Englisch, obwohl die Texte in `calendar_events`/`tasks`
+// landen und von dort in API, ICS-Feed und Sync gehen; deshalb dieselbe
+// Datensprache wie bei den Geburtstags-Terminen (#631, #632). Die Locale-Keys
+// sind dieselben, die der Client benutzt - eine Formulierung, zwei Aufrufer.
+function visitTitleFallback(database, worker) {
+  const { locale } = resolveHouseholdFormats(database);
+  return translate(locale, 'housekeeping.calendarVisitTitle', { name: worker.display_name });
+}
+
+function paymentTitleFallback(database, worker) {
+  const { locale } = resolveHouseholdFormats(database);
+  return translate(locale, 'housekeeping.paymentTaskTitle', { name: worker.display_name });
+}
+
+function paymentDescriptionFallback(database, visitDate, amount) {
+  const { locale, dateFormat, currency } = resolveHouseholdFormats(database);
+  return translate(locale, 'housekeeping.paymentTaskDescription', {
+    date: formatDateKey(visitDate, dateFormat),
+    amount: formatMoney(amount, { locale, currency, region: householdRegion(database) }),
+  });
+}
+
 function createVisitCalendarEvent(database, worker, checkIn, actorId, title = null, visitDateOverride = null) {
   const visitDate = visitDateOverride || checkIn.slice(0, 10);
   const result = database.prepare(`
@@ -243,7 +276,7 @@ function createVisitCalendarEvent(database, worker, checkIn, actorId, title = nu
       (title, start_datetime, end_datetime, all_day, color, icon, assigned_to, created_by, external_source)
     VALUES (?, ?, NULL, 1, ?, ?, ?, ?, 'local')
   `).run(
-    title || `Housekeeping: ${worker.display_name}`,
+    title || visitTitleFallback(database, worker),
     visitDate,
     worker.calendar_color || DEFAULT_CALENDAR_COLOR,
     HOUSEKEEPING_EVENT_ICON,
@@ -261,8 +294,8 @@ function createPaymentTask(database, worker, checkIn, amount, actorId, title = n
     INSERT INTO tasks (title, description, due_date, priority, category, status, created_by)
     VALUES (?, ?, ?, 'medium', 'household', 'open', ?)
   `).run(
-    title || `Pay ${worker.display_name} for housekeeping`,
-    description || `Housekeeping visit on ${visitDate}. Amount due: ${amount.toFixed(2)}.`,
+    title || paymentTitleFallback(database, worker),
+    description || paymentDescriptionFallback(database, visitDate, amount),
     visitDate,
     actorId,
   );
@@ -272,6 +305,12 @@ function createPaymentTask(database, worker, checkIn, amount, actorId, title = n
 function updateVisitLinks(database, session, worker, checkIn, dailyRate, extras, eventTitle = null, paymentTitle = null, paymentDescription = null) {
   const visitDate = checkIn.slice(0, 10);
   if (session.calendar_event_id) {
+    // Datum, Titel und Farbe des Termins stehen in MIRRORED_FIELDS. Ein Besuch,
+    // den der Apple-Sync bereits hochgeladen hat, trägt external_source='apple'
+    // und erreicht den Provider nur noch über outbound_dirty - ohne die
+    // Vormerkung bliebe die Verschiebung eines Besuchs lokal (dieselbe Lücke wie
+    // bei den Geburtstags-Titeln in #632).
+    const before = database.prepare('SELECT * FROM calendar_events WHERE id = ?').get(session.calendar_event_id);
     database.prepare(`
       UPDATE calendar_events
       SET title = COALESCE(?, title),
@@ -288,6 +327,10 @@ function updateVisitLinks(database, session, worker, checkIn, dailyRate, extras,
       HOUSEKEEPING_EVENT_ICON,
       session.calendar_event_id,
     );
+    const after = database.prepare('SELECT * FROM calendar_events WHERE id = ?').get(session.calendar_event_id);
+    // markEventOutbound vergleicht die gespiegelten Felder selbst und prüft
+    // Quelle, Kalenderzuordnung und ob der Provider überhaupt schreibbar ist.
+    if (before && after) markEventOutbound(before, after);
   }
   if (session.payment_task_id) {
     const totalAmount = Number(dailyRate || 0) + Number(extras || 0);
@@ -299,7 +342,7 @@ function updateVisitLinks(database, session, worker, checkIn, dailyRate, extras,
       WHERE id = ?
     `).run(
       paymentTitle,
-      paymentDescription || `Housekeeping visit on ${visitDate}. Amount due: ${totalAmount.toFixed(2)}.`,
+      paymentDescription || paymentDescriptionFallback(database, visitDate, totalAmount),
       visitDate,
       session.payment_task_id,
     );
@@ -307,7 +350,14 @@ function updateVisitLinks(database, session, worker, checkIn, dailyRate, extras,
 }
 
 function deleteVisitLinks(database, session) {
-  if (session.calendar_event_id) database.prepare('DELETE FROM calendar_events WHERE id = ?').run(session.calendar_event_id);
+  if (session.calendar_event_id) {
+    // Beim Provider liegende Kopie mit abräumen: ein reines DELETE hier ließe
+    // den Termin in iCloud/Google/Nextcloud stehen, und der nächste Inbound-Lauf
+    // spielte ihn womöglich wieder ein.
+    const event = database.prepare('SELECT * FROM calendar_events WHERE id = ?').get(session.calendar_event_id);
+    if (event) queueEventDeletion(event);
+    database.prepare('DELETE FROM calendar_events WHERE id = ?').run(session.calendar_event_id);
+  }
   if (session.payment_task_id) database.prepare('DELETE FROM tasks WHERE id = ?').run(session.payment_task_id);
 }
 

--- a/server/routes/housekeeping.js
+++ b/server/routes/housekeeping.js
@@ -19,7 +19,11 @@ import {
   resolveHouseholdFormats,
   translate,
 } from '../utils/i18n.js';
-import { markEventOutbound, queueEventDeletion } from '../services/calendar-outbound.js';
+import {
+  OUTBOUND_SOURCES,
+  mirroredFieldsChanged,
+  queueEventDeletion,
+} from '../services/calendar-outbound.js';
 
 const log = createLogger('Housekeeping');
 const router = express.Router();
@@ -328,9 +332,24 @@ function updateVisitLinks(database, session, worker, checkIn, dailyRate, extras,
       session.calendar_event_id,
     );
     const after = database.prepare('SELECT * FROM calendar_events WHERE id = ?').get(session.calendar_event_id);
-    // markEventOutbound vergleicht die gespiegelten Felder selbst und prüft
-    // Quelle, Kalenderzuordnung und ob der Provider überhaupt schreibbar ist.
-    if (before && after) markEventOutbound(before, after);
+    // Marker inline statt über markEventOutbound, aus zwei Gründen:
+    //
+    //   - markEventOutbound lehnt einen schreibgeschützten Provider ab
+    //     (`google_readonly`). Der Marker ist aber nicht nur ein Push-Auftrag,
+    //     sondern auch der Schutz davor, dass der Inbound die lokale Änderung
+    //     überschreibt - `if (existing?.outbound_dirty) continue`. Ohne ihn
+    //     verlöre ein verschobener Besuch sein Datum an den alten Serverstand,
+    //     sobald jemand den Nur-Lesen-Modus einschaltet.
+    //   - Es schreibt über db.get() und umginge die hier übergebene Connection.
+    //
+    // Der Feldvergleich bleibt derselbe: mirroredFieldsChanged prüft genau die
+    // Felder, die zum Provider gespiegelt werden.
+    const mirrored = after && OUTBOUND_SOURCES.includes(after.external_source) && !!after.external_calendar_id;
+    if (before && mirrored && mirroredFieldsChanged(before, after)) {
+      database.prepare(
+        'UPDATE calendar_events SET outbound_dirty = 1, outbound_attempts = 0 WHERE id = ?'
+      ).run(session.calendar_event_id);
+    }
   }
   if (session.payment_task_id) {
     const totalAmount = Number(dailyRate || 0) + Number(extras || 0);
@@ -355,7 +374,7 @@ function deleteVisitLinks(database, session) {
     // den Termin in iCloud/Google/Nextcloud stehen, und der nächste Inbound-Lauf
     // spielte ihn womöglich wieder ein.
     const event = database.prepare('SELECT * FROM calendar_events WHERE id = ?').get(session.calendar_event_id);
-    if (event) queueEventDeletion(event);
+    if (event) queueEventDeletion(event, database);
     database.prepare('DELETE FROM calendar_events WHERE id = ?').run(session.calendar_event_id);
   }
   if (session.payment_task_id) database.prepare('DELETE FROM tasks WHERE id = ?').run(session.payment_task_id);

--- a/server/services/birthdays.js
+++ b/server/services/birthdays.js
@@ -108,17 +108,14 @@ function eventDescription(name, birthDate, locale, dateFormat) {
  * entfernten Objekt (Kalender-ID und Objekt-URL stehen in der Zeile), und der
  * nächste Inbound-Lauf spielte den Termin sonst wieder ein.
  *
- * Grenze: `queueEventDeletion` schreibt über `db.get()`, nicht über die hier
- * übergebene Connection - dasselbe gilt für seine Guards. In der Anwendung ist
- * das dieselbe Verbindung; auseinander fallen sie nur, wenn ein Aufrufer eine
- * eigene injiziert (processDueNotifications nimmt eine entgegen, nutzt sie aber
- * nur in Tests). Das sauber durchzureichen hieße, vier Funktionen in
- * calendar-outbound.js umzubauen; das gehört in einen eigenen Vorgang, nicht in
- * diesen. retitleBirthdayEvents setzt seinen Marker aus demselben Grund inline.
+ * Die Connection wird durchgereicht: `syncBirthdayArtifacts` läuft auch mit einer
+ * eigenen (processDueNotifications gibt seine weiter, test-dashboard.js nutzt
+ * das). Über `db.get()` geschrieben landete die Vormerkung sonst in einer anderen
+ * Datenbank als der Termin, auf den sie sich bezieht.
  */
 function deleteCalendarEvent(database, eventId) {
   const event = database.prepare('SELECT * FROM calendar_events WHERE id = ?').get(eventId);
-  if (event) queueEventDeletion(event);
+  if (event) queueEventDeletion(event, database);
   database.prepare('DELETE FROM calendar_events WHERE id = ?').run(eventId);
 }
 
@@ -179,13 +176,21 @@ function syncBirthdayCalendarEvent(database, birthday) {
         // syncAllBirthdayReminders schon an einem GET /birthdays hängt, wäre das
         // ein Push pro Geburtstag pro Abruf, endlos. Diese Felder gehören
         // deshalb dem Provider, sobald er die Zeile einmal angefasst hat.
+        // `end_datetime` folgt dem Start, statt zu bleiben: der Inbound legt bei
+        // einem ganztägigen Termin ein Ende gleich dem Startdatum ab. Bliebe es
+        // beim Verschieben des Geburtsdatums stehen, läge das Ende vor dem
+        // Beginn - die Outbound-Serializer machen daraus ein DTEND vor DTSTART
+        // bzw. einen mehrtägigen Geburtstag. NULL bleibt NULL, damit ein noch
+        // nicht normalisierter Termin keine Scheinänderung bekommt.
         database.prepare(`
           UPDATE calendar_events
-          SET title = ?, description = ?, start_datetime = ?
+          SET title = ?, description = ?, start_datetime = ?,
+              end_datetime = CASE WHEN end_datetime IS NULL THEN NULL ELSE ? END
           WHERE id = ?
         `).run(
           payload.title,
           payload.description,
+          payload.start_datetime,
           payload.start_datetime,
           birthday.calendar_event_id,
         );

--- a/server/services/birthdays.js
+++ b/server/services/birthdays.js
@@ -4,6 +4,21 @@ import { OUTBOUND_SOURCES, markEventOutbound, queueEventDeletion } from './calen
 const BIRTHDAY_COLOR = '#E11D48';
 const BIRTHDAY_RRULE = 'FREQ=YEARLY;INTERVAL=1';
 
+// Felder, die der Geburtstag selbst hervorbringt: Titel und Beschreibung aus dem
+// Namen, Startdatum aus dem Geburtsdatum. Nur ihre Änderung darf einen Push zum
+// Provider auslösen.
+//
+// Bewusst NICHT dabei: Farbe, Ende, Ganztags-Flag und Ort sind Beiwerk, das der
+// Provider auf dem Rückweg normalisiert (der ICS-Export schreibt für ganztägige
+// Termine immer ein DTEND, eine Farbe überträgt er gar nicht) - sie mitzuzählen
+// erzeugte eine Endlosschleife aus Rückschreiben und Pushen, ausgelöst schon von
+// einem GET /birthdays. Die Serienregel fehlt aus einem anderen Grund: sie ist
+// bei einem Geburtstag konstant jährlich, und dasselbe Ergebnis existiert in
+// zwei Schreibweisen - lokal ohne, aus ICS mit `RRULE:`-Präfix (beide gültig,
+// server/services/recurrence.js:18 nimmt sie entgegen). Als Vergleichswert wäre
+// sie also nur eine weitere Quelle für Scheinänderungen.
+const AUTHORED_FIELDS = ['title', 'description', 'start_datetime'];
+
 function pad2(n) {
   return String(n).padStart(2, '0');
 }
@@ -92,6 +107,14 @@ function eventDescription(name, birthDate, locale, dateFormat) {
  * Löschung vor. Die Vormerkung muss davor passieren: danach fehlt der Weg zum
  * entfernten Objekt (Kalender-ID und Objekt-URL stehen in der Zeile), und der
  * nächste Inbound-Lauf spielte den Termin sonst wieder ein.
+ *
+ * Grenze: `queueEventDeletion` schreibt über `db.get()`, nicht über die hier
+ * übergebene Connection - dasselbe gilt für seine Guards. In der Anwendung ist
+ * das dieselbe Verbindung; auseinander fallen sie nur, wenn ein Aufrufer eine
+ * eigene injiziert (processDueNotifications nimmt eine entgegen, nutzt sie aber
+ * nur in Tests). Das sauber durchzureichen hieße, vier Funktionen in
+ * calendar-outbound.js umzubauen; das gehört in einen eigenen Vorgang, nicht in
+ * diesen. retitleBirthdayEvents setzt seinen Marker aus demselben Grund inline.
  */
 function deleteCalendarEvent(database, eventId) {
   const event = database.prepare('SELECT * FROM calendar_events WHERE id = ?').get(eventId);
@@ -135,29 +158,70 @@ function syncBirthdayCalendarEvent(database, birthday) {
       // external_source='apple', der Neu-Upload nach external_calendar_id IS NULL,
       // und mit 'local' + gesetzter Kalender-ID traf keiner von beiden zu. Ein
       // einmal gespiegelter Geburtstag fror dort für immer ein.
-      database.prepare(`
-        UPDATE calendar_events
-        SET title = ?, description = ?, start_datetime = ?, end_datetime = ?, all_day = ?,
-            location = ?, color = ?, icon = ?, assigned_to = ?, recurrence_rule = ?, created_by = ?
-        WHERE id = ?
-      `).run(
-        payload.title,
-        payload.description,
-        payload.start_datetime,
-        payload.end_datetime,
-        payload.all_day,
-        payload.location,
-        payload.color,
-        payload.icon,
-        payload.assigned_to,
-        payload.recurrence_rule,
-        payload.created_by,
-        birthday.calendar_event_id,
-      );
-      const after = database.prepare('SELECT * FROM calendar_events WHERE id = ?').get(birthday.calendar_event_id);
-      // Vergleicht die gespiegelten Felder selbst und prüft Quelle,
-      // Kalenderzuordnung und Schreibbarkeit des Providers.
-      if (after) markEventOutbound(existing, after);
+      //
+      // Folge, die dazugehört: die Zeile bleibt damit auch im Blick von
+      // pruneDeletedEvents (calendar-prune.js). Wer den Termin beim Provider
+      // löscht, den Geburtstag in Yuvomi aber behält, bekommt ihn beim nächsten
+      // Sync neu angelegt und hochgeladen. Das ist die konsequente Fortsetzung
+      // davon, dass der Geburtstag die Quelle ist und der Kalendereintrag sein
+      // Abbild - wer ihn loswerden will, stellt die Erinnerung auf "keine" oder
+      // löscht den Geburtstag.
+      const mirrored = OUTBOUND_SOURCES.includes(existing.external_source) && !!existing.external_calendar_id;
+
+      if (mirrored) {
+        // Bei einer gespiegelten Zeile nur schreiben, was der Geburtstag selbst
+        // hervorbringt. Der Weg über den Provider ist nicht wertneutral: der
+        // ICS-Export schreibt für einen ganztägigen Termin immer ein DTEND, und
+        // der Inbound macht daraus ein `end_datetime`, wo vorher NULL stand;
+        // eine Farbe überträgt er gar nicht, also kommt die des Kalenders
+        // zurück. Würde dieser Sync das stumpf zurückschreiben, sähe der
+        // Feldvergleich bei JEDEM Lauf eine Änderung - und weil
+        // syncAllBirthdayReminders schon an einem GET /birthdays hängt, wäre das
+        // ein Push pro Geburtstag pro Abruf, endlos. Diese Felder gehören
+        // deshalb dem Provider, sobald er die Zeile einmal angefasst hat.
+        database.prepare(`
+          UPDATE calendar_events
+          SET title = ?, description = ?, start_datetime = ?
+          WHERE id = ?
+        `).run(
+          payload.title,
+          payload.description,
+          payload.start_datetime,
+          birthday.calendar_event_id,
+        );
+
+        // Marker inline statt über markEventOutbound: das schreibt über db.get()
+        // und würde die übergebene Connection umgehen (dieselbe Überlegung wie
+        // in retitleBirthdayEvents). Verglichen wird genau das, was oben
+        // geschrieben wurde - alles andere ist Provider-Normalisierung und darf
+        // keinen Push auslösen.
+        const authoredChanged = AUTHORED_FIELDS.some((f) => existing[f] !== payload[f]);
+        if (authoredChanged) {
+          database.prepare(
+            'UPDATE calendar_events SET outbound_dirty = 1, outbound_attempts = 0 WHERE id = ?'
+          ).run(birthday.calendar_event_id);
+        }
+      } else {
+        database.prepare(`
+          UPDATE calendar_events
+          SET title = ?, description = ?, start_datetime = ?, end_datetime = ?, all_day = ?,
+              location = ?, color = ?, icon = ?, assigned_to = ?, recurrence_rule = ?, created_by = ?
+          WHERE id = ?
+        `).run(
+          payload.title,
+          payload.description,
+          payload.start_datetime,
+          payload.end_datetime,
+          payload.all_day,
+          payload.location,
+          payload.color,
+          payload.icon,
+          payload.assigned_to,
+          payload.recurrence_rule,
+          payload.created_by,
+          birthday.calendar_event_id,
+        );
+      }
       return birthday.calendar_event_id;
     }
   }

--- a/server/services/birthdays.js
+++ b/server/services/birthdays.js
@@ -1,5 +1,5 @@
 import { formatDateKey, resolveHouseholdFormats, translate } from '../utils/i18n.js';
-import { OUTBOUND_SOURCES } from './calendar-outbound.js';
+import { OUTBOUND_SOURCES, markEventOutbound, queueEventDeletion } from './calendar-outbound.js';
 
 const BIRTHDAY_COLOR = '#E11D48';
 const BIRTHDAY_RRULE = 'FREQ=YEARLY;INTERVAL=1';
@@ -87,12 +87,24 @@ function eventDescription(name, birthDate, locale, dateFormat) {
     : translate(locale, 'birthdays.calendarEventDescriptionNoDate', { name });
 }
 
+/**
+ * Löscht einen Geburtstags-Termin und merkt die beim Provider liegende Kopie zur
+ * Löschung vor. Die Vormerkung muss davor passieren: danach fehlt der Weg zum
+ * entfernten Objekt (Kalender-ID und Objekt-URL stehen in der Zeile), und der
+ * nächste Inbound-Lauf spielte den Termin sonst wieder ein.
+ */
+function deleteCalendarEvent(database, eventId) {
+  const event = database.prepare('SELECT * FROM calendar_events WHERE id = ?').get(eventId);
+  if (event) queueEventDeletion(event);
+  database.prepare('DELETE FROM calendar_events WHERE id = ?').run(eventId);
+}
+
 function syncBirthdayCalendarEvent(database, birthday) {
   // "Keine Benachrichtigung" → Geburtstag soll weder im Dashboard noch im
   // Kalender als Termin erscheinen. Vorhandenes Event löschen und null zurückgeben.
   if (birthday.reminder_offset === '') {
     if (birthday.calendar_event_id) {
-      database.prepare('DELETE FROM calendar_events WHERE id = ?').run(birthday.calendar_event_id);
+      deleteCalendarEvent(database, birthday.calendar_event_id);
       database.prepare('UPDATE birthdays SET calendar_event_id = NULL WHERE id = ?').run(birthday.id);
     }
     return null;
@@ -114,13 +126,19 @@ function syncBirthdayCalendarEvent(database, birthday) {
   };
 
   if (birthday.calendar_event_id) {
-    const existing = database.prepare('SELECT id FROM calendar_events WHERE id = ?').get(birthday.calendar_event_id);
+    const existing = database.prepare('SELECT * FROM calendar_events WHERE id = ?').get(birthday.calendar_event_id);
     if (existing) {
+      // `external_source` wird bewusst NICHT auf 'local' zurückgesetzt. Das tat
+      // diese Anweisung seit dem ersten Geburtstags-Commit, lange bevor es einen
+      // Outbound-Sync gab - und seither entkoppelte jede Bearbeitung den Termin
+      // von seiner Kopie beim Provider: `pendingUpdates` sucht nach
+      // external_source='apple', der Neu-Upload nach external_calendar_id IS NULL,
+      // und mit 'local' + gesetzter Kalender-ID traf keiner von beiden zu. Ein
+      // einmal gespiegelter Geburtstag fror dort für immer ein.
       database.prepare(`
         UPDATE calendar_events
         SET title = ?, description = ?, start_datetime = ?, end_datetime = ?, all_day = ?,
-            location = ?, color = ?, icon = ?, assigned_to = ?, recurrence_rule = ?, created_by = ?,
-            external_source = 'local'
+            location = ?, color = ?, icon = ?, assigned_to = ?, recurrence_rule = ?, created_by = ?
         WHERE id = ?
       `).run(
         payload.title,
@@ -136,6 +154,10 @@ function syncBirthdayCalendarEvent(database, birthday) {
         payload.created_by,
         birthday.calendar_event_id,
       );
+      const after = database.prepare('SELECT * FROM calendar_events WHERE id = ?').get(birthday.calendar_event_id);
+      // Vergleicht die gespiegelten Felder selbst und prüft Quelle,
+      // Kalenderzuordnung und Schreibbarkeit des Providers.
+      if (after) markEventOutbound(existing, after);
       return birthday.calendar_event_id;
     }
   }
@@ -212,7 +234,7 @@ function deleteBirthdayArtifacts(database, birthday) {
       DELETE FROM reminders
       WHERE entity_type = 'event' AND entity_id = ? AND created_by = ?
     `).run(birthday.calendar_event_id, birthday.created_by);
-    database.prepare('DELETE FROM calendar_events WHERE id = ?').run(birthday.calendar_event_id);
+    deleteCalendarEvent(database, birthday.calendar_event_id);
   }
 }
 

--- a/server/services/calendar-outbound.js
+++ b/server/services/calendar-outbound.js
@@ -87,11 +87,11 @@ export function outboundFailureAction(err, attempts) {
  * Legt einen Tombstone an. Idempotent über den UNIQUE-Index.
  * @returns {boolean} true, wenn eine Löschung vorgemerkt ist
  */
-export function queueDeletion({ source, calendarExternalId, eventExternalId, objectUrl = null }) {
+export function queueDeletion({ source, calendarExternalId, eventExternalId, objectUrl = null }, database = null) {
   if (!source || !eventExternalId) return false;
   if (!calendarExternalId && !objectUrl) return false;
 
-  db.get().prepare(`
+  (database || db.get()).prepare(`
     INSERT INTO calendar_pending_deletions (source, calendar_external_id, event_external_id, object_url)
     VALUES (?, ?, ?, ?)
     ON CONFLICT(source, calendar_external_id, event_external_id)
@@ -283,9 +283,9 @@ function cfg(key) {
 }
 
 /** Externe Kalender-Kennung, in der das Event beim Provider liegt. */
-function calendarExternalId(event) {
+function calendarExternalId(event, database = null) {
   if (event.calendar_ref_id) {
-    const row = db.get().prepare(
+    const row = (database || db.get()).prepare(
       'SELECT external_id FROM external_calendars WHERE id = ? AND source = ?'
     ).get(event.calendar_ref_id, event.external_source);
     if (row?.external_id) return row.external_id;
@@ -314,12 +314,12 @@ function acceptsOutbound(source) {
  * Muss VOR dem lokalen DELETE mit der noch vorhandenen Zeile aufgerufen werden.
  * @returns {boolean} true, wenn ein Tombstone entstanden ist
  */
-export function queueEventDeletion(event) {
+export function queueEventDeletion(event, database = null) {
   if (!event || !OUTBOUND_SOURCES.includes(event.external_source)) return false;
   if (!event.external_calendar_id) return false;
   if (!acceptsOutbound(event.external_source)) return false;
 
-  const calId = calendarExternalId(event);
+  const calId = calendarExternalId(event, database);
   // Ohne Kalender und ohne Objekt-URL gibt es keinen Weg zum entfernten Objekt.
   if (!calId && !event.external_object_url) {
     log.warn(`No remote calendar known for event ${event.id}, deletion at the provider skipped.`);
@@ -331,7 +331,7 @@ export function queueEventDeletion(event) {
     calendarExternalId: calId,
     eventExternalId:    event.external_calendar_id,
     objectUrl:          event.external_object_url || null,
-  });
+  }, database);
 }
 
 /**

--- a/server/utils/i18n.js
+++ b/server/utils/i18n.js
@@ -215,17 +215,48 @@ export function resolveHouseholdLocale(database, { ignoreExplicit = false } = {}
 }
 
 /**
- * Sprache + Datumsformat des Haushalts in einem Zug - beides steckt in
- * sync_config und wird von Aufrufern fast immer zusammen gebraucht.
+ * Sprache, Datumsformat und Währung des Haushalts in einem Zug - alles drei
+ * steckt in sync_config und wird von Aufrufern fast immer zusammen gebraucht.
  * @param {object} database
- * @returns {{ locale: string, dateFormat: string }}
+ * @returns {{ locale: string, dateFormat: string, currency: string }}
  */
 export function resolveHouseholdFormats(database) {
   const dateFormat = cfgValue(database, 'date_format');
   return {
     locale: resolveHouseholdLocale(database),
     dateFormat: VALID_DATE_FORMATS.includes(dateFormat) ? dateFormat : 'dmy',
+    currency: cfgValue(database, 'currency') || 'EUR',
   };
+}
+
+/**
+ * Formatiert einen Betrag als Währung, wie es der Client mit `money()` tut.
+ *
+ * Die Zahlformatierung folgt der **Region**, nicht der Sprache - ein
+ * deutschsprachiger Haushalt in der Schweiz schreibt `1'234.50`. Der Client
+ * macht dasselbe über `getFormatLocale()`; hier ist die Region der volle
+ * BCP-47-Tag aus sync_config, mit der Datensprache als Rückfall.
+ *
+ * Fehlerhafte Währungscodes lassen `Intl` werfen - dann bleibt die nackte Zahl
+ * übrig, was besser ist als ein 500 aus einer Beschriftung.
+ *
+ * @param {number} amount
+ * @param {{ locale: string, currency: string, region?: string|null }} opts
+ * @returns {string}
+ */
+export function formatMoney(amount, { locale, currency, region = null }) {
+  const numberLocale = /^[a-z]{2}-[A-Z]{2}$/.test(region ?? '') ? region : locale;
+  try {
+    return new Intl.NumberFormat(numberLocale, { style: 'currency', currency }).format(amount);
+  } catch {
+    return String(amount);
+  }
+}
+
+/** Gespeicherte Region des Haushalts (voller BCP-47-Tag) oder null. */
+export function householdRegion(database) {
+  const region = cfgValue(database, 'region');
+  return /^[a-z]{2}-[A-Z]{2}$/.test(region ?? '') ? region : null;
 }
 
 export { DEFAULT_LOCALE, REFERENCE_LOCALE };

--- a/test/test-birthday-localization.js
+++ b/test/test-birthday-localization.js
@@ -347,6 +347,95 @@ test('ein abgelehntes Feld hinterlässt keine Sprache ohne passende Titel', asyn
   );
 });
 
+// ---------------------------------------------------------------------------
+// Bearbeiten und Löschen eines bereits gespiegelten Geburtstags
+//
+// Das Umbenennen läuft über syncBirthdayCalendarEvent, nicht über den Backfill.
+// Diese Anweisung setzte `external_source` auf 'local' zurück - seit dem ersten
+// Geburtstags-Commit, lange vor dem Outbound-Sync. Mit 'local' UND gesetzter
+// Kalender-ID fiel der Termin aus beiden Pfaden: pendingUpdates sucht nach
+// 'apple', der Neu-Upload nach external_calendar_id IS NULL. Er fror beim
+// Provider ein, ohne dass irgendetwas ihn je wieder abgeholt hätte.
+// ---------------------------------------------------------------------------
+
+// Die Warteschlange ist auf (source, calendar_external_id, event_external_id)
+// eindeutig - zwei Termine mit derselben UID ergaeben nur eine Vormerkung, und
+// der zweite Test haette gegen den Eintrag des ersten geprueft.
+function mirrorEvent(eventId) {
+  db.prepare(`
+    UPDATE calendar_events
+    SET external_source = 'apple', external_calendar_id = ?,
+        external_object_url = ?, outbound_dirty = 0
+    WHERE id = ?
+  `).run(`bd-mirror-${eventId}@oikos.local`, `https://caldav.example/bd-${eventId}.ics`, eventId);
+}
+
+test('ein umbenannter Geburtstag bleibt mit seiner Kopie beim Provider verbunden', async () => {
+  setConfig('apple_caldav_url', 'https://caldav.example/');
+  const created = await call('POST', '/birthdays', { name: 'Oma', birth_date: '1950-04-01' });
+  const eventId = db.prepare('SELECT calendar_event_id AS id FROM birthdays WHERE id = ?')
+    .get(created.body.data.id).id;
+  mirrorEvent(eventId);
+
+  const renamed = await call('PUT', `/birthdays/${created.body.data.id}`, {
+    name: 'Großmutter',
+    birth_date: '1950-04-01',
+  });
+  assert.equal(renamed.status, 200);
+
+  const row = db.prepare('SELECT title, external_source, outbound_dirty FROM calendar_events WHERE id = ?')
+    .get(eventId);
+  assert.match(row.title, /Großmutter/);
+  assert.equal(row.external_source, 'apple', 'die Zuordnung zum Provider darf nicht verlorengehen');
+  assert.equal(row.outbound_dirty, 1, 'sonst erreicht der neue Name den Provider nie');
+});
+
+test('ein gelöschter Geburtstag räumt die Kopie beim Provider mit ab', async () => {
+  const created = await call('POST', '/birthdays', { name: 'Opa', birth_date: '1948-09-09' });
+  const eventId = db.prepare('SELECT calendar_event_id AS id FROM birthdays WHERE id = ?')
+    .get(created.body.data.id).id;
+  mirrorEvent(eventId);
+  const before = db.prepare('SELECT COUNT(*) AS c FROM calendar_pending_deletions').get().c;
+
+  const deleted = await call('DELETE', `/birthdays/${created.body.data.id}`);
+  assert.ok([200, 204].includes(deleted.status), `unerwarteter Status ${deleted.status}`);
+
+  assert.equal(
+    db.prepare('SELECT COUNT(*) AS c FROM calendar_events WHERE id = ?').get(eventId).c,
+    0,
+    'lokal gelöscht',
+  );
+  assert.ok(
+    db.prepare('SELECT COUNT(*) AS c FROM calendar_pending_deletions').get().c > before,
+    'ohne Vormerkung bliebe der Termin beim Provider stehen und käme beim nächsten Inbound zurück',
+  );
+});
+
+test('"keine Benachrichtigung" räumt die Kopie beim Provider ebenfalls ab', async () => {
+  const created = await call('POST', '/birthdays', { name: 'Tante', birth_date: '1970-01-15' });
+  const eventId = db.prepare('SELECT calendar_event_id AS id FROM birthdays WHERE id = ?')
+    .get(created.body.data.id).id;
+  mirrorEvent(eventId);
+  const before = db.prepare('SELECT COUNT(*) AS c FROM calendar_pending_deletions').get().c;
+
+  // reminder_offset = '' entfernt den Termin, ohne den Geburtstag zu löschen.
+  const muted = await call('PUT', `/birthdays/${created.body.data.id}`, {
+    name: 'Tante',
+    birth_date: '1970-01-15',
+    reminder_offset: '',
+  });
+  assert.equal(muted.status, 200);
+
+  assert.equal(
+    db.prepare('SELECT calendar_event_id FROM birthdays WHERE id = ?').get(created.body.data.id).calendar_event_id,
+    null,
+  );
+  assert.ok(
+    db.prepare('SELECT COUNT(*) AS c FROM calendar_pending_deletions').get().c > before,
+    'auch dieser Pfad löscht einen gespiegelten Termin',
+  );
+});
+
 test('GET /preferences liefert die drei Sprachfelder', async () => {
   // Eigene Vorbedingung: die drei Felder sind nur dann unterscheidbar, wenn
   // gewählte Sprache und Region auseinanderfallen.

--- a/test/test-birthday-localization.js
+++ b/test/test-birthday-localization.js
@@ -420,6 +420,48 @@ test('ein Sync ohne echte Änderung löst keinen Push aus', async () => {
   );
 });
 
+test('ein verschobenes Geburtsdatum nimmt das Ende des Termins mit', async () => {
+  const created = await call('POST', '/birthdays', { name: 'Papa', birth_date: '1955-04-01' });
+  const eventId = db.prepare('SELECT calendar_event_id AS id FROM birthdays WHERE id = ?')
+    .get(created.body.data.id).id;
+  mirrorEvent(eventId);
+  // Der Inbound legt bei einem ganztägigen Termin ein Ende gleich dem Start ab.
+  db.prepare('UPDATE calendar_events SET end_datetime = start_datetime WHERE id = ?').run(eventId);
+
+  await call('PUT', `/birthdays/${created.body.data.id}`, { name: 'Papa', birth_date: '1955-09-15' });
+
+  const row = db.prepare('SELECT start_datetime, end_datetime FROM calendar_events WHERE id = ?').get(eventId);
+  assert.equal(row.start_datetime, '1955-09-15');
+  assert.equal(
+    row.end_datetime, '1955-09-15',
+    'ein stehengebliebenes Ende läge vor dem Beginn - die Serializer machten daraus ein DTEND vor DTSTART',
+  );
+});
+
+test('im Nur-Lesen-Modus bleibt die lokale Änderung gegen den Inbound geschützt', async () => {
+  // Ein schreibgeschützter Provider nimmt den Push nicht an. Der Marker ist aber
+  // auch der Schutz davor, dass der Inbound die lokale Fassung überschreibt
+  // (`if (existing?.outbound_dirty) continue`) - er muss deshalb trotzdem stehen.
+  setConfig('google_refresh_token', 'token');
+  setConfig('google_readonly', '1');
+
+  const created = await call('POST', '/birthdays', { name: 'Cousine', birth_date: '1985-02-02' });
+  const eventId = db.prepare('SELECT calendar_event_id AS id FROM birthdays WHERE id = ?')
+    .get(created.body.data.id).id;
+  db.prepare(`
+    UPDATE calendar_events
+    SET external_source = 'google', external_calendar_id = ?, outbound_dirty = 0 WHERE id = ?
+  `).run(`bd-ro-${eventId}@google`, eventId);
+
+  await call('PUT', `/birthdays/${created.body.data.id}`, { name: 'Cousine Mia', birth_date: '1985-02-02' });
+
+  const row = db.prepare('SELECT title, outbound_dirty FROM calendar_events WHERE id = ?').get(eventId);
+  assert.match(row.title, /Mia/);
+  assert.equal(row.outbound_dirty, 1, 'ohne Marker überschriebe der nächste Inbound den neuen Namen');
+
+  db.prepare(`DELETE FROM sync_config WHERE key IN ('google_refresh_token', 'google_readonly')`).run();
+});
+
 test('ein gelöschter Geburtstag räumt die Kopie beim Provider mit ab', async () => {
   const created = await call('POST', '/birthdays', { name: 'Opa', birth_date: '1948-09-09' });
   const eventId = db.prepare('SELECT calendar_event_id AS id FROM birthdays WHERE id = ?')

--- a/test/test-birthday-localization.js
+++ b/test/test-birthday-localization.js
@@ -361,6 +361,11 @@ test('ein abgelehntes Feld hinterlässt keine Sprache ohne passende Titel', asyn
 // Die Warteschlange ist auf (source, calendar_external_id, event_external_id)
 // eindeutig - zwei Termine mit derselben UID ergaeben nur eine Vormerkung, und
 // der zweite Test haette gegen den Eintrag des ersten geprueft.
+// Provider-Konfiguration einmal fuer alle Tests dieses Blocks: acceptsOutbound()
+// prueft sie, und in einem Peer-Test gesetzt haetten die Folgetests von dessen
+// Ausfuehrung abgehangen (ein einzeln laufender Test waere rot gewesen).
+setConfig('apple_caldav_url', 'https://caldav.example/');
+
 function mirrorEvent(eventId) {
   db.prepare(`
     UPDATE calendar_events
@@ -371,7 +376,6 @@ function mirrorEvent(eventId) {
 }
 
 test('ein umbenannter Geburtstag bleibt mit seiner Kopie beim Provider verbunden', async () => {
-  setConfig('apple_caldav_url', 'https://caldav.example/');
   const created = await call('POST', '/birthdays', { name: 'Oma', birth_date: '1950-04-01' });
   const eventId = db.prepare('SELECT calendar_event_id AS id FROM birthdays WHERE id = ?')
     .get(created.body.data.id).id;
@@ -388,6 +392,32 @@ test('ein umbenannter Geburtstag bleibt mit seiner Kopie beim Provider verbunden
   assert.match(row.title, /Großmutter/);
   assert.equal(row.external_source, 'apple', 'die Zuordnung zum Provider darf nicht verlorengehen');
   assert.equal(row.outbound_dirty, 1, 'sonst erreicht der neue Name den Provider nie');
+});
+
+test('ein Sync ohne echte Änderung löst keinen Push aus', async () => {
+  const created = await call('POST', '/birthdays', { name: 'Onkel', birth_date: '1960-03-03' });
+  const eventId = db.prepare('SELECT calendar_event_id AS id FROM birthdays WHERE id = ?')
+    .get(created.body.data.id).id;
+  mirrorEvent(eventId);
+
+  // Der Weg über den Provider ist nicht wertneutral: der ICS-Export schreibt für
+  // einen ganztägigen Termin immer ein DTEND, und die Farbe überträgt er nicht -
+  // der Inbound schreibt also ein end_datetime, wo NULL stand, und die Farbe des
+  // Kalenders. Genau diesen Rückweg stellen die beiden Zeilen nach.
+  db.prepare(`
+    UPDATE calendar_events SET end_datetime = start_datetime, color = '#FC3C44' WHERE id = ?
+  `).run(eventId);
+
+  // syncAllBirthdayReminders hängt an GET /birthdays, GET /reminders und am
+  // Benachrichtigungs-Scheduler. Zählte der Vergleich die normalisierten Felder
+  // mit, wäre das ein Push pro Geburtstag pro Abruf - endlos.
+  for (let i = 0; i < 3; i++) await call('GET', '/birthdays');
+
+  assert.equal(
+    db.prepare('SELECT outbound_dirty FROM calendar_events WHERE id = ?').get(eventId).outbound_dirty,
+    0,
+    'Provider-Normalisierung darf keinen Push auslösen',
+  );
 });
 
 test('ein gelöschter Geburtstag räumt die Kopie beim Provider mit ab', async () => {

--- a/test/test-housekeeping-routes.js
+++ b/test/test-housekeeping-routes.js
@@ -500,6 +500,33 @@ test('ein verschobener Besuch wird zum Provider nachgezogen', async () => {
   assert.equal(event.outbound_dirty, 1, 'die Verschiebung muss den Provider erreichen');
 });
 
+test('im Nur-Lesen-Modus bleibt der verschobene Besuch gegen den Inbound geschützt', async () => {
+  // Ein schreibgeschützter Provider nimmt den Push nicht an - der Marker ist aber
+  // auch der Schutz davor, dass der Inbound das neue Datum überschreibt.
+  setConfig('google_refresh_token', 'token');
+  setConfig('google_readonly', '1');
+
+  const workerId = await freshWorker('Rita');
+  const created = await call('POST', '/work-sessions/check-in', {
+    as: ADM,
+    body: { worker_id: workerId, daily_rate: 40, local_date: '2025-07-01' },
+  });
+  const row = db.prepare('SELECT calendar_event_id AS id FROM housekeeping_work_sessions WHERE id = ?')
+    .get(created.body.data.id);
+  db.prepare(`
+    UPDATE calendar_events
+    SET external_source = 'google', external_calendar_id = ?, outbound_dirty = 0 WHERE id = ?
+  `).run(`hk-ro-${row.id}@google`, row.id);
+
+  await call('PUT', `/visits/${created.body.data.id}`, { as: ADM, body: { date: '2025-07-08', daily_rate: 40 } });
+
+  const event = db.prepare('SELECT start_datetime, outbound_dirty FROM calendar_events WHERE id = ?').get(row.id);
+  assert.equal(event.start_datetime, '2025-07-08');
+  assert.equal(event.outbound_dirty, 1, 'ohne Marker überschriebe der nächste Inbound das alte Datum zurück');
+
+  db.prepare(`DELETE FROM sync_config WHERE key IN ('google_refresh_token', 'google_readonly')`).run();
+});
+
 test('ein gelöschter Besuch räumt die Kopie beim Provider mit ab', async () => {
   const row = db.prepare('SELECT calendar_event_id FROM housekeeping_work_sessions WHERE id = ?').get(LOCALIZED_SESSION);
   const before = db.prepare('SELECT COUNT(*) AS c FROM calendar_pending_deletions').get().c;

--- a/test/test-housekeeping-routes.js
+++ b/test/test-housekeeping-routes.js
@@ -461,6 +461,10 @@ test('Fallback-Titel folgen der Datensprache des Haushalts', async () => {
 
 test('ohne gesetzte Sprache bleibt es beim englischen Bestandsverhalten', async () => {
   db.prepare(`DELETE FROM sync_config WHERE key IN ('language', 'region')`).run();
+  // Sprache am Ende wiederherstellen: die Folgetests pruefen deutsche Texte, und
+  // ohne das schriebe updateVisitLinks die Beschreibung stillschweigend auf
+  // Englisch zurueck - der Test davor haette dann eine Zusicherung gemacht, die
+  // der naechste Aufruf widerlegt.
 
   const workerId = await freshWorker('Nina');
   const r = await call('POST', '/work-sessions/check-in', {
@@ -470,6 +474,8 @@ test('ohne gesetzte Sprache bleibt es beim englischen Bestandsverhalten', async 
   const row = db.prepare('SELECT calendar_event_id FROM housekeeping_work_sessions WHERE id = ?').get(r.body.data.id);
   const event = db.prepare('SELECT title FROM calendar_events WHERE id = ?').get(row.calendar_event_id);
   assert.equal(event.title, 'Housekeeping: Nina');
+
+  setConfig('language', 'de');
 });
 
 test('ein verschobener Besuch wird zum Provider nachgezogen', async () => {

--- a/test/test-housekeeping-routes.js
+++ b/test/test-housekeeping-routes.js
@@ -403,6 +403,132 @@ test('PUT /visits/:id: Stundenkraft berechnet Betrag aus minutes_worked', async 
   assert.equal(row.daily_rate, computeHourlyAmount(120, 30));
 });
 
+// ---------------------------------------------------------------------------
+// Datensprache und Outbound-Kopplung der Besuchs-Artefakte
+//
+// Die Oberfläche schickt Titel und Beschreibung übersetzt mit; diese Fallbacks
+// greifen für alles, was die API direkt anspricht. Sie standen fest auf
+// Englisch, obwohl die Texte in calendar_events/tasks landen und von dort in
+// API, ICS-Feed und Sync gehen - dieselbe Ursache wie #631/#632.
+// ---------------------------------------------------------------------------
+
+function setConfig(key, value) {
+  db.prepare(`
+    INSERT INTO sync_config (key, value) VALUES (?, ?)
+    ON CONFLICT(key) DO UPDATE SET value = excluded.value
+  `).run(key, value);
+}
+
+async function freshWorker(name) {
+  await call('POST', '/worker', {
+    as: ADM,
+    body: { username: name, display_name: name, password: 'secret123', daily_rate: 40 },
+  });
+  const list = await call('GET', '/workers', { as: ADM });
+  return list.body.data.find((w) => w.display_name === name).id;
+}
+
+let LOCALIZED_SESSION;
+
+test('Fallback-Titel folgen der Datensprache des Haushalts', async () => {
+  setConfig('language', 'de');
+  setConfig('date_format', 'dmy');
+  setConfig('currency', 'EUR');
+  setConfig('housekeeping_payment_tasks', '1');
+
+  const workerId = await freshWorker('Marta');
+  // Bewusst ohne event_title/payment_* - genau der Pfad eines API-Aufrufers.
+  const r = await call('POST', '/work-sessions/check-in', {
+    as: ADM,
+    body: { worker_id: workerId, daily_rate: 40, extras: 5, local_date: '2025-06-02' },
+  });
+  assert.equal(r.status, 201);
+  LOCALIZED_SESSION = r.body.data.id;
+
+  const row = db.prepare(`
+    SELECT calendar_event_id, payment_task_id FROM housekeeping_work_sessions WHERE id = ?
+  `).get(LOCALIZED_SESSION);
+
+  const event = db.prepare('SELECT title FROM calendar_events WHERE id = ?').get(row.calendar_event_id);
+  assert.equal(event.title, 'Haushaltshilfe: Marta');
+
+  const task = db.prepare('SELECT title, description FROM tasks WHERE id = ?').get(row.payment_task_id);
+  assert.equal(task.title, 'Marta für Haushaltshilfe bezahlen');
+  // Datum nach date_format, Betrag als Währung - wie der Client es schriebe.
+  assert.match(task.description, /02\.06\.2025/);
+  assert.match(task.description, /45/);
+});
+
+test('ohne gesetzte Sprache bleibt es beim englischen Bestandsverhalten', async () => {
+  db.prepare(`DELETE FROM sync_config WHERE key IN ('language', 'region')`).run();
+
+  const workerId = await freshWorker('Nina');
+  const r = await call('POST', '/work-sessions/check-in', {
+    as: ADM,
+    body: { worker_id: workerId, daily_rate: 40, local_date: '2025-06-03' },
+  });
+  const row = db.prepare('SELECT calendar_event_id FROM housekeeping_work_sessions WHERE id = ?').get(r.body.data.id);
+  const event = db.prepare('SELECT title FROM calendar_events WHERE id = ?').get(row.calendar_event_id);
+  assert.equal(event.title, 'Housekeeping: Nina');
+});
+
+test('ein verschobener Besuch wird zum Provider nachgezogen', async () => {
+  // Der Termin liegt bereits beim Provider: der Apple-Sync lädt jedes lokale
+  // Event ohne Kalenderzuordnung hoch und stellt die Zeile danach auf 'apple'.
+  // Ab da erreicht ihn nur noch outbound_dirty (#632).
+  setConfig('apple_caldav_url', 'https://caldav.icloud.com/');
+  const row = db.prepare('SELECT calendar_event_id FROM housekeeping_work_sessions WHERE id = ?').get(LOCALIZED_SESSION);
+  db.prepare(`
+    UPDATE calendar_events
+    SET external_source = 'apple', external_calendar_id = 'hk-test@oikos.local',
+        external_object_url = 'https://caldav.icloud.com/home/hk-test.ics', outbound_dirty = 0
+    WHERE id = ?
+  `).run(row.calendar_event_id);
+
+  const r = await call('PUT', `/visits/${LOCALIZED_SESSION}`, { as: ADM, body: { date: '2025-06-09', daily_rate: 40 } });
+  assert.equal(r.status, 200);
+
+  const event = db.prepare('SELECT start_datetime, outbound_dirty FROM calendar_events WHERE id = ?')
+    .get(row.calendar_event_id);
+  assert.equal(event.start_datetime, '2025-06-09');
+  assert.equal(event.outbound_dirty, 1, 'die Verschiebung muss den Provider erreichen');
+});
+
+test('ein gelöschter Besuch räumt die Kopie beim Provider mit ab', async () => {
+  const row = db.prepare('SELECT calendar_event_id FROM housekeeping_work_sessions WHERE id = ?').get(LOCALIZED_SESSION);
+  const before = db.prepare('SELECT COUNT(*) AS c FROM calendar_pending_deletions').get().c;
+
+  const r = await call('DELETE', `/visits/${LOCALIZED_SESSION}`, { as: ADM });
+  assert.equal(r.status, 200);
+
+  assert.equal(
+    db.prepare('SELECT COUNT(*) AS c FROM calendar_events WHERE id = ?').get(row.calendar_event_id).c,
+    0,
+    'lokal gelöscht',
+  );
+  assert.ok(
+    db.prepare('SELECT COUNT(*) AS c FROM calendar_pending_deletions').get().c > before,
+    'die Löschung beim Provider muss vorgemerkt sein, sonst bleibt der Termin dort stehen',
+  );
+});
+
+test('ein rein lokaler Besuch merkt nichts beim Provider vor', async () => {
+  const workerId = await freshWorker('Tomas');
+  const created = await call('POST', '/work-sessions/check-in', {
+    as: ADM,
+    body: { worker_id: workerId, daily_rate: 40, local_date: '2025-06-04' },
+  });
+  const before = db.prepare('SELECT COUNT(*) AS c FROM calendar_pending_deletions').get().c;
+
+  await call('DELETE', `/visits/${created.body.data.id}`, { as: ADM });
+
+  assert.equal(
+    db.prepare('SELECT COUNT(*) AS c FROM calendar_pending_deletions').get().c,
+    before,
+    'ohne Provider-Zuordnung gibt es dort nichts zu löschen',
+  );
+});
+
 test('teardown: Server schließen', async () => {
   await new Promise((r) => server.close(r));
 });


### PR DESCRIPTION
Nachlese zu #631/#632, in zwei Modulen. Dieselbe Ursache, eine Ebene tiefer: Zeilen in `calendar_events`, die der Server schreibt, verlassen den Haushalt über API, ICS-Feed und Provider-Sync - und zwei Module haben das nicht bedacht.

## Housekeeping (`c1747d36`)

**Die Fallback-Texte standen fest auf Englisch.** Die Oberfläche schickt Titel und Beschreibung übersetzt mit; der Server hatte für alles andere - MCP, Skripte, Integrationen - `Housekeeping: <Name>` und `Pay <Name> for housekeeping`. Jetzt dieselbe Datensprache wie bei den Geburtstags-Terminen, über dieselben Locale-Keys, die auch der Client nutzt. Der Betrag wird dabei als Währung formatiert (`45,00 €` statt `45.00`) und das Datum nach `date_format` - der Fallback schrieb vorher ein rohes ISO-Datum, wo der Client längst formatierte.

**Ein verschobener Besuch erreichte den Provider nicht.** `updateVisitLinks` schreibt Titel, Startdatum und Farbe - alle drei stehen in `MIRRORED_FIELDS` - ohne die Zeile für den Push vorzumerken. Wer einen Besuch auf einen anderen Tag legte, sah ihn in Yuvomi am neuen Datum und in iCloud weiter am alten.

**Ein gelöschter Besuch ließ seine Kopie beim Provider stehen** und konnte beim nächsten Inbound-Lauf zurückkommen.

## Birthdays (`80724206`)

Der schwerere Fund. `syncBirthdayCalendarEvent` setzte bei **jeder** Bearbeitung `external_source` auf `'local'` zurück, ließ `external_calendar_id` aber stehen. Die Anweisung steht seit dem allerersten Geburtstags-Commit da, lange bevor es einen Outbound-Sync gab, und wurde nie angepasst.

Mit `'local'` UND gesetzter Kalender-ID fiel der Termin aus beiden Wegen nach draußen: `pendingUpdates` sucht nach `external_source='apple'`, der Neu-Upload nach `external_calendar_id IS NULL`. Nachgestellt:

```
vorher:  external_source=local,  outbound_dirty=0, pendingUpdates(apple)=0   → verwaist
nachher: external_source=apple,  outbound_dirty=1, pendingUpdates(apple)=1
```

Ein einmal gespiegelter Geburtstag war nach der ersten Bearbeitung dauerhaft eingefroren - lokal geändert, bei iCloud unverändert, und nichts holte ihn je wieder ab. Das traf jede Bearbeitung, nicht nur den Sprachwechsel.

Ping-Pong mit dem Provider droht nach dem Entfernen nicht: der Inbound überspringt Zeilen mit ausstehendem Push (`apple-calendar.js`, aus #593) - der Schutz ist genau dafür gebaut. Beide Löschpfade merken die Provider-Kopie jetzt vor, auch "keine Benachrichtigung", das den Termin entfernt, ohne den Geburtstag zu löschen.

## Warum das zusammen kommt

Der gemeinsame Nenner ist die Regel, die das Review an #632 zutage gefördert hat: **der Apple-Sync lädt jedes lokale Event ohne Kalenderzuordnung hoch** und stellt die Zeile danach auf `external_source='apple'`. Ab da führt der einzige Weg nach draußen über `outbound_dirty` bzw. die Löschwarteschlange. Wer eine `calendar_events`-Zeile direkt per UPDATE anfasst, muss das wissen.

Ein systematischer Blick auf alle direkten Schreibzugriffe zeigte genau drei Module: Housekeeping, Birthdays und `sync-assignment.js` - letzteres schreibt nur `assigned_to`, kein `MIRRORED_FIELD`, also korrekt ohne Marker.

## Prüfung

Acht neue Guards (fünf Housekeeping, drei Birthdays), jeweils mit beiden Gegenrichtungen: ein rein lokaler Termin merkt nichts vor, ohne gesetzte Sprache bleibt es englisch. Gegenprobe: jeder Fix einzeln zurückgedreht meldet genau seine Guards.

130 Suiten grün.
