### PR TITLE
fix(ui): move the page FAB out of the scrolling container

### DIFF
--- a/public/pages/birthdays.js
+++ b/public/pages/birthdays.js
@@ -6,6 +6,7 @@ import { esc } from '/utils/html.js';
 import { renderSkeletonList } from '/utils/skeleton.js';
 import { toLocalDateKey } from '/utils/date.js';
 import { renderPageSearch, wirePageSearch } from '/utils/page-search.js';
+import { findPageFab } from '/utils/fab.js';
 
 let state = {
   birthdays: [],
@@ -229,7 +230,7 @@ function renderPage() {
 }
 
 function bindEvents() {
-  _container.querySelector('#fab-new-birthday').addEventListener('click', () => openBirthdayModal({ mode: 'create' }));
+  findPageFab('fab-new-birthday').addEventListener('click', () => openBirthdayModal({ mode: 'create' }));
   _container.querySelector('#birthdays-import-btn')?.addEventListener('click', () => openImportModal());
 
   // Deep-Link aus dem Kontakt-Import („Zu Geburtstagen"): Kandidaten-Modal direkt

--- a/public/pages/budget.js
+++ b/public/pages/budget.js
@@ -23,6 +23,7 @@ import { budgetCategoryLabel } from '/utils/category-labels.js';
 import { intervalUnitLabel } from '/rrule-ui.js';
 import { appendCurrencyOptions } from '/settings/currency.js';
 import '/components/category-manager.js';
+import { findPageFab } from '/utils/fab.js';
 
 // --------------------------------------------------------
 // Konstanten
@@ -536,7 +537,7 @@ function wireNav() {
     }
   };
   _container.querySelector('#budget-add').addEventListener('click', addHandler);
-  _container.querySelector('#fab-new-budget').addEventListener('click', addHandler);
+  findPageFab('fab-new-budget').addEventListener('click', addHandler);
   // Geteilte Tablist-Verhaltensschicht (Klick + Pfeiltasten/Home/End + Roving-
   // Tabindex + ARIA) — dieselbe Grammatik wie Rewards/Haushaltshilfe statt einer
   // modul-eigenen Nachbildung (utils/tablist.js). wireTablist malt den aktiven
@@ -855,7 +856,7 @@ function updateTabs() {
       addBtn.setAttribute('title', addLabel);
     }
   }
-  const fab = _container.querySelector('#fab-new-budget');
+  const fab = findPageFab('fab-new-budget');
   if (fab) {
     fab.hidden = !caps.add;
     if (caps.add) fab.setAttribute('aria-label', addLabel);

--- a/public/pages/calendar.js
+++ b/public/pages/calendar.js
@@ -21,6 +21,7 @@ import { wireTablist } from '/utils/tablist.js';
 import { localizeBirthdayEvent } from '/utils/birthday-event.js';
 import { googleTargetValue, caldavTargetValue } from '/utils/sync-target.js';
 import { renderSkeletonList } from '/utils/skeleton.js';
+import { findPageFab } from '/utils/fab.js';
 
 // --------------------------------------------------------
 // Konstanten
@@ -972,7 +973,7 @@ export async function render(container, { user }) {
   renderView();
   bodyEl.removeAttribute('aria-busy');
 
-  container.querySelector('#fab-new-event')?.addEventListener('click', () => openEventModal({ mode: 'create' }));
+  findPageFab('fab-new-event')?.addEventListener('click', () => openEventModal({ mode: 'create' }));
 
   if (initialEvent) {
     const targetDate = deepLinkTargetDate(initialEvent, dateParam);

--- a/public/pages/contacts.js
+++ b/public/pages/contacts.js
@@ -16,6 +16,7 @@ import { parseVCards } from '/utils/vcard.js';
 import { composeDisplayName, contactSortKey, splitDisplayName } from '/utils/contact-name.js';
 import { getPhoneFormatter, createAsYouType, countryFromRegion } from '/utils/phone.js';
 import '/components/category-manager.js';
+import { findPageFab } from '/utils/fab.js';
 
 // --------------------------------------------------------
 // Konstanten
@@ -252,7 +253,7 @@ export async function render(container, { user }) {
   // Neu
   const addHandler = () => openContactModal({ mode: 'create' });
   _container.querySelector('#contacts-add-btn').addEventListener('click', addHandler);
-  _container.querySelector('#fab-new-contact').addEventListener('click', addHandler);
+  findPageFab('fab-new-contact').addEventListener('click', addHandler);
 
   // Auswahl-Modus (opt-in): Toggle in der Toolbar + Aktionen in der Auswahl-Leiste.
   _container.querySelector('#contacts-select-btn').addEventListener('click', () => {

--- a/public/pages/documents.js
+++ b/public/pages/documents.js
@@ -12,6 +12,7 @@ import { stagger, wireScrollFade, scheduleUndoableDelete } from '/utils/ux.js';
 import { renderSkeletonList } from '/utils/skeleton.js';
 import { renderPageSearch, wirePageSearch } from '/utils/page-search.js';
 import { previewKind } from '/utils/document-preview.js';
+import { findPageFab } from '/utils/fab.js';
 
 const CATEGORIES = ['medical', 'school', 'identity', 'insurance', 'finance', 'home', 'vehicle', 'legal', 'travel', 'pets', 'warranty', 'taxes', 'work', 'other'];
 const MAX_FILE_SIZE = 5 * 1024 * 1024;
@@ -242,7 +243,7 @@ function applyFilters() {
 
 function bindPageEvents() {
   _container.querySelector('#documents-folder-add')?.addEventListener('click', () => openFolderModal());
-  _container.querySelector('#fab-new-document')?.addEventListener('click', () => openDocumentModal());
+  findPageFab('fab-new-document')?.addEventListener('click', () => openDocumentModal());
 
   _search = wirePageSearch(_container, {
     id: 'documents-search',

--- a/public/pages/meals.js
+++ b/public/pages/meals.js
@@ -18,6 +18,7 @@ import { addLocalDays, startOfLocalWeekKey, toLocalDateKey } from '/utils/date.j
 import { normalizeRecipeMealTypes, recipeSupportsMealType } from '/utils/recipe-meal-types.js';
 import { mountEmptyState, mountLoadError, emptyStateEl } from '/utils/empty-state.js';
 import { mealPayloadFromRecipe } from '/utils/recipe-to-meal.js';
+import { findPageFab } from '/utils/fab.js';
 
 // --------------------------------------------------------
 // Konstanten
@@ -272,7 +273,7 @@ export async function render(container, { user }) {
   wireRecipeSidebar();
   wireRailToggle();
 
-  container.querySelector('#fab-new-meal').addEventListener('click', () => {
+  findPageFab('fab-new-meal').addEventListener('click', () => {
     const firstType = state.visibleMealTypes[0] ?? 'lunch';
     openMealModal({ mode: 'create', date: today, mealType: firstType });
   });

--- a/public/pages/notes.js
+++ b/public/pages/notes.js
@@ -12,6 +12,7 @@ import { esc, renderMarkdownLight } from '/utils/html.js';
 import { getReadableTextColor } from '/utils/color.js';
 import { renderSkeletonList } from '/utils/skeleton.js';
 import { renderPageSearch, wirePageSearch } from '/utils/page-search.js';
+import { findPageFab } from '/utils/fab.js';
 
 // --------------------------------------------------------
 // Konstanten
@@ -108,7 +109,7 @@ export async function render(container, { user }) {
   // #notes-add-btn ist per .toolbar-new-btn global ausgeblendet (FAB übernimmt),
   // bleibt aber als einheitliches Modul-Muster erhalten (frontend-audit 1.9).
   _container.querySelector('#notes-add-btn').addEventListener('click', addHandler);
-  _container.querySelector('#fab-new-note').addEventListener('click', addHandler);
+  findPageFab('fab-new-note').addEventListener('click', addHandler);
 
   wirePageSearch(_container, {
     id: 'notes-search',

--- a/public/pages/shopping.js
+++ b/public/pages/shopping.js
@@ -15,6 +15,7 @@ import { renderKitchenTabsBar, refreshKitchenBadges } from '/utils/kitchen-tabs.
 import { mountEmptyState, mountLoadError } from '/utils/empty-state.js';
 import { popoverMenuHtml, installPopoverMenus } from '/utils/popover-menu.js';
 import '/components/category-manager.js';
+import { findPageFab } from '/utils/fab.js';
 
 // --------------------------------------------------------
 // Konstanten
@@ -571,7 +572,7 @@ function _flashAddBtn(btn) {
  */
 function syncQuickAddDisclosure(container, open) {
   const page = container.querySelector('.shopping-page');
-  const fab = container.querySelector('#fab-new-item');
+  const fab = findPageFab('fab-new-item');
   if (!page || !fab) return;
 
   const collapsible = window.matchMedia('(hover: none)').matches && Boolean(state.activeList);
@@ -601,7 +602,7 @@ function wireQuickAdd(container) {
     if (!page?.classList.contains('shopping-page--adding')) return;
     e.stopPropagation();
     syncQuickAddDisclosure(container, false);
-    container.querySelector('#fab-new-item')?.focus();
+    findPageFab('fab-new-item')?.focus();
   });
 
   form.addEventListener('submit', async (e) => {
@@ -1754,7 +1755,7 @@ export async function render(container, { user }) {
   renderListContent(container);
   wireListContentEvents(container);
 
-  container.querySelector('#fab-new-item')?.addEventListener('click', (e) => {
+  findPageFab('fab-new-item')?.addEventListener('click', (e) => {
     const input = container.querySelector('#item-name-input');
     if (!input) {
       // Keine Liste aktiv → neue Liste erstellen

--- a/public/pages/split-expenses.js
+++ b/public/pages/split-expenses.js
@@ -12,6 +12,7 @@ import { stagger } from '/utils/ux.js';
 import { renderSkeletonList } from '/utils/skeleton.js';
 import { formatMoney, amountPlaceholder, toDecimalString, amountIsSavable, smallestUnitLabel } from '/utils/money.js';
 import { wireTablist } from '/utils/tablist.js';
+import { findPageFab } from '/utils/fab.js';
 
 let state = {
   meta: null,
@@ -180,7 +181,7 @@ async function loadMemberCandidates() {
 function bindShell() {
   _container.querySelector('#split-add-group')?.addEventListener('click', () => openGroupModal());
   _container.querySelector('#split-add-expense')?.addEventListener('click', () => openExpenseModal());
-  _container.querySelector('#split-fab')?.addEventListener('click', () => openExpenseModal());
+  findPageFab('split-fab')?.addEventListener('click', () => openExpenseModal());
   let groupSearchTimer;
   _container.querySelector('#split-group-search')?.addEventListener('input', (e) => {
     const value = e.target.value.trim();
@@ -235,7 +236,7 @@ function renderStatusFilter() {
   _statusTablist?.sync(state.groupStatus);
   const addExpense = _container.querySelector('#split-add-expense');
   if (addExpense) addExpense.hidden = isArchivedView();
-  const fab = _container.querySelector('#split-fab');
+  const fab = findPageFab('split-fab');
   if (fab) fab.hidden = isArchivedView();
 }
 

--- a/public/pages/tasks.js
+++ b/public/pages/tasks.js
@@ -18,6 +18,7 @@ import { renderPageSearch, wirePageSearch } from '/utils/page-search.js';
 import { isPreviewable } from '/utils/document-preview.js';
 import '/components/category-manager.js';
 import '/components/tag-manager.js';
+import { findPageFab } from '/utils/fab.js';
 
 // --------------------------------------------------------
 // Konstanten
@@ -2600,7 +2601,7 @@ function wireNewTaskBtn(container) {
     openTaskModal({ users: state.users }, container);
   };
   container.querySelector('#btn-new-task')?.addEventListener('click', handler);
-  container.querySelector('#fab-new-task')?.addEventListener('click', handler);
+  findPageFab('fab-new-task')?.addEventListener('click', handler);
 }
 
 function updateBulkActionsBar(container) {

--- a/public/router.js
+++ b/public/router.js
@@ -709,6 +709,9 @@ async function navigate(path, userOrPushState = true, pushState = true) {
         // weil kein Teardown existiert, an den man sich hängen könnte.
         const main = document.getElementById('main-content');
         if (main) main.scrollTop = scrollTarget;
+        // Ein Tabwechsel kann einen neuen FAB anlegen (Health-Tabs) - der muss
+        // denselben Weg aus dem Scrollport nehmen wie beim vollen Rendern.
+        adoptPageFab();
         updateNav(topLevelSection(basePath));
         return;
       }
@@ -1119,6 +1122,11 @@ async function renderPage(route, previousPath = null, scrollTarget = 0) {
     // Wiederherstellung bei popstate darf und soll das dagegen überschreiben,
     // sie steht deshalb unten hinter dem await.
     content.scrollTop = 0;
+    // Der FAB der alten Seite lebt in der Shell und fiele sonst nicht mit ihrem
+    // Inhalt weg - er bliebe über der neuen Seite stehen, bis diese adoptiert.
+    // Hier und nicht eine Zeile höher: der Scroll-Reset gehört unmittelbar an
+    // den Inhaltstausch (Guard in test-mobile-scroll-layout.js).
+    clearPageFab();
     style.cleanup();
 
     // Teardown abgeschlossen: ein evtl. gemerktes Soft-Update-Ziel ist jetzt
@@ -1133,6 +1141,11 @@ async function renderPage(route, previousPath = null, scrollTarget = 0) {
     // wodurch jedes vor dem Daten-await geseedete Skeleton beim Erstladen nie
     // erschien). Der Rest von render() (Daten + Verdrahtung) wird danach abgewartet.
     const renderPromise = module.render(pageWrapper, { user: currentUser });
+
+    // Schon jetzt umziehen, nicht erst nach den Daten: die meisten Seiten legen
+    // ihren FAB im synchronen Teil an, und er soll gar nicht erst im Scrollport
+    // erscheinen. Der zweite Aufruf unten holt die Nachzügler.
+    adoptPageFab();
 
     // Sichtbar machen und Einblend-Animation starten (Skeleton/Grundgerüst).
     pageWrapper.style.opacity = shouldAnimate ? '' : '1';
@@ -1164,7 +1177,7 @@ async function renderPage(route, previousPath = null, scrollTarget = 0) {
     _renderedModuleName = route.module;
 
     // FAB Long Loop: Einstiegsanimation nach FAB_SEEN_MAX Views pro Modul deaktivieren
-    const pageFab = pageWrapper.querySelector('.page-fab');
+    const pageFab = adoptPageFab();
     if (pageFab) {
       // Shortcut-Discoverability (Audit P3): der 'n'-Chord öffnet den FAB — als
       // Tooltip-Titel + aria-keyshortcuts sichtbar bzw. vorlesbar machen.
@@ -1424,6 +1437,13 @@ function renderAppShell(container) {
   main.id = 'main-content';
   main.tabIndex = -1;
 
+  // Wohnort des Page-FAB, außerhalb des Scrollports (#634). Der Knopf gehört
+  // inhaltlich zur Seite, aber nicht in den scrollenden Container - Begründung
+  // an `.fab-layer` in layout.css und an adoptPageFab().
+  const fabLayer = document.createElement('div');
+  fabLayer.className = 'fab-layer';
+  fabLayer.id = 'fab-layer';
+
   const bottomNav = document.createElement('nav');
   bottomNav.className = 'nav-bottom';
   bottomNav.setAttribute('aria-label', t('nav.navigation'));
@@ -1567,7 +1587,7 @@ function renderAppShell(container) {
     lgBackdrop.appendChild(blob);
   }
 
-  const shellNodes = [skipLink, lgBackdrop, sidebar, main, bottomNav];
+  const shellNodes = [skipLink, lgBackdrop, sidebar, main, fabLayer, bottomNav];
   if (backdrop)   shellNodes.push(backdrop);
   if (moreSheet)  shellNodes.push(moreSheet);
   shellNodes.push(searchOverlay, toastContainerPolite, toastContainerAssertive, routeAnnouncer);
@@ -1602,6 +1622,46 @@ function renderAppShell(container) {
   // Hauptnavigation im Leerlauf vorwärmen — die erste Modulnavigation soll
   // ohne Kaltstart-Wasserfall auskommen.
   warmPrimaryRoutes();
+}
+
+/**
+ * Den Page-FAB der aktuellen Seite in die App-Shell heben (#634).
+ *
+ * WARUM AUS DEM SCROLLPORT HERAUS. Der FAB ist `position: fixed`, hing aber im
+ * Modul-Root und damit INNERHALB von `.app-content` - dem Container, der auf
+ * den meisten Routen scrollt. Auf iOS bekommt ein solcher Scroller einen
+ * eigenen Compositor-Layer, und ein fixiertes Kind darin ist dort nicht
+ * verlässlich viewport-fest: es wird gegen den gescrollten Inhalt statt gegen
+ * den Viewport aufgelöst, wandert beim Laden mit der wachsenden Liste nach
+ * unten aus dem Bild und kommt ohne Repaint nicht zurück. Genau das
+ * beschreibt der Melder in #634 - erst mittig rechts, dann weg, und zwar in
+ * den Modulen, in denen .app-content wirklich scrollt (Aufgaben, Vorrat),
+ * während er anderswo nach dem Laden an seinen Platz springt.
+ *
+ * Dieselbe Falle hatte die Bottom-Nav schon einmal: sie ist deshalb längst
+ * `position: relative` und ein Flex-Kind der Shell (Begründung an `.nav-bottom`
+ * in layout.css). Der FAB war das letzte fixierte Element im Scrollport.
+ *
+ * Der Modulakzent geht dabei nicht verloren: die Layer liest ihn aus
+ * `--active-module-accent`, das applyModuleAccentForRoute() ohnehin bei jeder
+ * Navigation (und bei jedem Theme-Wechsel) auf <html> setzt.
+ *
+ * Idempotent: Der Aufruf sucht einen FAB im Inhalt und zieht ihn um; ist
+ * keiner da, bleibt der bereits umgezogene stehen. Ein DOM-Umzug behält
+ * Event-Listener, Referenzen (health/housekeeping/rewards halten ihren FAB)
+ * bleiben gültig.
+ */
+function adoptPageFab() {
+  const layer = document.getElementById('fab-layer');
+  if (!layer) return null;
+  const fresh = document.querySelector('#main-content .page-fab');
+  if (fresh) layer.replaceChildren(fresh);
+  return layer.firstElementChild;
+}
+
+/** FAB der alten Seite abräumen - zusammen mit deren Inhalt, nicht später. */
+function clearPageFab() {
+  document.getElementById('fab-layer')?.replaceChildren();
 }
 
 const FAB_SEEN_KEY = (module) => `yuvomi:fabSeen:${module}`;

--- a/public/styles/contacts.css
+++ b/public/styles/contacts.css
@@ -206,7 +206,10 @@
   background-color: color-mix(in srgb, var(--c-accent) 12%, transparent);
 }
 
-.contacts-page.is-selecting .page-fab {
+/* Auswahlmodus verdeckt die Anlege-Affordance. Gefragt wird über :has() am
+ * Dokument, weil der FAB seit #634 nicht mehr unter `.contacts-page` hängt,
+ * sondern in der Shell-Layer neben dem Scrollport. */
+html:has(.contacts-page.is-selecting) .page-fab {
   display: none;
 }
 

--- a/public/styles/layout.css
+++ b/public/styles/layout.css
@@ -191,8 +191,11 @@
  *
  * NUR MIT FAB: `:has()` fragt die Seite, statt eine Klasse zu verlangen, die
  * beim nächsten neuen Modul vergessen wird. `:not([hidden])`, weil eine Seite
- * ihren FAB zeitweise verbergen kann - dann gehört ihr der Platz. */
-.app-content:has(.page-fab:not([hidden])) {
+ * ihren FAB zeitweise verbergen kann - dann gehört ihr der Platz.
+ *
+ * Gefragt wird an der SHELL, nicht am Scrollport: der FAB hängt seit #634 in
+ * `.fab-layer` neben `.app-content`, nicht mehr darin. */
+.app-shell:has(.fab-layer > .page-fab:not([hidden])) .app-content {
   margin-block-end: var(--fab-safe-zone);
 }
 
@@ -998,6 +1001,29 @@ html:has(.search-overlay--visible) yuvomi-install-prompt {
   from  { transform: scale(0.5) translateY(12px); opacity: 0; }
   65%   { transform: scale(1.07) translateY(-2px); opacity: 1; }
   to    { transform: scale(1)   translateY(0);    opacity: 1; }
+}
+
+/* Wohnort des FAB: ein Shell-Kind neben dem Scrollport, kein Kind von ihm.
+ *
+ * Der FAB ist fixiert, hing aber im Modul-Root und damit im scrollenden
+ * `.app-content`. Ein fixiertes Kind eines Scrollers ist auf iOS nicht
+ * verlässlich viewport-fest (Compositor-Layer des Scrollers) - dieselbe Falle,
+ * die die Bottom-Nav schon aus `position: fixed` geholt hat, siehe dort. Es war
+ * das letzte fixierte Element im Scrollport (#634).
+ *
+ * Die Layer selbst trägt KEIN Layout: 0×0 an der Shell-Ecke. Sichtbar ist allein
+ * ihr fixiertes Kind, dessen Geometrie unverändert aus den --fab-*-Tokens kommt.
+ * Bewusst kein z-index → kein eigener Stacking-Context, die Reihenfolge
+ * gegenüber Nav/Modal/Toast bleibt exakt die alte. Der Modulakzent kommt aus
+ * --active-module-accent (Router setzt es je Route und je Theme), weil die
+ * Vererbung über den Modul-Root hier endet. */
+.fab-layer {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  width: 0;
+  height: 0;
+  --module-accent: var(--active-module-accent, var(--color-accent));
 }
 
 .page-fab {

--- a/public/utils/fab.js
+++ b/public/utils/fab.js
@@ -5,15 +5,19 @@
  * zuvor pro Seite handgeschriebene `<button class="page-fab">`-Markup und gibt
  * Tab-Modulen einen Kontext-FAB, dessen Aktion dem aktiven Tab folgt.
  *
- * Drei Wege:
+ * Vier Wege:
  *   - pageFabHtml()      → HTML-String für Template-Literal-Seiten (eigene Klick-Verdrahtung).
  *   - createPageFab()    → DOM-Element mit onClick, für DOM-basierte / dynamische Seiten.
+ *   - findPageFab()      → den FAB der aktuellen Seite finden (dokumentweit, siehe dort).
  *   - setPageFabAction() → Aktion/Label/Sichtbarkeit eines Kontext-FAB je Tab aktualisieren.
  *
- * Der FAB muss INNERHALB des Modul-Page-Roots hängen (das `--module-accent`
- * setzt), damit er modulfarben wird. Styling lebt in layout.css (.page-fab).
- * Icon-Default: plus (Lucide rendert 24px). Nach dem Einfügen einmal
- * `lucide.createIcons({ el })` auf dem Container aufrufen.
+ * WO DER FAB LEBT: Eine Seite legt ihn in ihrem Page-Root an, aber dort bleibt er
+ * nicht - der Router hebt ihn nach dem Rendern in die Shell-Layer neben dem
+ * Scrollport (adoptPageFab(), #634). Deshalb sucht man ihn dokumentweit und
+ * niemals im Seiten-Container, und deshalb kommt seine Farbe aus
+ * `--active-module-accent` statt aus dem `--module-accent` des Page-Roots.
+ * Styling lebt in layout.css (.page-fab). Icon-Default: plus (Lucide rendert
+ * 24px). Nach dem Einfügen einmal `lucide.createIcons({ el })` aufrufen.
  */
 
 /** Gemeinsame FAB-Markup als HTML-String (Label kommt aus t(), keine Nutzdaten). */
@@ -36,6 +40,18 @@ export function createPageFab({ id = 'page-fab', label = '', icon = 'plus', onCl
   fab.appendChild(glyph);
   if (onClick) fab.addEventListener('click', onClick);
   return fab;
+}
+
+/**
+ * Den FAB einer Seite finden - dokumentweit, nicht im Seiten-Container.
+ *
+ * Ein `container.querySelector('#fab-…')` fand ihn, solange er im Page-Root hing.
+ * Seit er in der Shell lebt (#634), liefert dieselbe Zeile still `null`, und die
+ * Verdrahtung entfällt lautlos: der Knopf ist sichtbar und tut nichts. Diese
+ * Funktion ist die eine Stelle, an der der Ort steht.
+ */
+export function findPageFab(id) {
+  return document.getElementById(id);
 }
 
 /**

--- a/test/test-frontend-audit.js
+++ b/test/test-frontend-audit.js
@@ -2355,7 +2355,7 @@ test('der FAB weicht der Zeile, statt eine Gasse zu reservieren', () => {
     '--fab-safe-zone muss aus --fab-gap und --fab-size abgeleitet werden');
   assert.match(tokens, /--fab-offset-bottom:\s*calc\([^;]*--fab-gap[^;]*\)/,
     '--fab-offset-bottom und --fab-safe-zone müssen dieselbe Quelle (--fab-gap) haben');
-  assert.match(layout, /\.app-content:has\(\.page-fab[\s\S]*?\{[^}]*margin-block-end:\s*var\(--fab-safe-zone\)/,
+  assert.match(layout, /:has\([^)]*\.page-fab[^)]*\)[^{]*\.app-content\s*\{[^}]*margin-block-end:\s*var\(--fab-safe-zone\)/,
     'der Scrollport muss über der FAB-Zone enden (Marge an .app-content)');
 
   // Die drei auseinandergedrifteten Kopien bleiben abgeschafft. Sie rechneten
@@ -2408,6 +2408,61 @@ test('der FAB weicht der Zeile, statt eine Gasse zu reservieren', () => {
         `${file} blendet den FAB per opacity aus - genau der Zustand aus #634`);
       assert.doesNotMatch(rule, /pointer-events:\s*none/,
         `${file} nimmt dem FAB die Bedienbarkeit - genau der Zustand aus #634`);
+    }
+  }
+});
+
+/**
+ * #634, dritte Runde: der FAB gehört nicht in den Scrollport.
+ *
+ * Nach Retract und Tastatur-Erkennung meldete derselbe Nutzer den Defekt ein
+ * drittes Mal - in der PWA, ohne Adressleiste, ohne Tastatur. Was blieb, war der
+ * Ort: der FAB ist `position: fixed`, hing aber im Modul-Root und damit INNERHALB
+ * von `.app-content`, dem Container, der auf den meisten Routen scrollt. Ein
+ * fixiertes Kind eines Scrollers ist auf iOS nicht verlässlich viewport-fest; es
+ * wird gegen den gescrollten Inhalt aufgelöst und wandert mit der wachsenden
+ * Liste aus dem Bild. Genau die Falle, die die Bottom-Nav schon aus
+ * `position: fixed` geholt hatte - der FAB war das letzte fixierte Element, das
+ * noch im Scrollport stand.
+ *
+ * Die Zusicherung ist der ORT, nicht der Weg dorthin: der FAB hängt in einer
+ * Shell-Layer neben `.app-content`, und kein Stylesheet darf ihn wieder über
+ * einen Modul-Kontext adressieren - eine solche Kette existiert nach dem Umzug
+ * nicht mehr und wäre still wirkungslos.
+ */
+test('der Page-FAB hängt in der Shell, nicht im Scrollport', () => {
+  const router = read('../public/router.js');
+  const layout = read('../public/styles/layout.css');
+  const styleDir = new URL('../public/styles/', import.meta.url);
+
+  // 1. Die Layer ist ein Geschwister von .app-content, kein Kind.
+  assert.match(router, /shellNodes\s*=\s*\[[^\]]*\bmain\b\s*,\s*fabLayer\s*,\s*bottomNav/,
+    'die FAB-Layer muss als Shell-Kind zwischen Scrollport und Bottom-Nav hängen (#634)');
+  assert.match(layout, /\.fab-layer\s*\{[^}]*position:\s*absolute/,
+    '.fab-layer braucht einen eigenen Kasten an der Shell-Ecke (#634)');
+
+  // 2. Jede Seite zieht ihren FAB dorthin um - auch die, die ihn erst nach den
+  //    Daten anlegt, und auch die Soft-Navigation zwischen Tabs.
+  assert.ok((router.match(/adoptPageFab\(\)/g) ?? []).length >= 4,
+    'adoptPageFab() muss definiert und an allen Renderpfaden aufgerufen werden (#634)');
+  assert.match(router, /clearPageFab\(\)/,
+    'der FAB der alten Seite muss mit ihrem Inhalt verschwinden, nicht später (#634)');
+
+  // 3. Und niemand adressiert ihn wieder über einen Modul-Vorfahren. Das ist eine
+  //    Regel über alle Stylesheets, keine Allowlist: erlaubt sind nur Wurzeln,
+  //    die den Umzug überleben (Dokument, Shell, Layer).
+  const ALLOWED_ROOT = /^(html|body|:root|\.app-shell|\.fab-layer|\.keyboard-visible)/;
+  for (const file of readdirSync(styleDir).filter((f) => f.endsWith('.css'))) {
+    const live = read(`../public/styles/${file}`).replace(/\/\*[\s\S]*?\*\//g, '');
+    for (const block of live.match(/[^{}]*\{[^}]*\}/g) ?? []) {
+      const selectors = block.slice(0, block.indexOf('{')).split(',');
+      for (const selector of selectors) {
+        if (!selector.includes('.page-fab')) continue;
+        const prefix = selector.slice(0, selector.indexOf('.page-fab')).trim();
+        assert.ok(prefix === '' || ALLOWED_ROOT.test(prefix),
+          `${file}: "${selector.trim()}" adressiert den FAB über einen Modul-Kontext - `
+          + 'seit #634 hängt er in der Shell, die Kette greift nicht mehr');
+      }
     }
   }
 });


### PR DESCRIPTION
Third attempt at #634. The two earlier fixes each removed a mechanism that could hide the FAB (the scroll retract in v1.71.2, the viewport-only keyboard detection in v1.73.1). The reporter saw the same defect after both. What was left is not a mechanism but a **place**.

## The place

`.page-fab` is `position: fixed`, but it was rendered inside the module root and therefore inside `.app-content` - the container that scrolls on most routes. A fixed child of a scroller is not reliably viewport-anchored on iOS: it resolves against the scrolled content, drifts down as the list grows during loading, and has no way back without a repaint.

That accounts for every detail in the report: the button appears mid-right (short skeleton content), then disappears - and it does so exactly in the modules where `.app-content` really scrolls (`/tasks`, `/pantry`), while in others it "reappears bottom right" once loading finishes.

The bottom nav walked into the same trap once and has been `position: relative`, a flex child of the shell, ever since - the reasoning is still written at `.nav-bottom` in `layout.css`. The FAB was the last fixed element left inside the scrollport.

## What changed

- New shell layer `#fab-layer`, a sibling of `.app-content` in front of `.nav-bottom`. It carries no layout (0×0 at the shell corner); the fixed child inside it keeps its exact geometry from the `--fab-*` tokens.
- `adoptPageFab()` in the router lifts the page's FAB there - synchronously right after render starts, again after the data await, and after a soft navigation between tabs. `clearPageFab()` drops it together with the outgoing page.
- Module colour now comes from `--active-module-accent`, which the router already sets per route **and** per theme, because inheritance through the module root ends here.
- The scrollport margin asks at the shell: `.app-shell:has(.fab-layer > .page-fab:not([hidden])) .app-content`.
- `.contacts-page.is-selecting .page-fab` became `html:has(.contacts-page.is-selecting) .page-fab` - the old chain no longer exists after the move.

**The trap this surfaced:** ten modules wired their FAB through `container.querySelector('#fab-…')`. After the move that returns `null` silently - a visible button that does nothing. They now use `findPageFab()` from `utils/fab.js`, and the guard states the rule (which selector roots survive the move) instead of listing today's ten offenders.

## Verification

- `npm test` green, including the new guard *"der Page-FAB hängt in der Shell, nicht im Scrollport"*.
- Playwright WebKit + Chromium, iPhone 13 mini profile, all 15 FAB routes: parent is `fab-layer`, position, colour and clearance unchanged (`top 493 / right 16`, 92px margin), and every FAB still triggers its action. Compared against a `git stash` run of the previous state - identical except for the parent node. Desktop layout and the contacts selection mode checked too.

## Honest caveat

The defect reproduces in neither Chromium nor WebKit; the FAB measures stable there in every position. This is a reasoned hardening, not a proven cause. What it does close is the last way this button can be positioned against anything other than the viewport.

Not touched on purpose: the dashboard speed dial (`#fab-container`, class `.fab`) is still fixed inside the scrollport and even keeps a scroll retract - but that one has a way back through scrolling up, and it was not reported.

Refs #634