### PR TITLE
fix(caldav): geloeschtes Konto entkoppelt seine gespiegelten Zeilen (#617)

### DIFF
--- a/server/db.js
+++ b/server/db.js
@@ -4616,6 +4616,54 @@ const MIGRATIONS = [
         ON tasks(recurrence_origin_id) WHERE recurrence_origin_id IS NOT NULL;
     `,
   },
+  {
+    version: 123,
+    description: 'CalDAV: detach mirrored tasks and shopping items from deleted accounts (#617)',
+    up: `
+      -- tasks.external_account_id und shopping_items.external_account_id sind
+      -- bloße INTEGER-Spalten (v45): löscht jemand ein CalDAV-Konto, nimmt
+      -- CASCADE nur mit, was dem Konto selbst gehört - Kalender- und
+      -- Listenauswahl und die offenen VTODO-Löschungen. Die gespiegelten
+      -- Zeilen bleiben stehen, mit einer Kennung, die auf nichts mehr zeigt.
+      --
+      -- Das war nicht nur unsauber, sondern eine Sackgasse: beim Löschen so
+      -- einer Zeile merkt queueTodoDeletion() sie in
+      -- caldav_todo_pending_deletions vor - und DIE Tabelle hat den
+      -- Fremdschlüssel sehr wohl. Der INSERT scheiterte, der Eintrag ließ sich
+      -- lokal gar nicht mehr löschen, während die entfernte Kopie ohne Konto
+      -- ohnehin unerreichbar ist.
+      --
+      -- Der Fremdschlüssel lässt sich in SQLite nicht nachträglich an eine
+      -- bestehende Spalte hängen; das hieße beide Tabellen samt Indizes,
+      -- Suchtriggern und den auf sie zeigenden Tabellen neu bauen. Diese
+      -- Migration räumt darum den Bestand, und caldavSync.deleteAccount
+      -- entkoppelt künftig selbst, bevor das Konto verschwindet.
+      --
+      -- Entkoppelt heißt lokal, nicht halb-extern: ohne Konto gibt es keine
+      -- Liste, in die etwas zurückginge, keinen Inbound, der die Zeile noch
+      -- anfasst, und keine UID, die noch etwas bedeutet. Was bleibt, ist eine
+      -- gewöhnliche Aufgabe bzw. ein gewöhnlicher Einkaufsposten.
+      UPDATE tasks
+         SET external_source     = 'local',
+             external_uid        = NULL,
+             external_account_id = NULL,
+             external_object_url = NULL,
+             outbound_dirty      = 0,
+             outbound_attempts   = 0
+       WHERE external_account_id IS NOT NULL
+         AND external_account_id NOT IN (SELECT id FROM caldav_accounts);
+
+      UPDATE shopping_items
+         SET external_source     = 'local',
+             external_uid        = NULL,
+             external_account_id = NULL,
+             external_object_url = NULL,
+             outbound_dirty      = 0,
+             outbound_attempts   = 0
+       WHERE external_account_id IS NOT NULL
+         AND external_account_id NOT IN (SELECT id FROM caldav_accounts);
+    `,
+  },
 ];
 
 /**

--- a/server/services/caldav-sync.js
+++ b/server/services/caldav-sync.js
@@ -13,6 +13,7 @@ import { assignDefaultToEvent } from './sync-assignment.js';
 import { pruneDeletedEvents } from './calendar-prune.js';
 import * as outbound from './calendar-outbound.js';
 import { processPendingDeletions, processPendingUpdates, flushAccount } from './caldav-outbound.js';
+import { detachAccountRows } from './caldav-todo-outbound.js';
 import { toICSDatetime, escapeICSText } from '../utils/ics-format.js';
 import { createCalDAVClient } from '../utils/caldav-client.js';
 
@@ -270,12 +271,26 @@ function deleteAccount(accountId) {
     throw new Error(`Account ${accountId} not found.`);
   }
 
-  // CASCADE will delete caldav_calendar_selection entries
-  db.get().prepare('DELETE FROM caldav_accounts WHERE id = ?').run(accountId);
+  // CASCADE räumt nur, was dem Konto selbst gehört: Kalender- und
+  // Listenauswahl und die offenen VTODO-Löschungen. Die gespiegelten Aufgaben
+  // und Einkaufsposten sind Nutzerdaten und bleiben - aber ihre
+  // external_account_id trägt keinen Fremdschlüssel und zeigte danach ins Leere
+  // (#617). Beim nächsten Löschen so einer Zeile scheiterte der Tombstone am
+  // Fremdschlüssel von caldav_todo_pending_deletions: die Aufgabe ließe sich
+  // lokal nicht mehr löschen, während die entfernte Kopie ohne Konto ohnehin
+  // unerreichbar ist. Also entkoppeln, bevor das Konto verschwindet - beides in
+  // einem Zug, damit keine Hälfte allein stehen bleibt.
+  const detached = db.get().transaction(() => {
+    const rows = detachAccountRows(accountId);
+    db.get().prepare('DELETE FROM caldav_accounts WHERE id = ?').run(accountId);
+    return rows;
+  })();
 
   // Events with calendar_ref_id to deleted account remain (orphaned but visible)
 
-  log.info(`Deleted CalDAV account ${accountId} ("${account.name}").`);
+  log.info(
+    `Deleted CalDAV account ${accountId} ("${account.name}"), detached ${detached} mirrored row(s).`
+  );
 
   return { success: true };
 }

--- a/server/services/caldav-todo-outbound.js
+++ b/server/services/caldav-todo-outbound.js
@@ -170,12 +170,54 @@ function hasCompleted(icsText) {
 // Vormerkung: Löschung
 // --------------------------------------------------------
 
+/** Gibt es das Konto noch? */
+function accountExists(accountId) {
+  return !!db.get().prepare('SELECT 1 FROM caldav_accounts WHERE id = ?').get(accountId);
+}
+
 /**
  * Ist dieser Eintrag ein CalDAV-Spiegel, für den die Rückrichtung überhaupt gilt?
  * Lokale Aufgaben haben external_source = 'local' und gehen nirgendwohin.
+ *
+ * Das Konto muss es noch geben. `external_account_id` trägt keinen
+ * Fremdschlüssel (v45), eine gedriftete Datenbank kann also auf ein längst
+ * gelöschtes Konto zeigen - und der Tombstone darauf scheiterte am
+ * Fremdschlüssel von caldav_todo_pending_deletions, womit sich die Aufgabe
+ * lokal nicht mehr löschen ließe. Ohne Konto gibt es keinen Rückweg, also ist
+ * hier nichts vorzumerken: dieselbe Vorprüfung wie acceptsOutbound() bei den
+ * Terminen. Der Regelfall ist ohnehin abgedeckt - caldavSync.deleteAccount
+ * entkoppelt seine Zeilen (detachAccountRows), Migration v123 den Bestand.
  */
 function isMirrored(row) {
-  return !!row && row.external_source === 'caldav' && !!row.external_uid && !!row.external_account_id;
+  if (!row || row.external_source !== 'caldav') return false;
+  if (!row.external_uid || !row.external_account_id) return false;
+  return accountExists(row.external_account_id);
+}
+
+/**
+ * Löst die gespiegelten Zeilen eines Kontos von ihm ab - zu rufen, bevor das
+ * Konto verschwindet. Was hier steht, sind Nutzerdaten und bleibt; nur die
+ * Verbindung zum Server geht. Danach ist es eine gewöhnliche Aufgabe bzw. ein
+ * gewöhnlicher Einkaufsposten: kein Tombstone, kein Push, und der Prune-Lauf
+ * eines anderen Kontos fasst sie nicht an.
+ *
+ * @returns {number} Anzahl entkoppelter Zeilen
+ */
+export function detachAccountRows(accountId) {
+  let detached = 0;
+  for (const def of Object.values(MODULES)) {
+    detached += db.get().prepare(`
+      UPDATE ${def.table}
+         SET external_source     = 'local',
+             external_uid        = NULL,
+             external_account_id = NULL,
+             external_object_url = NULL,
+             outbound_dirty      = 0,
+             outbound_attempts   = 0
+       WHERE external_source = 'caldav' AND external_account_id = ?
+    `).run(accountId).changes;
+  }
+  return detached;
 }
 
 /**

--- a/test/test-caldav-todo-outbound.js
+++ b/test/test-caldav-todo-outbound.js
@@ -38,6 +38,7 @@ const {
 const { patchICSTodo } = await import('../server/utils/ics-patch.js');
 const { mapVtodoPriority, mapVtodoStatus, splitDue, sync } =
   await import('../server/services/caldav-reminders-sync.js');
+const { deleteAccount } = await import('../server/services/caldav-sync.js');
 const { parseVTODO } = await import('../server/services/ics-parser.js');
 const { loadTags, loadItemTags, setTags, tagsKey } = await import('../server/utils/task-tags.js');
 const { MAX_OUTBOUND_ATTEMPTS } = await import('../server/services/calendar-outbound.js');
@@ -459,6 +460,67 @@ test('Eine lokale Aufgabe hinterlässt keinen Tombstone', () => {
   assert.strictEqual(pendingDeletions(accountId, 'tasks').length, 0);
 });
 
+// ── Gelöschtes Konto ────────────────────────────────────────────────────────────
+//
+// external_account_id trägt keinen Fremdschlüssel (v45), die Tombstone-Tabelle
+// sehr wohl: eine Zeile, die auf ein gelöschtes Konto zeigt, ließ sich nicht
+// mehr löschen - der Tombstone scheiterte, das lokale DELETE kam nie dazu, und
+// die entfernte Kopie blieb ohnehin unerreichbar stehen.
+
+test('Das Löschen eines Kontos entkoppelt seine gespiegelten Zeilen', () => {
+  const accountId = reset();
+  const task = insertTask({ accountId });
+  const item = insertShoppingItem({ accountId, uid: 'todo-2@test' });
+  db.prepare('UPDATE tasks SET outbound_dirty = 1, outbound_attempts = 2 WHERE id = ?').run(task.id);
+
+  deleteAccount(accountId);
+
+  for (const [label, row] of [
+    ['Aufgabe', reloadTask(task.id)],
+    ['Einkaufsposten', db.prepare('SELECT * FROM shopping_items WHERE id = ?').get(item.id)],
+  ]) {
+    assert.ok(row, `${label}: Nutzerdaten bleiben, nur die Verbindung geht`);
+    assert.strictEqual(row.external_source, 'local', `${label}: gehört ab jetzt Yuvomi allein`);
+    assert.strictEqual(row.external_account_id, null, `${label}: keine tote Kontokennung`);
+    assert.strictEqual(row.external_uid, null, `${label}: die UID bedeutet nichts mehr`);
+    assert.strictEqual(row.external_object_url, null);
+    assert.strictEqual(row.outbound_dirty, 0, `${label}: es gibt niemanden mehr, der das empfinge`);
+    assert.strictEqual(row.outbound_attempts, 0);
+  }
+});
+
+test('Eine entkoppelte Aufgabe lässt sich löschen, ohne am Fremdschlüssel zu scheitern', () => {
+  const accountId = reset();
+  const task = insertTask({ accountId });
+  deleteAccount(accountId);
+
+  // Der Löschpfad in routes/tasks.js liest die Zeile vor dem DELETE - nach der
+  // Entkopplung ist sie lokal, also gibt es nichts vorzumerken.
+  const doomed = reloadTask(task.id);
+  assert.strictEqual(queueTodoDeletion('tasks', doomed), false);
+  db.prepare('DELETE FROM tasks WHERE id = ?').run(task.id);
+  assert.strictEqual(reloadTask(task.id), undefined);
+});
+
+test('Eine Zeile mit toter Kontokennung wird still übersprungen statt zu werfen', () => {
+  // Gedriftete Datenbank: das Konto ist weg, die Kennung steht noch. Ohne
+  // Vorprüfung warf der INSERT in caldav_todo_pending_deletions hier einen
+  // Fremdschlüsselfehler - und der Route-Handler daraufhin eine 500, ohne je
+  // beim lokalen DELETE anzukommen.
+  const accountId = reset();
+  const task = insertTask({ accountId });
+  const item = insertShoppingItem({ accountId, uid: 'todo-2@test' });
+  db.prepare('DELETE FROM caldav_accounts WHERE id = ?').run(accountId);
+
+  assert.strictEqual(queueTodoDeletion('tasks', task), false);
+  assert.strictEqual(queueTodoDeletions('shopping', [item]), 0);
+  // Auch die Bearbeitung: ohne Konto gibt es niemanden, der den Push abholt.
+  assert.strictEqual(
+    markTodoOutbound('tasks', task, { ...task, title: 'Milch und Butter kaufen' }), false
+  );
+  assert.strictEqual(reloadTask(task.id).outbound_dirty, 0);
+});
+
 // ── Ausführung ──────────────────────────────────────────────────────────────────
 
 test('Eine vorgemerkte Änderung landet als PUT auf der Objekt-URL', async () => {
@@ -732,6 +794,66 @@ test('v113 ist additiv und startet mit neutralen Markern', async () => {
   old.prepare('PRAGMA foreign_keys = ON').run();
   old.prepare('DELETE FROM caldav_accounts WHERE id = 1').run();
   assert.strictEqual(old.prepare('SELECT COUNT(*) AS n FROM caldav_todo_pending_deletions').get().n, 0);
+
+  old.close();
+});
+
+test('v123 entkoppelt den Bestand toter Kontokennungen und lässt lebende in Ruhe', async () => {
+  const { mkdtempSync } = await import('node:fs');
+  const { tmpdir } = await import('node:os');
+  const { join } = await import('node:path');
+  const { default: Database } = await import('better-sqlite3-multiple-ciphers');
+  const { MIGRATIONS } = await import('../server/db.js');
+
+  const apply = (conn, migration) => {
+    if (typeof migration.up === 'function') migration.up(conn);
+    else conn.exec(migration.up);
+    migration.afterUp?.(conn);
+  };
+
+  const old = new Database(join(mkdtempSync(join(tmpdir(), 'yuvomi-detachmig-')), 'db.sqlite'));
+  for (const migration of MIGRATIONS.filter((m) => m.version <= 122)) apply(old, migration);
+
+  // Bestand eines Haushalts, der schon einmal ein CalDAV-Konto gelöscht hat:
+  // Konto 1 lebt, Konto 2 gab es einmal und die Zeilen wissen nichts davon.
+  old.prepare("INSERT INTO users (id, username, display_name, password_hash, role) VALUES (1,'admin','Admin','x','admin')").run();
+  old.prepare(`INSERT INTO caldav_accounts (id, name, caldav_url, username, password)
+               VALUES (1, 'Radicale', 'https://dav.example/', 'u', 'p')`).run();
+  old.prepare("INSERT INTO shopping_lists (id, name, created_by) VALUES (3, 'Einkauf', 1)").run();
+
+  const mkTask = old.prepare(`
+    INSERT INTO tasks (id, title, created_by, external_uid, external_source,
+                       external_account_id, external_object_url, outbound_dirty, outbound_attempts)
+    VALUES (?, ?, 1, ?, 'caldav', ?, 'https://dav.example/o.ics', ?, ?)
+  `);
+  mkTask.run(7, 'Milch kaufen', 'todo-1@test', 1, 1, 3);   // lebendes Konto
+  mkTask.run(8, 'Reifen wechseln', 'todo-2@test', 2, 1, 0); // verwaist
+  old.prepare(`INSERT INTO shopping_items (id, list_id, name, external_uid, external_source,
+                                           external_account_id, external_object_url)
+               VALUES (5, 3, 'Butter', 'todo-3@test', 'caldav', 2, 'https://dav.example/b.ics')`).run();
+
+  apply(old, MIGRATIONS.find((m) => m.version === 123));
+
+  const orphan = old.prepare('SELECT * FROM tasks WHERE id = 8').get();
+  assert.strictEqual(orphan.title, 'Reifen wechseln', 'die Aufgabe selbst bleibt - sie ist Nutzerdatum');
+  assert.strictEqual(orphan.external_source, 'local');
+  assert.strictEqual(orphan.external_account_id, null);
+  assert.strictEqual(orphan.external_uid, null);
+  assert.strictEqual(orphan.external_object_url, null);
+  assert.strictEqual(orphan.outbound_dirty, 0);
+
+  const orphanItem = old.prepare('SELECT * FROM shopping_items WHERE id = 5').get();
+  assert.strictEqual(orphanItem.external_source, 'local');
+  assert.strictEqual(orphanItem.external_account_id, null);
+
+  // Ein noch verbundenes Konto darf die Migration nicht mit abräumen, sonst
+  // stünde nach dem Update ein ganzer Spiegel still.
+  const live = old.prepare('SELECT * FROM tasks WHERE id = 7').get();
+  assert.strictEqual(live.external_source, 'caldav');
+  assert.strictEqual(live.external_account_id, 1);
+  assert.strictEqual(live.external_uid, 'todo-1@test');
+  assert.strictEqual(live.outbound_dirty, 1, 'eine wartende Bearbeitung bleibt vorgemerkt');
+  assert.strictEqual(live.outbound_attempts, 3);
 
   old.close();
 });


### PR DESCRIPTION
Ein geloeschtes CalDAV-Konto liess seine gespiegelten Aufgaben und Einkaufsposten mit einer Kontokennung zurueck, die auf nichts mehr zeigt - und machte sie damit unloeschbar. Gefunden im Codex-Review von PR #662, dort bewusst nicht gefixt (der PR behandelt nur Dialog-Folgentexte).

## Der Bug

`tasks.external_account_id` und `shopping_items.external_account_id` sind seit v45 blosse INTEGER-Spalten ohne Fremdschluessel. `caldavSync.deleteAccount` nahm per CASCADE nur mit, was dem Konto selbst gehoert: Kalender- und Listenauswahl und die offenen VTODO-Loeschungen.

Die Sackgasse liegt eine Ebene weiter: `queueTodoDeletion()` merkt eine geloeschte Spiegelzeile in `caldav_todo_pending_deletions` vor, und **die** Tabelle traegt den Fremdschluessel sehr wohl. Der INSERT scheiterte an der toten `account_id`, und weil er in `routes/tasks.js` und `routes/shopping.js` **vor** dem lokalen DELETE laeuft, kam das DELETE nie dazu: 500, Eintrag bleibt haengen, entfernte Kopie ohne Konto ohnehin unerreichbar.

Nachstellbar: CalDAV-Konto mit Aufgaben-/Erinnerungssync verbinden, VTODOs importieren, Konto in den Einstellungen loeschen, danach eine der importierten Aufgaben loeschen. Belegt: der INSERT wirft `FOREIGN KEY constraint failed`.

## Der Fix, drei Lagen

- **Ursache** - `deleteAccount` entkoppelt die gespiegelten Zeilen jetzt in einer Transaktion mit dem Konto-DELETE. Die neue `detachAccountRows()` liegt in `caldav-todo-outbound.js`, weil `MODULES` dort schon die Tabellen-Whitelist fuehrt. Entkoppelt heisst lokal, nicht halb-extern: `external_source = 'local'`, UID, Kontokennung, Objekt-URL und Outbound-Marker weg. Ohne Konto gibt es keine Liste, in die etwas zurueckginge, keine UID, die noch etwas bedeutet, und der `pruneRemoved`-Lauf eines anderen Kontos fasst die Zeile auch nicht an.
- **Guard** - `isMirrored()` prueft zusaetzlich, ob es das Konto noch gibt: dieselbe Vorpruefung wie `acceptsOutbound()` bei den Terminen. Das faengt gedriftete Datenbanken und wirkt fuer beide Aufrufer, also auch fuer `markTodoOutbound()`, das eine verwaiste Zeile sonst dauerhaft als dirty markiert haette.
- **Bestand** - Migration v123 raeumt Zeilen, deren `external_account_id` in keinem `caldav_accounts`-Eintrag steht, und laesst lebende Verbindungen samt wartender Pushes unangetastet.

## Warum kein echter Fremdschluessel

SQLite kann ihn nicht nachtraeglich an eine bestehende Spalte haengen; das hiesse `tasks` und `shopping_items` samt Indizes, FTS-Triggern und den auf sie zeigenden Tabellen neu bauen (wie v114). Unverhaeltnismaessig, wenn die Referenz nach diesem PR gar nicht erst verwaisen kann und der Guard den Rest abfaengt. Die Begruendung steht im Migrations-Kommentar, damit sie beim naechsten Rebuild greifbar ist.

Gegenprobe bei den Terminen: `calendar_pending_deletions` ist source-basiert und traegt keinen Fremdschluessel auf `caldav_accounts` - dort gibt es keine analoge Blockade, verwaiste Events bleiben wie gehabt sichtbar.

## Geprueft

Vier neue Tests in `test/test-caldav-todo-outbound.js`: Entkopplung beim Kontoloeschen (beide Module), Loeschbarkeit danach, stilles Ueberspringen bei toter Kennung inklusive `markTodoOutbound`, und Migration v123 gegen eine befuellte Bestands-DB (verwaist wird geraeumt, lebend bleibt).

Suite gruen mit 44 Tests. Dazu gruen: `test:db`, `test:schema-reconcile`, `test:db-isolation`, `test:rename-migration`, `test:caldav`, `test:caldav-reminders`, `test:caldav-outbound`, `test:tasks`, `test:tasks-routes`, `test:shopping`, `test:shopping-routes`, `test:layer-boundary`, `test:changelog`.

## Offen

Der CHANGELOG-Eintrag unter `[Unreleased]` fehlt noch, der gehoert zu `release-prep`.
