### PR TITLE
feat(budget): support revenue subcategories and fix related tests

### DIFF
--- a/public/pages/budget.js
+++ b/public/pages/budget.js
@@ -932,7 +932,7 @@ function renderEntries() {
     const recurTag  = e.is_recurring
       ? ` <span class="budget-recur-mark" role="img" aria-label="${t('budget.recurringLabel')}"><i data-lucide="repeat" class="icon-sm" aria-hidden="true"></i></span>${e.recurrence_virtual ? ' ' + t('budget.virtualBudgetBadge') : ''}`
       : (e.recurrence_parent_id ? ` <span class="budget-recur-mark" role="img" aria-label="${t('budget.recurringInstanceLabel')}"><i data-lucide="corner-down-left" class="icon-sm" aria-hidden="true"></i></span>` : '');
-    const categoryMeta = isIncome || !e.subcategory
+    const categoryMeta = !e.subcategory
       ? categoryLabel(e.category)
       : `${categoryLabel(e.category)} · ${subcategoryLabel(e.subcategory)}`;
     const acctName = accountName(e.account_id);
@@ -1765,7 +1765,7 @@ function openCategoryManager() {
         basePath: '/budget/categories',
         groups: [
           { key: 'expense', labelKey: 'budget.expenses', addLabelKey: 'budget.addCategory', subcategories: true },
-          { key: 'income',  labelKey: 'budget.income',   addLabelKey: 'budget.addCategory' },
+          { key: 'income',  labelKey: 'budget.income',   addLabelKey: 'budget.addCategory', subcategories: true },
         ],
         supportsSubcategories: true,
         labelResolver: (item) => item.label ?? budgetCategoryLabel(item.key, item.name, t),
@@ -1859,6 +1859,14 @@ function openBudgetModal({ mode, entry = null, initialType = '' }) {
       <select class="form-input" id="bm-category">${catOpts}</select>
     </div>
 
+    <div class="form-group js-entry-field" id="bm-subcategory-group">
+      <div class="budget-field-header">
+        <label class="form-label" for="bm-subcategory">${t('budget.subcategoryLabel')}</label>
+        <button class="btn btn--secondary budget-inline-add" type="button" id="bm-add-subcategory">${t('budget.addSubcategory')}</button>
+      </div>
+      <select class="form-input" id="bm-subcategory">${subcatOpts}</select>
+    </div>
+
     <div class="form-group js-entry-field">
       <label class="form-label" for="bm-date">${t('budget.dateLabel')}</label>
       <yuvomi-datepicker type="date" id="bm-date"
@@ -1878,14 +1886,6 @@ function openBudgetModal({ mode, entry = null, initialType = '' }) {
     <div class="js-entry-field">
       ${advancedSection(`
         ${accountField}
-        <div class="form-group" id="bm-subcategory-group" ${isExpense ? '' : 'hidden'}>
-          <div class="budget-field-header">
-            <label class="form-label" for="bm-subcategory">${t('budget.subcategoryLabel')}</label>
-            <button class="btn btn--secondary budget-inline-add" type="button" id="bm-add-subcategory">${t('budget.addSubcategory')}</button>
-          </div>
-          <select class="form-input" id="bm-subcategory">${subcatOpts}</select>
-        </div>
-
         <div class="form-group">
           <label class="toggle">
             <input type="checkbox" id="bm-recurring" ${isEdit && entry.is_recurring ? 'checked' : ''}>
@@ -2012,10 +2012,10 @@ function openBudgetModal({ mode, entry = null, initialType = '' }) {
         const catSelect = panel.querySelector('#bm-category');
         const subcatGroup = panel.querySelector('#bm-subcategory-group');
         const subcatSelect = panel.querySelector('#bm-subcategory');
-        const subcategories = currentType === 'expense' ? getSubcategories(catSelect.value) : [];
+        const subcategories = getSubcategories(catSelect.value);
         const currentValue = preferredSubcategory || subcatSelect.value;
 
-        subcatGroup.hidden = currentType !== 'expense';
+        subcatGroup.hidden = false;
         subcatSelect.replaceChildren(...subcategories.map((s) => {
           const opt = document.createElement('option');
           opt.value = s.key;
@@ -2046,7 +2046,6 @@ function openBudgetModal({ mode, entry = null, initialType = '' }) {
       };
 
       const addSubcategory = async () => {
-        if (currentType !== 'expense') return;
         const category = panel.querySelector('#bm-category').value;
         if (!category) return;
         const name = await requestNameInPanel(panel, {
@@ -2125,7 +2124,7 @@ function openBudgetModal({ mode, entry = null, initialType = '' }) {
         const title      = panel.querySelector('#bm-title').value.trim();
         const absVal     = parseFloat(panel.querySelector('#bm-amount').value);
         const category   = panel.querySelector('#bm-category').value;
-        const subcategory = currentType === 'expense' ? panel.querySelector('#bm-subcategory').value : '';
+        const subcategory = panel.querySelector('#bm-subcategory').value;
         const date       = panel.querySelector('#bm-date').value;
         const recurring  = panel.querySelector('#bm-recurring').checked ? 1 : 0;
         const interval   = panel.querySelector('#bm-interval').value;

--- a/server/routes/budget/categories.js
+++ b/server/routes/budget/categories.js
@@ -179,7 +179,7 @@ router.patch('/categories/reorder', (req, res) => {
 router.post('/categories/:categoryKey/subcategories', (req, res) => {
   try {
     const cat = db.get().prepare(`
-      SELECT * FROM budget_categories WHERE key = ? AND type = 'expense'
+      SELECT * FROM budget_categories WHERE key = ?
     `).get(req.params.categoryKey);
     if (!cat) return res.status(404).json({ error: 'Category not found.', code: 404 });
 

--- a/server/routes/budget/helpers.js
+++ b/server/routes/budget/helpers.js
@@ -484,7 +484,6 @@ export function defaultSubcategory(category) {
 }
 
 export function validateSubcategory(category, subcategory) {
-  if (!validExpenseCategoryKeys().includes(category)) return '';
   if (!subcategory) return defaultSubcategory(category);
   const row = db.get().prepare(`
     SELECT 1 FROM budget_subcategories WHERE category_key = ? AND key = ?

--- a/test/test-budget-categories-routes.js
+++ b/test/test-budget-categories-routes.js
@@ -202,10 +202,11 @@ test('POST subcategories: unbekannte Kategorie → 404', async () => {
   assert.equal(r.status, 404);
 });
 
-test('POST subcategories: income-Kategorie erlaubt keine Subkategorie → 404', async () => {
+test('POST subcategories: income-Kategorie erlaubt keine Subkategorie', async () => {
   const inc = await newCategory('IncCat', 'income');
   const r = await call('POST', `/categories/${inc.key}/subcategories`, { name: 'S' });
-  assert.equal(r.status, 404);
+  assert.equal(r.status, 201);
+  assert.equal(r.body.data.category_key, inc.key);
 });
 
 test('POST subcategories: leerer Name → 400', async () => {

--- a/test/test-detail-view.js
+++ b/test/test-detail-view.js
@@ -19,7 +19,9 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { readFile, readdir } from 'node:fs/promises';
 
-const read = (path) => readFile(new URL(`../${path}`, import.meta.url), 'utf8');
+const read = async (path) => (
+  await readFile(new URL(`../${path}`, import.meta.url), 'utf8')
+).replace(/\r\n/g, '\n');
 
 const detailJs   = () => read('public/components/detail-view.js');
 const detailCss  = () => read('public/styles/detail-view.css');

--- a/test/test-shopping.js
+++ b/test/test-shopping.js
@@ -468,7 +468,7 @@ test('Detail-Refresh aktualisiert die Zeile, ohne das .shopping-item zu ersetzen
   assert(/kitchen-row__meta/.test(fn), 'die Menge muss aktualisiert werden - sie kann auch wegfallen');
   // Ein Kategoriewechsel verschiebt die Zeile in eine andere Gruppe; das kann keine
   // Zeilen-Auffrischung leisten, dafür muss die Liste neu gruppiert werden.
-  const details = source.match(/function openItemDetails[\s\S]*?\n\}\n/)?.[0] ?? '';
+  const details = source.match(/function openItemDetails[\s\S]*?\r?\n\}\r?\n/)?.[0] ?? '';
   assert(/categoryChanged/.test(details), 'ein Kategoriewechsel muss die Gruppierung neu aufbauen');
 });
 


### PR DESCRIPTION
# feat(budget): support revenue subcategories and fix related test failures

## Summary

This Pull Request improves the **Budget** module by adding support for subcategories to **Revenue** categories and improving the **New Entry** form layout.

### Budget

* Move the **Subcategory** field below the **Category** field in the **New Entry** form.
* Allow creating subcategories for **Revenue** categories.
* Keep the subcategory list synchronized with the selected category.
* Allow selecting revenue subcategories when creating or editing budget entries.

## Motivation

Previously, subcategories were only available for expense categories, limiting how revenue entries could be organized.

With this change, revenue categories can now be organized hierarchically. For example:

* Salary

  * Monthly Salary
  * Overtime
  * Bonus

* Investments

  * Dividends
  * Interest
  * Returns

## How to Test

1. Open the **Budget** page.
2. Go to the category manager.
3. Create or edit a **Revenue** category.
4. Create a subcategory for that category.
5. Open the **New Entry** form.
6. Select **Revenue** as the entry type.
7. Select the configured category.
8. Verify that the **Subcategory** field appears directly below the **Category** field.
9. Select a subcategory.
10. Save the entry and verify that it is stored correctly.

## Expected Result

* Revenue categories support subcategories.
* The **Subcategory** field is displayed below the **Category** field.
* Revenue entries can be saved with a selected subcategory.

## Tests

In addition to validating the changes to the **Budget** module, this Pull Request also fixes test failures **that are unrelated to the implemented Budget functionality**:

* ✅ `test/test-shopping.js`

  * `Detail-Refresh aktualisiert die Zeile, ohne das .shopping-item zu ersetzen (Swipe-Closures bleiben intakt): ein Kategoriewechsel muss die Gruppierung neu aufbauen`

* ✅ `test/test-detail-view.js`

  * `Kontaktdaten kommen als Text ins DOM, nie als Markup`

The following test is still failing and **was not fixed** in this Pull Request because it is unrelated to the changes introduced here:

* ⚠️ `test/test-password-normalization.js`

The changes in this Pull Request do not affect the behavior of this test. It will be addressed in a separate Pull Request.
