### PR TITLE
test(ui): die drei Breiten-Zusicherungen der Küchen-Listen absichern

### DIFF
--- a/test/test-frontend-audit.js
+++ b/test/test-frontend-audit.js
@@ -1928,27 +1928,43 @@ test('die Küchen-Listen teilen eine Zeilen-Grammatik', () => {
   //   - Kurzschreibweisen setzen dieselbe Eigenschaft mit: `place-self:
   //     stretch` setzt `align-self` zurück. Deshalb nimmt die Funktion eine
   //     Liste und gibt bei `place-*` den ersten Teilwert (die Block-Achse).
+  //   - `!important` schlägt die Quellreihenfolge. `max-width: none !important;
+  //     max-width: var(…)` sieht sonst erfüllt aus, obwohl das `none` gewinnt.
   const declaredValue = (body, props) => {
     const alternatives = [].concat(props).map((p) => escapeForRegExp(p)).join('|');
-    const hits = [...body.matchAll(new RegExp(`(?:^|;)\\s*(${alternatives})\\s*:\\s*([^;]+)`, 'gm'))];
+    const hits = [...body.matchAll(new RegExp(`(?:^|;)\\s*(${alternatives})\\s*:\\s*([^;]+)`, 'gm'))]
+      .map(([, prop, raw]) => ({ prop, raw: raw.trim() }));
     if (!hits.length) return null;
-    const [, prop, raw] = hits[hits.length - 1];
-    const value = raw.trim();
+    const important = hits.filter(({ raw }) => /!\s*important$/.test(raw));
+    const { prop, raw } = (important.length ? important : hits).at(-1);
+    const value = raw.replace(/!\s*important$/, '').trim();
     return prop.startsWith('place-') ? value.split(/\s+/)[0] : value;
   };
   const NARROW = 'var(--content-max-width-narrow)';
   const ALIGN_SELF = ['align-self', 'place-self'];
+  // Eine Kappung ist eine Kappung, egal wie buchstabiert: die logischen Formen
+  // wirken im Schreibmodus dieser App auf dieselbe Achse. Dasselbe Paar prüft
+  // der Modul-Root-Breiten-Guard weiter unten schon.
+  const WIDTH_CAP = ['width', 'max-width', 'inline-size', 'max-inline-size'];
+  const MAX_WIDTH = ['max-width', 'max-inline-size'];
 
   // Zielt der Selektor auf das Element selbst, nicht auf einen Nachfahren?
   // Geprüft wird der LETZTE Compound, damit auch `.kitchen-list#items-list`,
   // `.kitchen-list:hover` und `:is(.kitchen-list)` als Treffer gelten -
-  // `.kitchen-list .row` dagegen nicht. `:not(…)` fällt vorher weg, sonst
-  // meldete ausgerechnet der Ausschluss einen Treffer.
-  const targets = (selector, cls) => {
-    const compound = selector.trim().split(/[\s>+~]+/).pop()?.replace(/:not\([^)]*\)/g, '') ?? '';
-    return new RegExp(`\\.${escapeForRegExp(cls)}(?![\\w-])`).test(compound);
+  // `.kitchen-list .row` dagegen nicht.
+  //
+  // `:not(…)` und `:has(…)` fallen vorher weg, und zwar VOR dem Zerlegen:
+  // beide nennen die Klasse, ohne dass die Regel sie stylt. `.page:has(
+  // .kitchen-list)` gestaltet den Vorfahren, nicht den Scroller - dort rot zu
+  // werden hieße, eine korrekte Layoutregel zu blockieren.
+  // Das Token ist `.klasse` oder `#id`: dasselbe Element lässt sich über beide
+  // ansprechen, und eine Regel auf der ID nennt keine seiner Klassen.
+  const targets = (selector, token) => {
+    const subject = selector.replace(/:(?:not|has)\([^)]*\)/g, '');
+    const compound = subject.trim().split(/[\s>+~]+/).pop() ?? '';
+    return new RegExp(`${escapeForRegExp(token)}(?![\\w-])`).test(compound);
   };
-  const rulesFor = (cls) => allRules.filter(({ selectors }) => selectors.some((s) => targets(s, cls)));
+  const rulesFor = (token) => allRules.filter(({ selectors }) => selectors.some((s) => targets(s, token)));
 
   // 1. Der Scroller selbst darf nicht gekappt werden. Er ist das Element mit
   //    `overflow-y: auto`; kappt man es aufs Lesemaß, endet damit auch sein
@@ -1961,21 +1977,43 @@ test('die Küchen-Listen teilen eine Zeilen-Grammatik', () => {
   //    Mindestzahl genügt nicht: fiele nur eine Seite aus der Erkennung, würden
   //    die beiden anderen sie weiter erfüllen, und deren Modul-Klasse wäre
   //    ungeprüft.
-  const scrollerClasses = new Set(['kitchen-list']);
+  const scrollerTokens = new Set(['.kitchen-list']);
   for (const page of ['shopping', 'pantry', 'recipes']) {
-    const combos = [...read(`../public/pages/${page}.js`)
-      .matchAll(/class(?:Name)?\s*=\s*(['"`])([^'"`]*\bkitchen-list\b[^'"`]*)\1/g)];
+    const src = read(`../public/pages/${page}.js`);
+    const combos = [...src.matchAll(/class(?:Name)?\s*=\s*(['"`])([^'"`]*\bkitchen-list\b[^'"`]*)\1/g)];
     assert.ok(combos.length > 0,
       `${page}.js hängt seine Klasse nicht mehr literal an .kitchen-list - dieser Scan findet sie dann nicht und prüft den Scroller des Tabs ungewollt gar nicht`);
-    combos.forEach(([, , combo]) => combo.trim().split(/\s+/).forEach((cls) => scrollerClasses.add(cls)));
+    combos.forEach(([, , combo]) => combo.trim().split(/\s+/).forEach((cls) => scrollerTokens.add(`.${cls}`)));
+
+    // Und über die ID, die alle drei Scroller tragen: `#recipes-list` trifft
+    // dasselbe Element, ohne eine seiner Klassen zu nennen. Keine ID im
+    // Markup heißt umgekehrt, dass kein ID-Selektor es treffen kann - deshalb
+    // ist hier nichts zu fordern, nur einzusammeln.
+    const inTag = (src.match(/<[^>]*\bkitchen-list\b[^>]*>/g) ?? [])
+      .map((tag) => tag.match(/\bid="([^"]+)"/)?.[1]);
+    const nextToClassName = [...src.matchAll(
+      /(\w+)\.className\s*=\s*['"`][^'"`]*\bkitchen-list\b[^'"`]*['"`];\s*\1\.id\s*=\s*['"`]([^'"`]+)/g)]
+      .map(([, , id]) => id);
+    [...inTag, ...nextToClassName].filter(Boolean).forEach((id) => scrollerTokens.add(`#${id}`));
   }
-  assert.ok(rulesFor('kitchen-list').length > 0,
+  assert.ok(rulesFor('.kitchen-list').length > 0,
     '.kitchen-list ist nirgends definiert: ein leerer Treffer darf hier nicht still grün bleiben');
-  for (const cls of scrollerClasses) {
+  for (const cls of scrollerTokens) {
     for (const { file, selectors, body } of rulesFor(cls)) {
-      assert.equal(declaredValue(body, 'max-width'), null,
+      assert.equal(declaredValue(body, WIDTH_CAP), null,
         `${file} ${selectors.join(', ')}: der Scroller darf nicht gekappt werden, sonst endet sein Mausrad-Trefferbereich an der Lesespalten-Kante`);
     }
+  }
+
+  //    Und das Lesemaß behält EINE Quelle. Definierte ein Modul
+  //    --content-max-width-narrow lokal um, trüge das Kind zwar weiter die
+  //    geforderte Deklaration, löste sie aber auf ein anderes Maß auf - der
+  //    Guard unten vergliche dann zwei Texte, die dasselbe sagen und
+  //    Verschiedenes bedeuten.
+  for (const { file, selectors, body } of allRules) {
+    if (file === 'tokens.css') continue;
+    assert.equal(declaredValue(body, '--content-max-width-narrow'), null,
+      `${file} ${selectors.join(', ')}: --content-max-width-narrow wird hier lokal umdefiniert - das Lesemaß kommt aus tokens.css und nirgendwo sonst`);
   }
 
   // 2. Tragen muss die Kappung stattdessen jedes Kind, das ALLEIN Kind des
@@ -1983,15 +2021,15 @@ test('die Küchen-Listen teilen eine Zeilen-Grammatik', () => {
   //    Vorrat), .kitchen-rows ungruppiert (Rezepte). Fehlt sie an einem der
   //    beiden, läuft der betroffene Tab bildschirmbreit - und ein zweiter
   //    Block darf sie auch nicht auf einen abweichenden Wert ziehen.
-  for (const cls of ['kitchen-group', 'kitchen-rows']) {
+  for (const cls of ['.kitchen-group', '.kitchen-rows']) {
     const rules = rulesFor(cls);
-    assert.ok(rules.some(({ body }) => declaredValue(body, 'max-width') === NARROW),
-      `.${cls} muss das Lesemaß selbst tragen: es kann alleiniges Kind von .kitchen-list sein, und .kitchen-list kappt nicht mehr`);
+    assert.ok(rules.some(({ body }) => declaredValue(body, MAX_WIDTH) === NARROW),
+      `${cls} muss das Lesemaß selbst tragen: es kann alleiniges Kind von .kitchen-list sein, und .kitchen-list kappt nicht mehr`);
     for (const { file, body } of rules) {
-      const width = declaredValue(body, 'max-width');
+      const width = declaredValue(body, MAX_WIDTH);
       if (width === null) continue;
       assert.equal(width, NARROW,
-        `${file}: .${cls} bekommt hier eine zweite, abweichende Breite - das Lesemaß ist EIN Wert`);
+        `${file}: ${cls} bekommt hier eine zweite, abweichende Breite - das Lesemaß ist EIN Wert`);
     }
   }
 
@@ -2016,7 +2054,7 @@ test('die Küchen-Listen teilen eine Zeilen-Grammatik', () => {
   //    aber nicht. Käme dort ein `overflow: hidden` dazu, meldet dieser Guard
   //    einen Fall, den ein Mensch entscheiden muss.
   for (const { selectors, body } of cssRules(shared)) {
-    if (declaredValue(body, 'max-width') !== NARROW) continue;
+    if (declaredValue(body, MAX_WIDTH) !== NARROW) continue;
     if (declaredValue(body, 'overflow') !== 'hidden') continue;
     assert.equal(declaredValue(body, ALIGN_SELF), 'start',
       `${selectors.join(', ')} kappt aufs Lesemaß und clippt zugleich, ist also ein gekapptes Kind des Scroller-Grids: ohne align-self: start schneidet es den Überlauf ab, bevor .kitchen-list ihn sieht`);
@@ -2024,7 +2062,7 @@ test('die Küchen-Listen teilen eine Zeilen-Grammatik', () => {
 
   // Und kein später geladenes Modul-Stylesheet biegt den Wert wieder um -
   // auch nicht über die Kurzschreibweise place-self.
-  for (const { file, body } of rulesFor('kitchen-rows')) {
+  for (const { file, body } of rulesFor('.kitchen-rows')) {
     const align = declaredValue(body, ALIGN_SELF);
     if (align === null) continue;
     assert.equal(align, 'start',

--- a/test/test-frontend-audit.js
+++ b/test/test-frontend-audit.js
@@ -1908,41 +1908,99 @@ test('die Küchen-Listen teilen eine Zeilen-Grammatik', () => {
   // Die Kappung aufs Lesemaß sitzt an den KINDERN des Scrollers, nicht am
   // Scroller selbst (PR #614). Die Begründung dafür stand bisher nur als
   // Kommentar im CSS.
-  const sharedLive = stripCssComments(shared);
+  //
+  // Gescannt wird JEDE Regel JEDER Stylesheet-Datei, nicht der erste Textblock
+  // je Selektor. Zwei Wege führen sonst am Guard vorbei: ein zweiter Block
+  // hinter einem Breakpoint, und das Modul-CSS, das später lädt und auf
+  // demselben Element sitzt (`class="kitchen-list items-list"`).
+  const styleDir = new URL('../public/styles/', import.meta.url);
+  const allRules = readdirSync(styleDir).filter((f) => f.endsWith('.css'))
+    .flatMap((file) => cssRules(read(`../public/styles/${file}`)).map((rule) => ({ file, ...rule })));
 
-  // 1. .kitchen-list ist das Element mit `overflow-y: auto`. Kappt man es aufs
-  //    Lesemaß, endet damit auch sein eigener Trefferbereich fürs Mausrad an
-  //    der Lesespalten-Kante, und auf einem breiten Fenster greift das Rad
-  //    rechts davon ins Leere.
-  assert.doesNotMatch(cssRuleBody(sharedLive, '.kitchen-list'), /max-width:/,
-    '.kitchen-list darf kein max-width setzen: der Scroller muss die volle Breite behalten, sonst endet sein Mausrad-Trefferbereich an der Lesespalten-Kante');
+  // Eine DEKLARATION, kein Textvorkommen: `--eigene-max-width: 40rem` ist
+  // keine, und `--x: var(--content-max-width-narrow)` erfüllt keine Zusage.
+  const declares = (body, prop, value = '') =>
+    new RegExp(`(?:^|;)\\s*${prop}\\s*:\\s*${value}`, 'm').test(body);
+  const NARROW = String.raw`var\(--content-max-width-narrow\)`;
 
-  // 2. Tragen muss sie stattdessen jedes Kind, das ALLEIN Kind des Scrollers
-  //    sein kann: .kitchen-group bei gruppierten Tabs (Einkauf, Vorrat),
-  //    .kitchen-rows ungruppiert (Rezepte). Fehlt sie an einem der beiden,
-  //    läuft der betroffene Tab bildschirmbreit.
-  for (const selector of ['.kitchen-group', '.kitchen-rows']) {
-    assert.match(cssRuleBody(sharedLive, selector), /max-width:\s*var\(--content-max-width-narrow\)/,
-      `${selector} muss das Lesemaß selbst tragen: es kann alleiniges Kind von .kitchen-list sein, und .kitchen-list kappt nicht mehr`);
+  // Zielt der Selektor auf das Element selbst, nicht auf einen Nachfahren?
+  const targets = (selector, cls) =>
+    new RegExp(`\\.${escapeForRegExp(cls)}(?![\\w-])(?:[:.[][^\\s>+~]*)?\\s*$`).test(selector);
+  const rulesFor = (cls) => allRules.filter(({ selectors }) => selectors.some((s) => targets(s, cls)));
+
+  // 1. Der Scroller selbst darf nicht gekappt werden. Er ist das Element mit
+  //    `overflow-y: auto`; kappt man es aufs Lesemaß, endet damit auch sein
+  //    eigener Trefferbereich fürs Mausrad an der Lesespalten-Kante, und auf
+  //    einem breiten Fenster greift das Rad rechts davon ins Leere.
+  //
+  //    Welche Klassen den Scroller mitbenennen, sagt das Markup, nicht diese
+  //    Liste: wer auf demselben Element sitzt, kann seine Breite kappen.
+  const scrollerClasses = new Set(['kitchen-list']);
+  for (const page of ['shopping', 'pantry', 'recipes']) {
+    for (const [, , combo] of read(`../public/pages/${page}.js`)
+      .matchAll(/class(?:Name)?\s*=\s*(['"])([^'"]*\bkitchen-list\b[^'"]*)\1/g)) {
+      combo.trim().split(/\s+/).forEach((cls) => scrollerClasses.add(cls));
+    }
+  }
+  assert.ok(scrollerClasses.size > 1,
+    'kein Modul hängt seine Klasse mehr an .kitchen-list - dann prüft dieser Scan die falschen Regeln');
+  assert.ok(rulesFor('kitchen-list').length > 0,
+    '.kitchen-list ist nirgends definiert: ein leerer Treffer darf hier nicht still grün bleiben');
+  for (const cls of scrollerClasses) {
+    for (const { file, selectors, body } of rulesFor(cls)) {
+      assert.ok(!declares(body, 'max-width'),
+        `${file} ${selectors.join(', ')}: der Scroller darf nicht gekappt werden, sonst endet sein Mausrad-Trefferbereich an der Lesespalten-Kante`);
+    }
+  }
+
+  // 2. Tragen muss die Kappung stattdessen jedes Kind, das ALLEIN Kind des
+  //    Scrollers sein kann: .kitchen-group bei gruppierten Tabs (Einkauf,
+  //    Vorrat), .kitchen-rows ungruppiert (Rezepte). Fehlt sie an einem der
+  //    beiden, läuft der betroffene Tab bildschirmbreit - und ein zweiter
+  //    Block darf sie auch nicht auf einen abweichenden Wert ziehen.
+  for (const cls of ['kitchen-group', 'kitchen-rows']) {
+    const rules = rulesFor(cls);
+    assert.ok(rules.some(({ body }) => declares(body, 'max-width', NARROW)),
+      `.${cls} muss das Lesemaß selbst tragen: es kann alleiniges Kind von .kitchen-list sein, und .kitchen-list kappt nicht mehr`);
+    for (const { file, body } of rules) {
+      if (!declares(body, 'max-width')) continue;
+      assert.ok(declares(body, 'max-width', NARROW),
+        `${file}: .${cls} bekommt hier eine zweite, abweichende Breite - das Lesemaß ist EIN Wert`);
+    }
   }
 
   // 3. Und wer aufs Lesemaß kappt UND clippt, muss auf seine Inhaltshöhe
   //    wachsen dürfen.
   //
-  //    Absichtlich eine Regel und keine Allowlist: das Lesemaß trägt nur, wer
-  //    Kind des Scroller-Grids ist, und `overflow: hidden` (hier für die
-  //    Eckenradien) macht ihn zum Clipper. Ohne `align-self: start` streckt das
-  //    voreingestellte `align-items: stretch` ihn auf die volle Spurhöhe, und
-  //    er schneidet alles darüber still ab, bevor .kitchen-list den Überlauf je
-  //    sieht. Gemessen an einer Rezeptliste mit 50 gespiegelten Einträgen:
-  //    scrollHeight 3249px gegen clientHeight 657px, kein Scrollbalken, kein
-  //    Weg an die übrigen Zeilen. Harmlos ist das nur, solange mehrere kurze
-  //    Gruppen dieselbe Spur teilen.
+  //    Absichtlich eine Regel und keine Allowlist: `overflow: hidden` (hier für
+  //    die Eckenradien) macht aus dem gekappten Kind einen Clipper. Ohne
+  //    `align-self: start` streckt das voreingestellte `align-items: stretch`
+  //    es auf die volle Spurhöhe, und es schneidet alles darüber still ab,
+  //    bevor .kitchen-list den Überlauf je sieht. Gemessen an einer Rezeptliste
+  //    mit 50 gespiegelten Einträgen: scrollHeight 3249px gegen clientHeight
+  //    657px, kein Scrollbalken, kein Weg an die übrigen Zeilen. Harmlos ist
+  //    das nur, solange mehrere kurze Gruppen dieselbe Spur teilen.
+  //
+  //    Der Scan bleibt auf kitchen-row.css, wo die geteilten Bausteine
+  //    definiert werden. Andere Module kappen mit demselben Token Elemente, die
+  //    nie Grid-Item dieses Scrollers werden (shopping.css die Eingabezeile,
+  //    layout.css den Leerzustand) - für die wäre `align-self: start` falsch.
+  //    Innerhalb dieser Datei gilt dieselbe Einschränkung für .kitchen-bulkbar:
+  //    sie steht ÜBER dem Scroller (siehe dort) und trägt das Lesemaß, clippt
+  //    aber nicht. Käme dort ein `overflow: hidden` dazu, meldet dieser Guard
+  //    einen Fall, den ein Mensch entscheiden muss.
   for (const { selectors, body } of cssRules(shared)) {
-    if (!/max-width:\s*var\(--content-max-width-narrow\)/.test(body)) continue;
-    if (!/overflow:\s*hidden/.test(body)) continue;
-    assert.match(body, /align-self:\s*start/,
+    if (!declares(body, 'max-width', NARROW)) continue;
+    if (!declares(body, 'overflow', 'hidden')) continue;
+    assert.ok(declares(body, 'align-self', 'start'),
       `${selectors.join(', ')} kappt aufs Lesemaß und clippt zugleich, ist also ein gekapptes Kind des Scroller-Grids: ohne align-self: start schneidet es den Überlauf ab, bevor .kitchen-list ihn sieht`);
+  }
+
+  // Und kein später geladenes Modul-Stylesheet biegt den Wert wieder um.
+  for (const { file, body } of rulesFor('kitchen-rows')) {
+    if (!declares(body, 'align-self')) continue;
+    assert.ok(declares(body, 'align-self', 'start'),
+      `${file}: .kitchen-rows bekommt hier ein anderes align-self - genau der Rückfall, den die Regel darüber verhindert`);
   }
 });
 

--- a/test/test-frontend-audit.js
+++ b/test/test-frontend-audit.js
@@ -1917,15 +1917,37 @@ test('die Küchen-Listen teilen eine Zeilen-Grammatik', () => {
   const allRules = readdirSync(styleDir).filter((f) => f.endsWith('.css'))
     .flatMap((file) => cssRules(read(`../public/styles/${file}`)).map((rule) => ({ file, ...rule })));
 
-  // Eine DEKLARATION, kein Textvorkommen: `--eigene-max-width: 40rem` ist
-  // keine, und `--x: var(--content-max-width-narrow)` erfüllt keine Zusage.
-  const declares = (body, prop, value = '') =>
-    new RegExp(`(?:^|;)\\s*${prop}\\s*:\\s*${value}`, 'm').test(body);
-  const NARROW = String.raw`var\(--content-max-width-narrow\)`;
+  // Der WIRKSAME Wert einer Eigenschaft, oder null. Drei Fallen stecken darin:
+  //
+  //   - Eine Deklaration ist kein Textvorkommen: `--eigene-max-width: 40rem`
+  //     setzt keine Breite, und `--x: var(--content-max-width-narrow)` erfüllt
+  //     keine Zusage.
+  //   - Die LETZTE Deklaration gewinnt, wie im Browser. Sonst gilt
+  //     `max-width: var(--content-max-width-narrow); max-width: none` als
+  //     erfüllt, obwohl das Element bildschirmbreit läuft.
+  //   - Kurzschreibweisen setzen dieselbe Eigenschaft mit: `place-self:
+  //     stretch` setzt `align-self` zurück. Deshalb nimmt die Funktion eine
+  //     Liste und gibt bei `place-*` den ersten Teilwert (die Block-Achse).
+  const declaredValue = (body, props) => {
+    const alternatives = [].concat(props).map((p) => escapeForRegExp(p)).join('|');
+    const hits = [...body.matchAll(new RegExp(`(?:^|;)\\s*(${alternatives})\\s*:\\s*([^;]+)`, 'gm'))];
+    if (!hits.length) return null;
+    const [, prop, raw] = hits[hits.length - 1];
+    const value = raw.trim();
+    return prop.startsWith('place-') ? value.split(/\s+/)[0] : value;
+  };
+  const NARROW = 'var(--content-max-width-narrow)';
+  const ALIGN_SELF = ['align-self', 'place-self'];
 
   // Zielt der Selektor auf das Element selbst, nicht auf einen Nachfahren?
-  const targets = (selector, cls) =>
-    new RegExp(`\\.${escapeForRegExp(cls)}(?![\\w-])(?:[:.[][^\\s>+~]*)?\\s*$`).test(selector);
+  // Geprüft wird der LETZTE Compound, damit auch `.kitchen-list#items-list`,
+  // `.kitchen-list:hover` und `:is(.kitchen-list)` als Treffer gelten -
+  // `.kitchen-list .row` dagegen nicht. `:not(…)` fällt vorher weg, sonst
+  // meldete ausgerechnet der Ausschluss einen Treffer.
+  const targets = (selector, cls) => {
+    const compound = selector.trim().split(/[\s>+~]+/).pop()?.replace(/:not\([^)]*\)/g, '') ?? '';
+    return new RegExp(`\\.${escapeForRegExp(cls)}(?![\\w-])`).test(compound);
+  };
   const rulesFor = (cls) => allRules.filter(({ selectors }) => selectors.some((s) => targets(s, cls)));
 
   // 1. Der Scroller selbst darf nicht gekappt werden. Er ist das Element mit
@@ -1935,20 +1957,23 @@ test('die Küchen-Listen teilen eine Zeilen-Grammatik', () => {
   //
   //    Welche Klassen den Scroller mitbenennen, sagt das Markup, nicht diese
   //    Liste: wer auf demselben Element sitzt, kann seine Breite kappen.
+  //    JEDE geprüfte Seite muss ihre eigene Kombination liefern. Eine globale
+  //    Mindestzahl genügt nicht: fiele nur eine Seite aus der Erkennung, würden
+  //    die beiden anderen sie weiter erfüllen, und deren Modul-Klasse wäre
+  //    ungeprüft.
   const scrollerClasses = new Set(['kitchen-list']);
   for (const page of ['shopping', 'pantry', 'recipes']) {
-    for (const [, , combo] of read(`../public/pages/${page}.js`)
-      .matchAll(/class(?:Name)?\s*=\s*(['"])([^'"]*\bkitchen-list\b[^'"]*)\1/g)) {
-      combo.trim().split(/\s+/).forEach((cls) => scrollerClasses.add(cls));
-    }
+    const combos = [...read(`../public/pages/${page}.js`)
+      .matchAll(/class(?:Name)?\s*=\s*(['"`])([^'"`]*\bkitchen-list\b[^'"`]*)\1/g)];
+    assert.ok(combos.length > 0,
+      `${page}.js hängt seine Klasse nicht mehr literal an .kitchen-list - dieser Scan findet sie dann nicht und prüft den Scroller des Tabs ungewollt gar nicht`);
+    combos.forEach(([, , combo]) => combo.trim().split(/\s+/).forEach((cls) => scrollerClasses.add(cls)));
   }
-  assert.ok(scrollerClasses.size > 1,
-    'kein Modul hängt seine Klasse mehr an .kitchen-list - dann prüft dieser Scan die falschen Regeln');
   assert.ok(rulesFor('kitchen-list').length > 0,
     '.kitchen-list ist nirgends definiert: ein leerer Treffer darf hier nicht still grün bleiben');
   for (const cls of scrollerClasses) {
     for (const { file, selectors, body } of rulesFor(cls)) {
-      assert.ok(!declares(body, 'max-width'),
+      assert.equal(declaredValue(body, 'max-width'), null,
         `${file} ${selectors.join(', ')}: der Scroller darf nicht gekappt werden, sonst endet sein Mausrad-Trefferbereich an der Lesespalten-Kante`);
     }
   }
@@ -1960,11 +1985,12 @@ test('die Küchen-Listen teilen eine Zeilen-Grammatik', () => {
   //    Block darf sie auch nicht auf einen abweichenden Wert ziehen.
   for (const cls of ['kitchen-group', 'kitchen-rows']) {
     const rules = rulesFor(cls);
-    assert.ok(rules.some(({ body }) => declares(body, 'max-width', NARROW)),
+    assert.ok(rules.some(({ body }) => declaredValue(body, 'max-width') === NARROW),
       `.${cls} muss das Lesemaß selbst tragen: es kann alleiniges Kind von .kitchen-list sein, und .kitchen-list kappt nicht mehr`);
     for (const { file, body } of rules) {
-      if (!declares(body, 'max-width')) continue;
-      assert.ok(declares(body, 'max-width', NARROW),
+      const width = declaredValue(body, 'max-width');
+      if (width === null) continue;
+      assert.equal(width, NARROW,
         `${file}: .${cls} bekommt hier eine zweite, abweichende Breite - das Lesemaß ist EIN Wert`);
     }
   }
@@ -1990,16 +2016,18 @@ test('die Küchen-Listen teilen eine Zeilen-Grammatik', () => {
   //    aber nicht. Käme dort ein `overflow: hidden` dazu, meldet dieser Guard
   //    einen Fall, den ein Mensch entscheiden muss.
   for (const { selectors, body } of cssRules(shared)) {
-    if (!declares(body, 'max-width', NARROW)) continue;
-    if (!declares(body, 'overflow', 'hidden')) continue;
-    assert.ok(declares(body, 'align-self', 'start'),
+    if (declaredValue(body, 'max-width') !== NARROW) continue;
+    if (declaredValue(body, 'overflow') !== 'hidden') continue;
+    assert.equal(declaredValue(body, ALIGN_SELF), 'start',
       `${selectors.join(', ')} kappt aufs Lesemaß und clippt zugleich, ist also ein gekapptes Kind des Scroller-Grids: ohne align-self: start schneidet es den Überlauf ab, bevor .kitchen-list ihn sieht`);
   }
 
-  // Und kein später geladenes Modul-Stylesheet biegt den Wert wieder um.
+  // Und kein später geladenes Modul-Stylesheet biegt den Wert wieder um -
+  // auch nicht über die Kurzschreibweise place-self.
   for (const { file, body } of rulesFor('kitchen-rows')) {
-    if (!declares(body, 'align-self')) continue;
-    assert.ok(declares(body, 'align-self', 'start'),
+    const align = declaredValue(body, ALIGN_SELF);
+    if (align === null) continue;
+    assert.equal(align, 'start',
       `${file}: .kitchen-rows bekommt hier ein anderes align-self - genau der Rückfall, den die Regel darüber verhindert`);
   }
 });

--- a/test/test-frontend-audit.js
+++ b/test/test-frontend-audit.js
@@ -1904,6 +1904,46 @@ test('die Küchen-Listen teilen eine Zeilen-Grammatik', () => {
     '.items-list darf kein horizontales Polster setzen: #list-content trägt schon --page-inline-pad');
   assert.doesNotMatch(shared.match(/\.kitchen-list\s*\{([^}]*)\}/)?.[1] ?? '', /padding-inline:/,
     '.kitchen-list darf kein padding-inline setzen: wo der Spalten-Träger sitzt, ist pro Tab verschieden');
+
+  // Die Kappung aufs Lesemaß sitzt an den KINDERN des Scrollers, nicht am
+  // Scroller selbst (PR #614). Die Begründung dafür stand bisher nur als
+  // Kommentar im CSS.
+  const sharedLive = stripCssComments(shared);
+
+  // 1. .kitchen-list ist das Element mit `overflow-y: auto`. Kappt man es aufs
+  //    Lesemaß, endet damit auch sein eigener Trefferbereich fürs Mausrad an
+  //    der Lesespalten-Kante, und auf einem breiten Fenster greift das Rad
+  //    rechts davon ins Leere.
+  assert.doesNotMatch(cssRuleBody(sharedLive, '.kitchen-list'), /max-width:/,
+    '.kitchen-list darf kein max-width setzen: der Scroller muss die volle Breite behalten, sonst endet sein Mausrad-Trefferbereich an der Lesespalten-Kante');
+
+  // 2. Tragen muss sie stattdessen jedes Kind, das ALLEIN Kind des Scrollers
+  //    sein kann: .kitchen-group bei gruppierten Tabs (Einkauf, Vorrat),
+  //    .kitchen-rows ungruppiert (Rezepte). Fehlt sie an einem der beiden,
+  //    läuft der betroffene Tab bildschirmbreit.
+  for (const selector of ['.kitchen-group', '.kitchen-rows']) {
+    assert.match(cssRuleBody(sharedLive, selector), /max-width:\s*var\(--content-max-width-narrow\)/,
+      `${selector} muss das Lesemaß selbst tragen: es kann alleiniges Kind von .kitchen-list sein, und .kitchen-list kappt nicht mehr`);
+  }
+
+  // 3. Und wer aufs Lesemaß kappt UND clippt, muss auf seine Inhaltshöhe
+  //    wachsen dürfen.
+  //
+  //    Absichtlich eine Regel und keine Allowlist: das Lesemaß trägt nur, wer
+  //    Kind des Scroller-Grids ist, und `overflow: hidden` (hier für die
+  //    Eckenradien) macht ihn zum Clipper. Ohne `align-self: start` streckt das
+  //    voreingestellte `align-items: stretch` ihn auf die volle Spurhöhe, und
+  //    er schneidet alles darüber still ab, bevor .kitchen-list den Überlauf je
+  //    sieht. Gemessen an einer Rezeptliste mit 50 gespiegelten Einträgen:
+  //    scrollHeight 3249px gegen clientHeight 657px, kein Scrollbalken, kein
+  //    Weg an die übrigen Zeilen. Harmlos ist das nur, solange mehrere kurze
+  //    Gruppen dieselbe Spur teilen.
+  for (const { selectors, body } of cssRules(shared)) {
+    if (!/max-width:\s*var\(--content-max-width-narrow\)/.test(body)) continue;
+    if (!/overflow:\s*hidden/.test(body)) continue;
+    assert.match(body, /align-self:\s*start/,
+      `${selectors.join(', ')} kappt aufs Lesemaß und clippt zugleich, ist also ein gekapptes Kind des Scroller-Grids: ohne align-self: start schneidet es den Überlauf ab, bevor .kitchen-list ihn sieht`);
+  }
 });
 
 /**

--- a/test/test-frontend-audit.js
+++ b/test/test-frontend-audit.js
@@ -1913,9 +1913,13 @@ test('die Küchen-Listen teilen eine Zeilen-Grammatik', () => {
   // je Selektor. Zwei Wege führen sonst am Guard vorbei: ein zweiter Block
   // hinter einem Breakpoint, und das Modul-CSS, das später lädt und auf
   // demselben Element sitzt (`class="kitchen-list items-list"`).
+  //
+  // Und jede Regel weiß, OB sie bedingt gilt. cssRules() wirft das At-Rule-
+  // Präludium weg; eine geforderte Kappung, die nur unter `@media (max-width:
+  // 640px)` steht, ist auf jedem breiteren Fenster keine.
   const styleDir = new URL('../public/styles/', import.meta.url);
   const allRules = readdirSync(styleDir).filter((f) => f.endsWith('.css'))
-    .flatMap((file) => cssRules(read(`../public/styles/${file}`)).map((rule) => ({ file, ...rule })));
+    .flatMap((file) => scopedRules(read(`../public/styles/${file}`)).map((rule) => ({ file, ...rule })));
 
   // Der WIRKSAME Wert einer Eigenschaft, oder null. Drei Fallen stecken darin:
   //
@@ -1931,14 +1935,18 @@ test('die Küchen-Listen teilen eine Zeilen-Grammatik', () => {
   //   - `!important` schlägt die Quellreihenfolge. `max-width: none !important;
   //     max-width: var(…)` sieht sonst erfüllt aus, obwohl das `none` gewinnt.
   const declaredValue = (body, props) => {
-    const alternatives = [].concat(props).map((p) => escapeForRegExp(p)).join('|');
-    const hits = [...body.matchAll(new RegExp(`(?:^|;)\\s*(${alternatives})\\s*:\\s*([^;]+)`, 'gm'))]
+    const list = [].concat(props);
+    const alternatives = list.map((p) => escapeForRegExp(p)).join('|');
+    // Standard-Eigenschaften sind ASCII-case-insensitiv (`MAX-WIDTH` wirkt),
+    // Custom Properties dagegen nicht: `--Foo` und `--foo` sind zwei Namen.
+    const flags = list.some((p) => p.startsWith('--')) ? 'gm' : 'gmi';
+    const hits = [...body.matchAll(new RegExp(`(?:^|;)\\s*(${alternatives})\\s*:\\s*([^;]+)`, flags))]
       .map(([, prop, raw]) => ({ prop, raw: raw.trim() }));
     if (!hits.length) return null;
     const important = hits.filter(({ raw }) => /!\s*important$/i.test(raw));
     const { prop, raw } = (important.length ? important : hits).at(-1);
     const value = raw.replace(/!\s*important$/i, '').trim();
-    return prop.startsWith('place-') ? value.split(/\s+/)[0] : value;
+    return prop.toLowerCase().startsWith('place-') ? value.split(/\s+/)[0] : value;
   };
   const NARROW = 'var(--content-max-width-narrow)';
   const ALIGN_SELF = ['align-self', 'place-self'];
@@ -1999,6 +2007,26 @@ test('die Küchen-Listen teilen eine Zeilen-Grammatik', () => {
       /(\w+)\.className\s*=\s*['"`][^'"`]*\bkitchen-list\b[^'"`]*['"`];\s*\1\.id\s*=\s*['"`]([^'"`]+)/g)]
       .map(([, , id]) => id);
     [...inTag, ...nextToClassName].filter(Boolean).forEach((id) => scrollerTokens.add(`#${id}`));
+
+    // Inline-Styles stehen in keiner der gescannten Dateien und schlagen
+    // trotzdem jede Regel darin. Der Scroller wird im JS gebaut, also muss
+    // der Scan dort nachsehen - an derselben Variablen, die die Klasse bekommt,
+    // und im Tag, das sie im Markup trägt.
+    for (const [, variable] of src.matchAll(/(\w+)\.className\s*=\s*['"`][^'"`]*\bkitchen-list\b/g)) {
+      const name = escapeForRegExp(variable);
+      assert.doesNotMatch(src, new RegExp(`\\b${name}\\.style\\.(?:max)?(?:Width|InlineSize)\\s*=`, 'i'),
+        `${page}.js setzt eine Inline-Breite am Scroller - die schlägt jede Regel im Stylesheet und damit auch diesen Guard`);
+      assert.doesNotMatch(src, new RegExp(`\\b${name}\\.style\\.(?:alignSelf|placeSelf)\\s*=`),
+        `${page}.js setzt align-self inline am Scroller - das nimmt ihm die volle Breite`);
+      assert.doesNotMatch(src, new RegExp(`\\b${name}\\.style\\.setProperty\\(\\s*['"\`](?:max-)?(?:width|inline-size|align-self|place-self)`, 'i'),
+        `${page}.js setzt eine Breite oder Ausrichtung inline am Scroller (setProperty)`);
+      assert.doesNotMatch(src, new RegExp(`\\b${name}\\.style\\.cssText\\s*=`),
+        `${page}.js überschreibt den Stil des Scrollers per cssText - was darin steht, sieht dieser Guard nicht`);
+    }
+    (src.match(/<[^>]*\bkitchen-list\b[^>]*>/g) ?? []).forEach((tag) => {
+      assert.doesNotMatch(tag, /\sstyle\s*=/,
+        `${page}.js gibt dem Scroller ein style-Attribut - Inline-Stile schlagen jede Regel im Stylesheet`);
+    });
   }
   assert.ok(rulesFor('.kitchen-list').length > 0,
     '.kitchen-list ist nirgends definiert: ein leerer Treffer darf hier nicht still grün bleiben');
@@ -2006,6 +2034,15 @@ test('die Küchen-Listen teilen eine Zeilen-Grammatik', () => {
     for (const { file, selectors, body } of rulesFor(cls)) {
       assert.equal(declaredValue(body, WIDTH_CAP), null,
         `${file} ${selectors.join(', ')}: der Scroller darf nicht gekappt werden, sonst endet sein Mausrad-Trefferbereich an der Lesespalten-Kante`);
+
+      // Dieselbe Kante ohne jede Breitenangabe: der Scroller ist Flex-Item
+      // seines Modul-Roots (.recipes-page & Co. sind flex column). Ein
+      // `align-self: start` nimmt ihm das voreingestellte Strecken und lässt
+      // ihn auf Inhaltsbreite schrumpfen - der Trefferbereich fürs Mausrad
+      // endet dann genau dort. Erlaubt bleibt nur, was ihn füllen lässt.
+      const spread = declaredValue(body, ALIGN_SELF);
+      assert.ok(spread === null || ['stretch', 'normal', 'auto', 'initial', 'unset'].includes(spread),
+        `${file} ${selectors.join(', ')}: align-self: ${spread} nimmt dem Scroller die volle Breite - dann greift das Mausrad rechts daneben ins Leere`);
     }
   }
 
@@ -2023,6 +2060,15 @@ test('die Küchen-Listen teilen eine Zeilen-Grammatik', () => {
       `${file} ${selectors.join(', ')}: --content-max-width-narrow wird hier lokal umdefiniert - das Lesemaß kommt aus tokens.css und nirgendwo sonst`);
   }
 
+  //    Und es muss sie geben: fehlt die :root-Deklaration, wird jedes
+  //    `var(--content-max-width-narrow)` ungültig und das max-width fällt auf
+  //    `none` zurück - die Listen liefen bildschirmbreit, während dieser Test
+  //    weiter zwei Texte vergleicht, die zueinander passen.
+  assert.ok(allRules.some(({ file, selectors, body, conditional }) =>
+    file === 'tokens.css' && !conditional && selectors.some((sel) => /^:root\b/.test(sel))
+    && declaredValue(body, '--content-max-width-narrow') !== null),
+  'tokens.css muss --content-max-width-narrow unbedingt in :root definieren - ohne die Deklaration löst var(…) auf nichts auf und die Kappung entfällt');
+
   // 2. Tragen muss die Kappung stattdessen jedes Kind, das ALLEIN Kind des
   //    Scrollers sein kann: .kitchen-group bei gruppierten Tabs (Einkauf,
   //    Vorrat), .kitchen-rows ungruppiert (Rezepte). Fehlt sie an einem der
@@ -2030,16 +2076,16 @@ test('die Küchen-Listen teilen eine Zeilen-Grammatik', () => {
   //    Block darf sie auch nicht auf einen abweichenden Wert ziehen.
   for (const cls of ['.kitchen-group', '.kitchen-rows']) {
     const rules = rulesFor(cls);
-    assert.ok(rules.some(({ body }) => declaredValue(body, MAX_WIDTH) === NARROW),
-      `${cls} muss das Lesemaß selbst tragen: es kann alleiniges Kind von .kitchen-list sein, und .kitchen-list kappt nicht mehr`);
+    assert.ok(rules.some(({ body, conditional }) => !conditional && declaredValue(body, MAX_WIDTH) === NARROW),
+      `${cls} muss das Lesemaß UNBEDINGT tragen: es kann alleiniges Kind von .kitchen-list sein, und eine Kappung, die nur hinter einem Breakpoint steht, fehlt auf jedem anderen Fenster`);
     for (const { file, body } of rules) {
       // Eine feste Breite schlägt die Kappung, ohne sie anzufassen: mit
       // `width: 20rem` bleibt das max-width korrekt stehen und die Liste steht
       // trotzdem schmal. Prozentwerte und `auto` sind unschädlich - sie messen
       // den (ungekappten) Scroller, und das max-width begrenzt weiter.
       const definite = declaredValue(body, ['width', 'inline-size']);
-      assert.ok(definite === null || definite === 'auto' || definite.endsWith('%'),
-        `${file}: ${cls} bekommt hier eine feste Breite (${definite}) - gekappt wird über max-width, sonst steht die Liste unabhängig vom Lesemaß`);
+      assert.ok(definite === null || definite === 'auto' || definite === '100%',
+        `${file}: ${cls} bekommt hier eine feste Breite (${definite}) - gekappt wird über max-width, sonst steht die Liste unabhängig vom Lesemaß schmal`);
 
       const width = declaredValue(body, MAX_WIDTH);
       if (width === null) continue;
@@ -4672,6 +4718,41 @@ test('housekeeping exposes its page title as the primary heading', () => {
 // sonst auch in /* ... */ und die halbe Vertragsprüfung wäre durch eine
 // Erwähnung im Fließtext erfüllbar.
 const stripCssComments = (css) => css.replace(/\/\*[\s\S]*?\*\//g, '');
+
+// Wie cssRules(), aber jede Regel weiß zusätzlich, ob sie in einer At-Rule
+// steht (`conditional`). Für eine GEFORDERTE Deklaration ist das der
+// Unterschied zwischen „gilt immer" und „gilt unterhalb von 640px": cssRules()
+// wirft das Präludium weg und kann beides nicht auseinanderhalten.
+function scopedRules(css) {
+  const live = stripCssComments(css);
+  const rules = [];
+  let depth = 0;   // Tiefe der offenen At-Rule-Blöcke
+  let from = 0;    // Beginn des laufenden Präludiums
+  for (let i = 0; i < live.length; i += 1) {
+    const char = live[i];
+    if (char === '{') {
+      const prelude = live.slice(from, i).trim();
+      if (prelude.startsWith('@')) {
+        depth += 1;
+        from = i + 1;
+        continue;
+      }
+      const end = live.indexOf('}', i);
+      if (end === -1) break;
+      rules.push({
+        selectors: prelude.replace(/\s+/g, ' ').split(',').map((s) => s.trim()).filter(Boolean),
+        body: live.slice(i + 1, end),
+        conditional: depth > 0,
+      });
+      i = end;
+      from = i + 1;
+    } else if (char === '}') {
+      depth = Math.max(0, depth - 1);
+      from = i + 1;
+    }
+  }
+  return rules;
+}
 
 // Flacher Regelblock-Scanner. At-Rule-Präludien (@media, @supports, @container)
 // fallen automatisch weg, weil [^{}]* kein '{' fressen kann und der Selektor

--- a/test/test-frontend-audit.js
+++ b/test/test-frontend-audit.js
@@ -1934,7 +1934,7 @@ test('die Küchen-Listen teilen eine Zeilen-Grammatik', () => {
   //     Liste und gibt bei `place-*` den ersten Teilwert (die Block-Achse).
   //   - `!important` schlägt die Quellreihenfolge. `max-width: none !important;
   //     max-width: var(…)` sieht sonst erfüllt aus, obwohl das `none` gewinnt.
-  const declaredValue = (body, props) => {
+  const declaredValue = (body, props, axis = 'block') => {
     const list = [].concat(props);
     const alternatives = list.map((p) => escapeForRegExp(p)).join('|');
     // Standard-Eigenschaften sind ASCII-case-insensitiv (`MAX-WIDTH` wirkt),
@@ -1946,7 +1946,11 @@ test('die Küchen-Listen teilen eine Zeilen-Grammatik', () => {
     const important = hits.filter(({ raw }) => /!\s*important$/i.test(raw));
     const { prop, raw } = (important.length ? important : hits).at(-1);
     const value = raw.replace(/!\s*important$/i, '').trim();
-    return prop.toLowerCase().startsWith('place-') ? value.split(/\s+/)[0] : value;
+    if (!prop.toLowerCase().startsWith('place-')) return value;
+    // `place-self: <align> <justify>` - fehlt der zweite Wert, gilt der erste
+    // fuer beide Achsen.
+    const parts = value.split(/\s+/);
+    return axis === 'inline' ? (parts[1] ?? parts[0]) : parts[0];
   };
   const NARROW = 'var(--content-max-width-narrow)';
   const ALIGN_SELF = ['align-self', 'place-self'];
@@ -2022,6 +2026,8 @@ test('die Küchen-Listen teilen eine Zeilen-Grammatik', () => {
         `${page}.js setzt eine Breite oder Ausrichtung inline am Scroller (setProperty)`);
       assert.doesNotMatch(src, new RegExp(`\\b${name}\\.style\\.cssText\\s*=`),
         `${page}.js überschreibt den Stil des Scrollers per cssText - was darin steht, sieht dieser Guard nicht`);
+      assert.doesNotMatch(src, new RegExp(`\\b${name}\\.setAttribute\\(\\s*['"\`]style`, 'i'),
+        `${page}.js setzt den Stil des Scrollers per setAttribute - derselbe Inline-Stil über einen anderen Weg`);
     }
     (src.match(/<[^>]*\bkitchen-list\b[^>]*>/g) ?? []).forEach((tag) => {
       assert.doesNotMatch(tag, /\sstyle\s*=/,
@@ -2043,6 +2049,11 @@ test('die Küchen-Listen teilen eine Zeilen-Grammatik', () => {
       const spread = declaredValue(body, ALIGN_SELF);
       assert.ok(spread === null || ['stretch', 'normal', 'auto', 'initial', 'unset'].includes(spread),
         `${file} ${selectors.join(', ')}: align-self: ${spread} nimmt dem Scroller die volle Breite - dann greift das Mausrad rechts daneben ins Leere`);
+
+      // `all` setzt jede der oben geprüften Eigenschaften mit zurück, ohne
+      // eine davon zu nennen.
+      assert.equal(declaredValue(body, 'all'), null,
+        `${file} ${selectors.join(', ')}: die all-Kurzschreibweise setzt Breite und Ausrichtung des Scrollers zurück`);
     }
   }
 
@@ -2076,8 +2087,13 @@ test('die Küchen-Listen teilen eine Zeilen-Grammatik', () => {
   //    Block darf sie auch nicht auf einen abweichenden Wert ziehen.
   for (const cls of ['.kitchen-group', '.kitchen-rows']) {
     const rules = rulesFor(cls);
-    assert.ok(rules.some(({ body, conditional }) => !conditional && declaredValue(body, MAX_WIDTH) === NARROW),
-      `${cls} muss das Lesemaß UNBEDINGT tragen: es kann alleiniges Kind von .kitchen-list sein, und eine Kappung, die nur hinter einem Breakpoint steht, fehlt auf jedem anderen Fenster`);
+    // Unbedingt heißt zweierlei: nicht hinter einem Breakpoint UND nicht an
+    // einen Zustand gebunden. `.kitchen-rows:hover` kappt nur unter dem
+    // Mauszeiger; auf Touch und per Tastatur liefe die Liste voll breit.
+    const unstated = (sel) => !/:(?!(?:is|where)\()/.test(sel);
+    assert.ok(rules.some(({ body, conditional, selectors }) =>
+      !conditional && selectors.some(unstated) && declaredValue(body, MAX_WIDTH) === NARROW),
+    `${cls} muss das Lesemaß UNBEDINGT tragen: eine Kappung hinter einem Breakpoint oder an einem Zustand (:hover) fehlt im Normalfall`);
     for (const { file, body } of rules) {
       // Eine feste Breite schlägt die Kappung, ohne sie anzufassen: mit
       // `width: 20rem` bleibt das max-width korrekt stehen und die Liste steht
@@ -2086,6 +2102,16 @@ test('die Küchen-Listen teilen eine Zeilen-Grammatik', () => {
       const definite = declaredValue(body, ['width', 'inline-size']);
       assert.ok(definite === null || definite === 'auto' || definite === '100%',
         `${file}: ${cls} bekommt hier eine feste Breite (${definite}) - gekappt wird über max-width, sonst steht die Liste unabhängig vom Lesemaß schmal`);
+
+      // Dasselbe ohne Breitenangabe: als Grid-Item von .kitchen-list füllt das
+      // Kind seine Spur per Voreinstellung. `justify-self: start` nimmt ihm
+      // das, und die auto-Breite fällt auf den Inhalt zusammen - das Lesemaß
+      // bleibt dabei unangetastet und unwirksam.
+      const inline = declaredValue(body, ['justify-self', 'place-self'], 'inline');
+      assert.ok(inline === null || ['stretch', 'normal', 'auto', 'initial', 'unset'].includes(inline),
+        `${file}: ${cls} bekommt justify-self: ${inline} - dann schrumpft die Gruppe auf ihren Inhalt, statt das Lesemaß auszufüllen`);
+      assert.equal(declaredValue(body, 'all'), null,
+        `${file}: ${cls} wird per all-Kurzschreibweise zurückgesetzt - das nimmt Kappung und Ausrichtung mit`);
 
       const width = declaredValue(body, MAX_WIDTH);
       if (width === null) continue;
@@ -4748,6 +4774,13 @@ function scopedRules(css) {
       from = i + 1;
     } else if (char === '}') {
       depth = Math.max(0, depth - 1);
+      from = i + 1;
+    } else if (char === ';') {
+      // Statement-At-Rules (@import, @charset, @layer x;) enden mit Semikolon
+      // und oeffnen keinen Block. Ohne diesen Zweig waechst das Praeludium
+      // ueber sie hinaus, beginnt mit '@' - und die erste echte Regel der
+      // Datei wird still als At-Rule-Rumpf verschluckt. Deklarations-Semikola
+      // landen hier nie: ueber Regelbloecke springt die Schleife hinweg.
       from = i + 1;
     }
   }

--- a/test/test-frontend-audit.js
+++ b/test/test-frontend-audit.js
@@ -1935,9 +1935,9 @@ test('die Küchen-Listen teilen eine Zeilen-Grammatik', () => {
     const hits = [...body.matchAll(new RegExp(`(?:^|;)\\s*(${alternatives})\\s*:\\s*([^;]+)`, 'gm'))]
       .map(([, prop, raw]) => ({ prop, raw: raw.trim() }));
     if (!hits.length) return null;
-    const important = hits.filter(({ raw }) => /!\s*important$/.test(raw));
+    const important = hits.filter(({ raw }) => /!\s*important$/i.test(raw));
     const { prop, raw } = (important.length ? important : hits).at(-1);
-    const value = raw.replace(/!\s*important$/, '').trim();
+    const value = raw.replace(/!\s*important$/i, '').trim();
     return prop.startsWith('place-') ? value.split(/\s+/)[0] : value;
   };
   const NARROW = 'var(--content-max-width-narrow)';
@@ -1962,6 +1962,10 @@ test('die Küchen-Listen teilen eine Zeilen-Grammatik', () => {
   const targets = (selector, token) => {
     const subject = selector.replace(/:(?:not|has)\([^)]*\)/g, '');
     const compound = subject.trim().split(/[\s>+~]+/).pop() ?? '';
+    // Ein Pseudo-Element ist ein eigener Kasten, nicht das Element selbst:
+    // `.recipes-list::before { width: 1rem }` kappt den Scroller nicht, und
+    // dort rot zu werden hieße, eine harmlose Dekoration zu verbieten.
+    if (/::|:(?:before|after|first-line|first-letter|marker|backdrop|selection|placeholder)\b/.test(compound)) return false;
     return new RegExp(`${escapeForRegExp(token)}(?![\\w-])`).test(compound);
   };
   const rulesFor = (token) => allRules.filter(({ selectors }) => selectors.some((s) => targets(s, token)));
@@ -2011,7 +2015,10 @@ test('die Küchen-Listen teilen eine Zeilen-Grammatik', () => {
   //    Guard unten vergliche dann zwei Texte, die dasselbe sagen und
   //    Verschiedenes bedeuten.
   for (const { file, selectors, body } of allRules) {
-    if (file === 'tokens.css') continue;
+    // Ausgenommen ist die KANONISCHE Deklaration, nicht die Datei: eine auf
+    // einen Selektor gescopte Neudefinition in tokens.css selbst umginge
+    // dieselbe Invariante, die dieser Block schützt.
+    if (file === 'tokens.css' && selectors.every((s) => /^:root\b/.test(s.trim()))) continue;
     assert.equal(declaredValue(body, '--content-max-width-narrow'), null,
       `${file} ${selectors.join(', ')}: --content-max-width-narrow wird hier lokal umdefiniert - das Lesemaß kommt aus tokens.css und nirgendwo sonst`);
   }
@@ -2026,6 +2033,14 @@ test('die Küchen-Listen teilen eine Zeilen-Grammatik', () => {
     assert.ok(rules.some(({ body }) => declaredValue(body, MAX_WIDTH) === NARROW),
       `${cls} muss das Lesemaß selbst tragen: es kann alleiniges Kind von .kitchen-list sein, und .kitchen-list kappt nicht mehr`);
     for (const { file, body } of rules) {
+      // Eine feste Breite schlägt die Kappung, ohne sie anzufassen: mit
+      // `width: 20rem` bleibt das max-width korrekt stehen und die Liste steht
+      // trotzdem schmal. Prozentwerte und `auto` sind unschädlich - sie messen
+      // den (ungekappten) Scroller, und das max-width begrenzt weiter.
+      const definite = declaredValue(body, ['width', 'inline-size']);
+      assert.ok(definite === null || definite === 'auto' || definite.endsWith('%'),
+        `${file}: ${cls} bekommt hier eine feste Breite (${definite}) - gekappt wird über max-width, sonst steht die Liste unabhängig vom Lesemaß`);
+
       const width = declaredValue(body, MAX_WIDTH);
       if (width === null) continue;
       assert.equal(width, NARROW,
@@ -2055,7 +2070,11 @@ test('die Küchen-Listen teilen eine Zeilen-Grammatik', () => {
   //    einen Fall, den ein Mensch entscheiden muss.
   for (const { selectors, body } of cssRules(shared)) {
     if (declaredValue(body, MAX_WIDTH) !== NARROW) continue;
-    if (declaredValue(body, 'overflow') !== 'hidden') continue;
+    // `clip` kappt wie `hidden`, nur ohne Scrollport - und die Block-Achse
+    // lässt sich auch als Langform setzen. Der Grund für die Zusicherung ist
+    // das Abschneiden, nicht die eine Schreibweise dafür.
+    const overflow = declaredValue(body, ['overflow', 'overflow-y', 'overflow-block']);
+    if (overflow === null || !/\b(?:hidden|clip)\b/.test(overflow)) continue;
     assert.equal(declaredValue(body, ALIGN_SELF), 'start',
       `${selectors.join(', ')} kappt aufs Lesemaß und clippt zugleich, ist also ein gekapptes Kind des Scroller-Grids: ohne align-self: start schneidet es den Überlauf ab, bevor .kitchen-list ihn sieht`);
   }


### PR DESCRIPTION
PR #614 brachte zwei CSS-Fixes in `public/styles/kitchen-row.css` mit, für die kein Guard existiert. Ihre Begründung steht bis jetzt ausschließlich als Kommentar im CSS. Der FAB-Bereich daneben ist dreifach abgesichert, diese Zeilen gar nicht.

Kein CSS geändert: die Zeilen sind korrekt, sie waren nur ungeschützt.

## Die drei Invarianten

1. **`.kitchen-list` darf kein `max-width` tragen.** Es ist das Element mit `overflow-y: auto`. Kappt man es aufs Lesemaß, endet damit auch sein eigener Trefferbereich fürs Mausrad an der Lesespalten-Kante, und auf einem breiten Fenster greift das Rad rechts davon ins Leere.
2. **`.kitchen-group` und `.kitchen-rows` tragen die Kappung stattdessen.** Jedes von beiden kann alleiniges Kind des Scrollers sein: `.kitchen-group` bei gruppierten Tabs (Einkauf, Vorrat), `.kitchen-rows` ungruppiert (Rezepte). Fehlt sie an einem der beiden, läuft der betroffene Tab bildschirmbreit.
3. **`.kitchen-rows` braucht `align-self: start`.** Als Grid-Item von `.kitchen-list` streckt es das voreingestellte `align-items: stretch` sonst auf die volle Spurhöhe, und es schneidet über sein `overflow: hidden` (für die Eckenradien) alles darüber still ab, bevor der eigentliche Scroller den Überlauf je sieht. Gemessen an einer Rezeptliste mit 50 gespiegelten Einträgen: scrollHeight 3249px gegen clientHeight 657px, kein Scrollbalken.

## Regel statt Allowlist

Zusicherung 3 nennt `.kitchen-rows` nicht. Sie läuft über alle Regeln der Datei und verlangt `align-self: start` von jedem Selektor, der `max-width: var(--content-max-width-narrow)` UND `overflow: hidden` trägt: wer aufs Lesemaß kappt und zugleich clippt, ist per Definition ein gekapptes Kind des Scroller-Grids. Damit fällt auch eine künftige Gruppe darunter, die unter anderem Namen dieselbe Kombination baut.

Das Lesemaß ist als Kriterium nötig statt irgendeines `max-width`: `.item-tag` in derselben Datei kombiniert `max-width: 12rem` mit `overflow: hidden` und ist ein Zeilen-Etikett, kein Kind des Scrollers.

## Verifikation

Jede Zusicherung einzeln fallen gelassen und den roten Lauf bestätigt:

| Rückbau | Ergebnis |
|---|---|
| `max-width` zurück an `.kitchen-list` | rot |
| `max-width` aus `.kitchen-group` entfernt | rot |
| `max-width` aus `.kitchen-rows` entfernt | rot |
| `align-self: start` entfernt | rot, Selektor kommt aus dem Scan |

Invariante 1 ist eine Abwesenheit und lässt sich nur durch Wiedereinsetzen der Kappung auslösen; genau so geprüft. Zusätzlich hat ein frei erfundener Selektor mit derselben Kombination den Test rot gemacht, obwohl sein Name im Guard nirgends steht - das ist der Unterschied zur Allowlist.

`npm test` vollständig: 2660 grün, 0 rot.