### PR TITLE
feat(budget): add NZD currency support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add New Zealand Dollar (NZD) as a selectable currency across household settings, subscriptions and split expenses, with an English (New Zealand) region preset.
+
 ## [1.75.3] - 2026-08-03
 
 ### Fixed

--- a/public/pages/subscriptions.js
+++ b/public/pages/subscriptions.js
@@ -35,7 +35,7 @@ let container = null;
 // sonst ist die Haushaltswährung hier nicht wählbar (per Test abgesichert).
 const CURRENCIES = [
   'AED', 'AUD', 'BRL', 'CAD', 'CHF', 'CLP', 'CNY', 'CZK', 'DKK', 'EUR', 'GBP',
-  'HUF', 'IDR', 'INR', 'IRR', 'JPY', 'KRW', 'KZT', 'MYR', 'NOK', 'PLN', 'RUB',
+  'HUF', 'IDR', 'INR', 'IRR', 'JPY', 'KRW', 'KZT', 'MYR', 'NOK', 'NZD', 'PLN', 'RUB',
   'SAR', 'SEK', 'TRY', 'UAH', 'USD', 'ZAR',
 ];
 const DEFAULT_CATEGORY_LABELS = {

--- a/public/settings/currency.js
+++ b/public/settings/currency.js
@@ -4,7 +4,7 @@ import { getLocale } from '/i18n.js';
 // server/routes/preferences.js übereinstimmen (per Test abgesichert).
 export const SUPPORTED_CURRENCIES = [
   'AED', 'AUD', 'BRL', 'CAD', 'CHF', 'CLP', 'CNY', 'CZK', 'DKK', 'EUR', 'GBP',
-  'HUF', 'IDR', 'INR', 'IRR', 'JPY', 'KRW', 'KZT', 'MYR', 'NOK', 'PLN', 'RUB', 'SAR',
+  'HUF', 'IDR', 'INR', 'IRR', 'JPY', 'KRW', 'KZT', 'MYR', 'NOK', 'NZD', 'PLN', 'RUB', 'SAR',
   'SEK', 'TRY', 'UAH', 'USD', 'ZAR',
 ];
 

--- a/public/settings/region-presets.js
+++ b/public/settings/region-presets.js
@@ -19,6 +19,7 @@ export const REGION_PRESETS = {
   'en-GB': { currency: 'GBP', date_format: 'dmy_slash', time_format: '24h' },
   'en-CA': { currency: 'CAD', date_format: 'ymd', time_format: '12h' },
   'en-AU': { currency: 'AUD', date_format: 'dmy_slash', time_format: '12h' },
+  'en-NZ': { currency: 'NZD', date_format: 'dmy_slash', time_format: '12h' },
   'es-ES': { currency: 'EUR', date_format: 'dmy_slash', time_format: '24h' },
   'es-CL': { currency: 'CLP', date_format: 'dmy_slash', time_format: '24h' },
   'fr-FR': { currency: 'EUR', date_format: 'dmy_slash', time_format: '24h' },

--- a/server/routes/preferences.js
+++ b/server/routes/preferences.js
@@ -19,7 +19,7 @@ const router = express.Router();
 const VALID_MEAL_TYPES = ['breakfast', 'lunch', 'dinner', 'snack'];
 const DEFAULT_MEAL_TYPES = VALID_MEAL_TYPES.join(',');
 
-const VALID_CURRENCIES = ['AED', 'AUD', 'BRL', 'CAD', 'CHF', 'CLP', 'CNY', 'CZK', 'DKK', 'EUR', 'GBP', 'HUF', 'IDR', 'INR', 'IRR', 'JPY', 'KRW', 'KZT', 'MYR', 'NOK', 'PLN', 'RUB', 'SAR', 'SEK', 'TRY', 'UAH', 'USD', 'ZAR'];
+const VALID_CURRENCIES = ['AED', 'AUD', 'BRL', 'CAD', 'CHF', 'CLP', 'CNY', 'CZK', 'DKK', 'EUR', 'GBP', 'HUF', 'IDR', 'INR', 'IRR', 'JPY', 'KRW', 'KZT', 'MYR', 'NOK', 'NZD', 'PLN', 'RUB', 'SAR', 'SEK', 'TRY', 'UAH', 'USD', 'ZAR'];
 const DEFAULT_CURRENCY = 'EUR';
 const DEFAULT_APP_NAME = 'Yuvomi';
 

--- a/server/routes/split-expenses.js
+++ b/server/routes/split-expenses.js
@@ -25,7 +25,7 @@ const SPLIT_METHODS = ['equal', 'exact', 'percentage', 'shares'];
 const CATEGORIES = ['groceries', 'rent', 'utilities', 'baby', 'pets', 'school', 'travel', 'shopping', 'subscriptions', 'health', 'home', 'general'];
 // Muss mit VALID_CURRENCIES in server/routes/preferences.js übereinstimmen,
 // sonst lehnt diese Route die Haushaltswährung ab (per Test abgesichert).
-const CURRENCIES = ['AED', 'AUD', 'BRL', 'CAD', 'CHF', 'CLP', 'CNY', 'CZK', 'DKK', 'EUR', 'GBP', 'HUF', 'IDR', 'INR', 'IRR', 'JPY', 'KRW', 'KZT', 'MYR', 'NOK', 'PLN', 'RUB', 'SAR', 'SEK', 'TRY', 'UAH', 'USD', 'ZAR'];
+const CURRENCIES = ['AED', 'AUD', 'BRL', 'CAD', 'CHF', 'CLP', 'CNY', 'CZK', 'DKK', 'EUR', 'GBP', 'HUF', 'IDR', 'INR', 'IRR', 'JPY', 'KRW', 'KZT', 'MYR', 'NOK', 'NZD', 'PLN', 'RUB', 'SAR', 'SEK', 'TRY', 'UAH', 'USD', 'ZAR'];
 const FREQUENCIES = ['weekly', 'monthly', 'yearly'];
 const FAMILY_ROLES = ['dad', 'mom', 'parent', 'child', 'grandparent', 'relative', 'other'];
 

--- a/test/test-preferences-routes.js
+++ b/test/test-preferences-routes.js
@@ -111,8 +111,8 @@ test('PUT visible_meal_types: gültige Teilmenge persistiert + filtert Unbekannt
 // --------------------------------------------------------
 test('PUT currency: ungültig -> 400, gültig -> persist', async () => {
   assert.equal((await put({ currency: 'XXX' })).status, 400);
-  assert.equal((await put({ currency: 'USD' })).body.data.currency, 'USD');
-  assert.equal((await get()).body.data.currency, 'USD');
+  assert.equal((await put({ currency: 'NZD' })).body.data.currency, 'NZD');
+  assert.equal((await get()).body.data.currency, 'NZD');
 });
 test('PUT date_format: ungültig -> 400, gültig -> persist', async () => {
   assert.equal((await put({ date_format: 'zzz' })).status, 400);

--- a/test/test-region-presets.js
+++ b/test/test-region-presets.js
@@ -117,6 +117,16 @@ test('Malaysia preset formats MYR amounts with the local currency symbol', () =>
   assert.ok(formatted.includes('1,234.56'));
 });
 
+test('New Zealand preset uses NZD and local number formatting', () => {
+  const locale = numberLocaleFor({ region: 'en-NZ', ...REGION_PRESETS['en-NZ'] });
+  const formatted = new Intl.NumberFormat(locale, { style: 'currency', currency: 'NZD' })
+    .format(1234.56);
+
+  assert.equal(locale, 'en-NZ');
+  assert.ok(formatted.includes('$'));
+  assert.ok(formatted.includes('1,234.56'));
+});
+
 test('numberLocaleFor derives the tag even without a stored region, and empties for custom', () => {
   // Region nicht gesetzt, aber Formate entsprechen einem Preset → abgeleiteter Tag.
   assert.equal(numberLocaleFor({ ...REGION_PRESETS['de-CH'] }), 'de-CH');


### PR DESCRIPTION
## Summary

- add NZD to the household, subscription, and split-expense currency contracts
- add an English (New Zealand) region preset using NZD, day/month/year dates, and 12-hour time
- cover NZD preference persistence, currency-list parity, and New Zealand number formatting
- document the user-facing change under `[Unreleased]`

## Why

New Zealand households could not configure NZD because the currency code was absent from the backend whitelist and the duplicated frontend/module currency lists. There was also no `en-NZ` preset, so selecting New Zealand locale behavior was not possible through the region settings.

## Validation

Passing:

- `npm run test:settings-navigation` (80 tests)
- `npm run test:preferences-routes` (49 tests)
- `npm run test:region-presets` (13 tests)
- `npm run test:changelog` (5 tests)

The full `npm test` suite was also attempted under Node 22 on Linux. It stops at the unrelated Shopping test `Detail-Refresh aktualisiert die Zeile...` after 39 passes. The same Shopping test fails on unchanged upstream `main`, confirming it is a pre-existing baseline failure rather than a regression from this change.