### PR TITLE
feat(notifications): add generic webhook notification channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Administrators can now send reminders to generic HTTP webhooks alongside Web Push, Gotify, and ntfy. Each webhook receives a documented JSON payload through `POST`, may use an optional write-only Bearer token, can be verified from Notification settings, and participates in the existing per-channel retry and deduplication flow.
+
 ## [1.87.0] - 2026-08-06
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,6 +62,7 @@ npm run test:meals
 npm run test:calendar
 npm run test:ncb            # notes, contacts, budget
 npm run test:reminders
+npm run test:notifications    # Web Push and external notification channels
 npm run test:dashboard
 npm run test:api
 npm run test:ics-parser

--- a/README.de.md
+++ b/README.de.md
@@ -265,7 +265,7 @@ Siebzehn eigenständige Module teilen sich eine ruhige, konsistente Oberfläche.
 | ![notes](https://raw.githubusercontent.com/ulsklyc/yuvomi/main/docs/icons/notes.png) | **Notizen &amp; Kontakte** | Bunte Markdown-Notizzettel plus ein Kontaktverzeichnis mit CardDAV-Sync und vCard-Import/-Export. |
 | ![birthdays](https://raw.githubusercontent.com/ulsklyc/yuvomi/main/docs/icons/birthdays.png) | **Geburtstage** | Geburtstags-Tracker mit automatischen Kalenderterminen, Altersanzeige und Erinnerungen. |
 | ![family](https://raw.githubusercontent.com/ulsklyc/yuvomi/main/docs/icons/family.png) | **Familie** | Mitgliederprofile mit Rollen, Fotos und Kontaktdaten, synchronisiert mit Kontakten und Geburtstagen. Neue Mitglieder kommen über einen Einladungslink dazu und wählen ihr Passwort selbst. |
-| ![reminders](https://raw.githubusercontent.com/ulsklyc/yuvomi/main/docs/icons/reminders.png) | **Erinnerungen** | Erinnerungen zu Aufgaben und Terminen per In-App-Badge, Opt-in-Web-Push und Haushalts-Kanälen über Gotify/ntfy. |
+| ![reminders](https://raw.githubusercontent.com/ulsklyc/yuvomi/main/docs/icons/reminders.png) | **Erinnerungen** | Erinnerungen zu Aufgaben und Terminen per In-App-Badge, Opt-in-Web-Push und Haushalts-Kanälen über Gotify, ntfy oder Webhooks. |
 | ![api-tokens](https://raw.githubusercontent.com/ulsklyc/yuvomi/main/docs/icons/api-tokens.png) | **API-Tokens** | Bearer-/X-API-Key-Tokens mit OpenAPI-3.0-Spec und eingebautem MCP-Endpunkt für KI-Agenten. |
 | ![backup](https://raw.githubusercontent.com/ulsklyc/yuvomi/main/docs/icons/backup.png) | **Backup** | Manuelles und geplantes Datenbank-Backup/-Restore mit Rollback vor dem Zurückspielen und optionalem WebDAV-Upload. |
 
@@ -288,7 +288,7 @@ Siebzehn eigenständige Module teilen sich eine ruhige, konsistente Oberfläche.
 - **Notizen &amp; Kontakte** - Bunte Markdown-Notizzettel, die gerendert im Lesemodus öffnen (Umschalter zum Bearbeiten), mit Volltextsuche, Filter nach Ersteller und vorangestellten angepinnten Notizen, plus ein Kontaktverzeichnis mit CardDAV-Sync und vCard-Import/-Export mehrerer Kontakte. Kontakte folgen derselben Grammatik: Antippen zeigt den Eintrag, bevor es ihn ändern lässt, mit jeder gespeicherten Nummer, Mail und Adresse als eigener Trefferfläche - die Liste bot immer nur die erste davon - und Bearbeiten als eigenem Schritt.
 - **Geburtstage** - Geburtstags-Tracker mit automatischen Kalenderterminen, Altersanzeige, eigenen Erinnerungen und selektivem Import aus synchronisierten Kontakten.
 - **Familie** - Mitgliederprofile mit Rollen, Fotos und Kontaktdaten, synchronisiert mit Kontakten und Geburtstagen.
-- **Erinnerungen** - Erinnerungen zu Aufgaben und Terminen per In-App-Badge, Opt-in-Web-Push (HTTPS) und Haushalts-Kanälen über Gotify/ntfy.
+- **Erinnerungen** - Erinnerungen zu Aufgaben und Terminen per In-App-Badge, Opt-in-Web-Push (HTTPS) und Haushalts-Kanälen über Gotify, ntfy oder generische HTTP-Webhooks. Webhooks senden JSON und unterstützen ein optionales, nur schreibbares Bearer-Token; Details stehen im [Webhook-Leitfaden](docs/notification-webhooks.md).
 - **API-Tokens** - Bearer-/X-API-Key-Tokens mit OpenAPI-3.0-Spec und eingebautem MCP-Endpunkt (`/mcp`), über den KI-Agenten wie Claude Desktop die gesamte API in natürlicher Sprache steuern. Optionale Modul-Scopes (Lesen/Schreiben) halten ein Token - etwa eines für einen KI-Client - von sensiblen Bereichen fern.
 - **Backup** - Manuelles und geplantes Datenbank-Backup/-Restore mit automatischem Rollback vor dem Zurückspielen. Optionales WebDAV-Upload-Ziel (Nextcloud, ownCloud usw.).
 
@@ -438,7 +438,7 @@ Nichts. Yuvomi ist kostenlos und MIT-lizenziert. Du stellst den Server; es gibt 
 
 ## Dokumentation
 
-[Installation](docs/installation.md) &nbsp;·&nbsp; [Spec &amp; Datenmodell](docs/SPEC.md) &nbsp;·&nbsp; [Module](MODULES.md) &nbsp;·&nbsp; [Mitwirken](CONTRIBUTING.md) &nbsp;·&nbsp; [Sicherheit](SECURITY.md) &nbsp;·&nbsp; [Datenschutz für Selbsthoster](docs/PRIVACY-FOR-SELFHOSTERS.md) &nbsp;·&nbsp; [Changelog](CHANGELOG.md) &nbsp;·&nbsp; [Backlog](BACKLOG.md)
+[Installation](docs/installation.md) &nbsp;·&nbsp; [Benachrichtigungs-Webhooks](docs/notification-webhooks.md) &nbsp;·&nbsp; [Spec &amp; Datenmodell](docs/SPEC.md) &nbsp;·&nbsp; [Module](MODULES.md) &nbsp;·&nbsp; [Mitwirken](CONTRIBUTING.md) &nbsp;·&nbsp; [Sicherheit](SECURITY.md) &nbsp;·&nbsp; [Datenschutz für Selbsthoster](docs/PRIVACY-FOR-SELFHOSTERS.md) &nbsp;·&nbsp; [Changelog](CHANGELOG.md) &nbsp;·&nbsp; [Backlog](BACKLOG.md)
 
 Wenn du Yuvomi in einem DSGVO-Kontext selbst hostest (EU/EWR, Verarbeitung fremder Daten), lies [docs/PRIVACY-FOR-SELFHOSTERS.md](docs/PRIVACY-FOR-SELFHOSTERS.md) vor dem Produktivbetrieb: Es behandelt Drittland-Bewertungen für jeden externen Dienst (Wetter, CalDAV/CardDAV, OIDC, WebDAV-Backup und Dokumentenspeicher), Hinweise zu Auftragsverarbeitungsverträgen, Empfehlungen zur Log-Aufbewahrung und eine Vorlage für das Verzeichnis von Verarbeitungstätigkeiten.
 

--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ Seventeen independent modules share one calm, consistent interface. Turn on what
 | ![notes](https://raw.githubusercontent.com/ulsklyc/yuvomi/main/docs/icons/notes.png) | **Notes &amp; Contacts** | Colored Markdown sticky notes plus a contact directory with CardDAV sync and vCard import/export. |
 | ![birthdays](https://raw.githubusercontent.com/ulsklyc/yuvomi/main/docs/icons/birthdays.png) | **Birthdays** | Birthday tracker with automatic calendar events, age display and reminders. |
 | ![family](https://raw.githubusercontent.com/ulsklyc/yuvomi/main/docs/icons/family.png) | **Family** | Member profiles with roles, photos and contact details, synced to Contacts and Birthdays. New members join through an invite link and pick their own password. |
-| ![reminders](https://raw.githubusercontent.com/ulsklyc/yuvomi/main/docs/icons/reminders.png) | **Reminders** | Task and calendar reminders via in-app badges, opt-in Web Push and household Gotify/ntfy channels. |
+| ![reminders](https://raw.githubusercontent.com/ulsklyc/yuvomi/main/docs/icons/reminders.png) | **Reminders** | Task and calendar reminders via in-app badges, opt-in Web Push and household Gotify, ntfy or webhook channels. |
 | ![api-tokens](https://raw.githubusercontent.com/ulsklyc/yuvomi/main/docs/icons/api-tokens.png) | **API Tokens** | Bearer / X-API-Key tokens with an OpenAPI 3.0 spec and a built-in MCP endpoint for AI agents. |
 | ![backup](https://raw.githubusercontent.com/ulsklyc/yuvomi/main/docs/icons/backup.png) | **Backup** | Manual and scheduled database backup/restore with pre-restore rollback and optional WebDAV upload. |
 
@@ -288,7 +288,7 @@ Seventeen independent modules share one calm, consistent interface. Turn on what
 - **Notes &amp; Contacts** - Colored Markdown sticky notes that open in a rendered reader view (toggle to edit), with full-text search, a per-author filter and pinned notes grouped up front, plus a contact directory with CardDAV sync and multi-contact vCard import/export. Contacts follow the same grammar: tapping one shows it before it lets you change it, with every stored number, mail and address as its own tap target - the list only ever offered the first of each - and editing as a separate step.
 - **Birthdays** - Birthday tracker with automatic calendar events, age display, custom reminders, and selective import from synced contacts.
 - **Family** - Member profiles with roles, photos, and contact details, synced to Contacts and Birthdays.
-- **Reminders** - Task and calendar reminders via in-app badges, opt-in Web Push (HTTPS), and household Gotify/ntfy channels.
+- **Reminders** - Task and calendar reminders via in-app badges, opt-in Web Push (HTTPS), and household Gotify, ntfy or generic HTTP webhook channels. Webhooks send a JSON payload and support an optional write-only Bearer token; see the [notification webhook guide](docs/notification-webhooks.md).
 - **API Tokens** - Bearer / X-API-Key tokens with an OpenAPI 3.0 spec and a built-in MCP endpoint (`/mcp`) that lets AI agents like Claude Desktop drive the whole API in natural language. Optional per-module read/write scopes keep a token, for example one handed to an AI client, off sensitive areas.
 - **Backup** - Manual and scheduled database backup/restore with pre-restore rollback. Optional WebDAV upload (Nextcloud, ownCloud, etc.).
 
@@ -438,7 +438,7 @@ Nothing. Yuvomi is free and MIT-licensed. You provide the server; there is no su
 
 ## Documentation
 
-[Installation](docs/installation.md) &nbsp;·&nbsp; [Spec &amp; data model](docs/SPEC.md) &nbsp;·&nbsp; [Third-party modules](MODULES.md) &nbsp;·&nbsp; [Contributing](CONTRIBUTING.md) &nbsp;·&nbsp; [Security](SECURITY.md) &nbsp;·&nbsp; [Privacy for self-hosters](docs/PRIVACY-FOR-SELFHOSTERS.md) &nbsp;·&nbsp; [Changelog](CHANGELOG.md) &nbsp;·&nbsp; [Backlog](BACKLOG.md)
+[Installation](docs/installation.md) &nbsp;·&nbsp; [Notification webhooks](docs/notification-webhooks.md) &nbsp;·&nbsp; [Spec &amp; data model](docs/SPEC.md) &nbsp;·&nbsp; [Third-party modules](MODULES.md) &nbsp;·&nbsp; [Contributing](CONTRIBUTING.md) &nbsp;·&nbsp; [Security](SECURITY.md) &nbsp;·&nbsp; [Privacy for self-hosters](docs/PRIVACY-FOR-SELFHOSTERS.md) &nbsp;·&nbsp; [Changelog](CHANGELOG.md) &nbsp;·&nbsp; [Backlog](BACKLOG.md)
 
 If you self-host Yuvomi in a GDPR context (EU/EEA, processing other people's data), read [docs/PRIVACY-FOR-SELFHOSTERS.md](docs/PRIVACY-FOR-SELFHOSTERS.md) before going live. It covers third-country assessments for every external service (weather, CalDAV/CardDAV, OIDC, WebDAV backup and document storage), data-processing-agreement notes, log-retention guidance, and a records-of-processing template.
 

--- a/docs/notification-webhooks.md
+++ b/docs/notification-webhooks.md
@@ -1,0 +1,56 @@
+# Notification webhooks
+
+Yuvomi can deliver every due reminder to a generic HTTP webhook in addition to
+Web Push, Gotify, and ntfy. Webhook channels use the same per-channel delivery
+tracking, retry, and deduplication flow as the other notification providers.
+
+## Configure a channel
+
+Only administrators can manage household notification channels.
+
+1. Open **Settings → Personal → Notifications**.
+2. Under **Household channels**, select **Add channel**.
+3. Choose **Webhook** as the provider and enter a name.
+4. Enter the complete HTTP or HTTPS endpoint URL.
+5. Optionally enter a Bearer token. Yuvomi stores it as a write-only secret and
+   sends it as `Authorization: Bearer <token>`.
+6. Save the channel, enable it, and use **Send test** to verify the endpoint.
+
+The receiver must return a successful HTTP status (`2xx`). Failed deliveries
+are retried by the notification scheduler with the same backoff and attempt
+limit used for Gotify and ntfy. Secrets are never returned by the channel API
+or written into delivery error messages.
+
+## Request format
+
+Yuvomi sends an HTTP `POST` with `Content-Type: application/json`:
+
+```json
+{
+  "event": "notification",
+  "notification": {
+    "title": "Yuvomi",
+    "body": "Take out the bins",
+    "url": "/reminders",
+    "tag": "reminder-42",
+    "priority": "default"
+  },
+  "sentAt": "2026-08-06T20:30:00.000Z"
+}
+```
+
+`sentAt` is generated for each delivery attempt. The notification `tag`
+identifies the reminder and can be used by receivers for their own
+deduplication. The `url` is relative to the Yuvomi application.
+
+## Security notes
+
+- Use HTTPS whenever the endpoint is outside a trusted private network.
+- Give the webhook a dedicated, revocable token with only the permissions it
+  needs.
+- Treat notification bodies as household data. The receiving service gets the
+  reminder title and, for subscriptions, the name, amount, currency, and next
+  renewal date.
+- Rotate a token by entering a replacement in the channel form. Leaving the
+  field empty preserves the stored token.
+

--- a/docs/test-suites.md
+++ b/docs/test-suites.md
@@ -88,7 +88,7 @@ npm run test:password-reset # Reset tokens: create/verify/consume/cleanup + forg
 npm run test:admin-password-reset # PATCH /auth/users/:id password field: admin sets existing member's password (#372)
 npm run test:password-normalization # Passwort-Unicode: NFC-Hashing, Login mit NFD-Eingabe (Firefox/macOS), stille Migration alter NFD-Hashes, /me/password (#608)
 npm run test:invites        # Einladungslinks: Token-Lebenszyklus (nur der Hash liegt in der DB, alle vier Ausschlussgründe beim Prüfen, Einlösen markiert statt löscht) + Routen: requireAdmin-Gate, CSRF, und Rolle/Familienrolle stammen aus der Einladung, nie aus dem Body des Eingeladenen
-npm run test:notifications  # Notification-Kanäle (Gotify/ntfy): Provider-Mapping, Reminder-Fan-out, Admin-Routen, Payload-Body je entity_type (#581)
+npm run test:notifications  # Notification-Kanäle (Gotify/ntfy/Webhook): Provider-Mapping inkl. JSON/Bearer-Auth, Reminder-Fan-out, Admin-Routen, Payload-Body je entity_type (#581)
 npm run test:mcp            # MCP-Server: JSON-RPC-Dispatch (initialize/tools/list/tools/call) + Tool-Logik (Tasks, Shopping, Kalender)
 npm run test:token-scopes   # API-/MCP-Token-Scopes: scopes.js-Modell + Enforcement (tools/list-Filter, tools/call-Deny)
 npm run test:permissions    # Rollen & Rechte: Resolver (Admin-Bypass, Rolle/Mitglied-Override, Widget-Kaskade), Session-Enforcement-Map, Sparse-Speicherung (#467); dazu der Abgleich der drei Widget-Listen (WIDGET_IDS in dashboard.js, PERMISSION_WIDGETS serverseitig, WIDGET_LABEL_KEYS in der Rechte-UI) - ein neues Widget fehlt sonst still in den Rechten oder trägt dort seinen rohen Slug

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "yuvomi",
   "version": "1.87.0",
-  "description": "Self-hosted family planner - calendar, tasks, shopping, meal planning, budget and more. Private, open-source, no subscription.",
+  "description": "Self-hosted family planner with calendar, tasks, shopping, meal planning, budget, and Web Push, Gotify, ntfy, or webhook notifications.",
   "main": "server/index.js",
   "type": "module",
   "engines": {

--- a/public/locales/ar.json
+++ b/public/locales/ar.json
@@ -2070,6 +2070,7 @@
         "notificationChannelNtfyToken": "رمز ntfy",
         "notificationChannelNtfyUsername": "اسم مستخدم ntfy",
         "notificationChannelNtfyPassword": "كلمة مرور ntfy",
+        "notificationChannelWebhookToken": "رمز Bearer (اختياري)",
         "notificationChannelSave": "حفظ القناة",
         "notificationChannelSaved": "تم حفظ القناة.",
         "notificationChannelTest": "إرسال اختبار",

--- a/public/locales/cs.json
+++ b/public/locales/cs.json
@@ -2070,6 +2070,7 @@
         "notificationChannelNtfyToken": "Token ntfy",
         "notificationChannelNtfyUsername": "Uživatelské jméno ntfy",
         "notificationChannelNtfyPassword": "Heslo ntfy",
+        "notificationChannelWebhookToken": "Bearer token (volitelný)",
         "notificationChannelSave": "Uložit kanál",
         "notificationChannelSaved": "Kanál uložen.",
         "notificationChannelTest": "Odeslat test",

--- a/public/locales/de.json
+++ b/public/locales/de.json
@@ -2103,6 +2103,7 @@
         "notificationChannelNtfyToken": "ntfy Token",
         "notificationChannelNtfyUsername": "ntfy Benutzername",
         "notificationChannelNtfyPassword": "ntfy Passwort",
+        "notificationChannelWebhookToken": "Bearer-Token (optional)",
         "notificationChannelSave": "Kanal speichern",
         "notificationChannelSaved": "Kanal gespeichert.",
         "notificationChannelTest": "Test senden",

--- a/public/locales/el.json
+++ b/public/locales/el.json
@@ -2070,6 +2070,7 @@
         "notificationChannelNtfyToken": "Token ntfy",
         "notificationChannelNtfyUsername": "Όνομα χρήστη ntfy",
         "notificationChannelNtfyPassword": "Κωδικός ntfy",
+        "notificationChannelWebhookToken": "Διακριτικό Bearer (προαιρετικό)",
         "notificationChannelSave": "Αποθήκευση καναλιού",
         "notificationChannelSaved": "Το κανάλι αποθηκεύτηκε.",
         "notificationChannelTest": "Αποστολή δοκιμής",

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -2091,6 +2091,7 @@
         "notificationChannelNtfyToken": "ntfy token",
         "notificationChannelNtfyUsername": "ntfy username",
         "notificationChannelNtfyPassword": "ntfy password",
+        "notificationChannelWebhookToken": "Bearer token (optional)",
         "notificationChannelSave": "Save channel",
         "notificationChannelSaved": "Channel saved.",
         "notificationChannelTest": "Send test",

--- a/public/locales/es.json
+++ b/public/locales/es.json
@@ -2070,6 +2070,7 @@
         "notificationChannelNtfyToken": "Token ntfy",
         "notificationChannelNtfyUsername": "Usuario ntfy",
         "notificationChannelNtfyPassword": "Contraseña ntfy",
+        "notificationChannelWebhookToken": "Token Bearer (opcional)",
         "notificationChannelSave": "Guardar canal",
         "notificationChannelSaved": "Canal guardado.",
         "notificationChannelTest": "Enviar prueba",

--- a/public/locales/fa.json
+++ b/public/locales/fa.json
@@ -2082,6 +2082,7 @@
         "notificationChannelNtfyToken": "توکن ntfy",
         "notificationChannelNtfyUsername": "نام کاربری ntfy",
         "notificationChannelNtfyPassword": "رمز عبور ntfy",
+        "notificationChannelWebhookToken": "توکن Bearer (اختیاری)",
         "notificationChannelSave": "ذخیره کانال",
         "notificationChannelSaved": "کانال ذخیره شد.",
         "notificationChannelTest": "ارسال آزمایشی",

--- a/public/locales/fil.json
+++ b/public/locales/fil.json
@@ -2103,6 +2103,7 @@
         "notificationChannelNtfyToken": "Token ng ntfy",
         "notificationChannelNtfyUsername": "Username ng ntfy",
         "notificationChannelNtfyPassword": "Password ng ntfy",
+        "notificationChannelWebhookToken": "Bearer token (opsyonal)",
         "notificationChannelSave": "I-save ang channel",
         "notificationChannelSaved": "Na-save ang channel.",
         "notificationChannelTest": "Magpadala ng pansubok",

--- a/public/locales/fr.json
+++ b/public/locales/fr.json
@@ -2070,6 +2070,7 @@
         "notificationChannelNtfyToken": "Jeton ntfy",
         "notificationChannelNtfyUsername": "Nom d’utilisateur ntfy",
         "notificationChannelNtfyPassword": "Mot de passe ntfy",
+        "notificationChannelWebhookToken": "Jeton Bearer (facultatif)",
         "notificationChannelSave": "Enregistrer le canal",
         "notificationChannelSaved": "Canal enregistré.",
         "notificationChannelTest": "Envoyer un test",

--- a/public/locales/hi.json
+++ b/public/locales/hi.json
@@ -2070,6 +2070,7 @@
         "notificationChannelNtfyToken": "ntfy टोकन",
         "notificationChannelNtfyUsername": "ntfy उपयोगकर्ता नाम",
         "notificationChannelNtfyPassword": "ntfy पासवर्ड",
+        "notificationChannelWebhookToken": "Bearer टोकन (वैकल्पिक)",
         "notificationChannelSave": "चैनल सहेजें",
         "notificationChannelSaved": "चैनल सहेजा गया।",
         "notificationChannelTest": "टेस्ट भेजें",

--- a/public/locales/hu.json
+++ b/public/locales/hu.json
@@ -2070,6 +2070,7 @@
         "notificationChannelNtfyToken": "ntfy token",
         "notificationChannelNtfyUsername": "ntfy felhasználónév",
         "notificationChannelNtfyPassword": "ntfy jelszó",
+        "notificationChannelWebhookToken": "Bearer token (opcionális)",
         "notificationChannelSave": "Csatorna mentése",
         "notificationChannelSaved": "Csatorna mentve.",
         "notificationChannelTest": "Teszt küldése",

--- a/public/locales/id.json
+++ b/public/locales/id.json
@@ -2082,6 +2082,7 @@
         "notificationChannelNtfyToken": "Token ntfy",
         "notificationChannelNtfyUsername": "Nama pengguna ntfy",
         "notificationChannelNtfyPassword": "Kata sandi ntfy",
+        "notificationChannelWebhookToken": "Token Bearer (opsional)",
         "notificationChannelSave": "Simpan saluran",
         "notificationChannelSaved": "Saluran disimpan.",
         "notificationChannelTest": "Kirim uji",

--- a/public/locales/it.json
+++ b/public/locales/it.json
@@ -2070,6 +2070,7 @@
         "notificationChannelNtfyToken": "Token ntfy",
         "notificationChannelNtfyUsername": "Nome utente ntfy",
         "notificationChannelNtfyPassword": "Password ntfy",
+        "notificationChannelWebhookToken": "Token Bearer (facoltativo)",
         "notificationChannelSave": "Salva canale",
         "notificationChannelSaved": "Canale salvato.",
         "notificationChannelTest": "Invia test",

--- a/public/locales/ja.json
+++ b/public/locales/ja.json
@@ -2070,6 +2070,7 @@
         "notificationChannelNtfyToken": "ntfy トークン",
         "notificationChannelNtfyUsername": "ntfy ユーザー名",
         "notificationChannelNtfyPassword": "ntfy パスワード",
+        "notificationChannelWebhookToken": "Bearer トークン（任意）",
         "notificationChannelSave": "チャンネルを保存",
         "notificationChannelSaved": "チャンネルを保存しました。",
         "notificationChannelTest": "テストを送信",

--- a/public/locales/ko.json
+++ b/public/locales/ko.json
@@ -2082,6 +2082,7 @@
         "notificationChannelNtfyToken": "ntfy 토큰",
         "notificationChannelNtfyUsername": "ntfy 사용자 이름",
         "notificationChannelNtfyPassword": "ntfy 비밀번호",
+        "notificationChannelWebhookToken": "Bearer 토큰(선택 사항)",
         "notificationChannelSave": "채널 저장",
         "notificationChannelSaved": "채널이 저장되었습니다.",
         "notificationChannelTest": "테스트 보내기",

--- a/public/locales/nl.json
+++ b/public/locales/nl.json
@@ -2070,6 +2070,7 @@
         "notificationChannelNtfyToken": "ntfy-token",
         "notificationChannelNtfyUsername": "ntfy-gebruikersnaam",
         "notificationChannelNtfyPassword": "ntfy-wachtwoord",
+        "notificationChannelWebhookToken": "Bearer-token (optioneel)",
         "notificationChannelSave": "Kanaal opslaan",
         "notificationChannelSaved": "Kanaal opgeslagen.",
         "notificationChannelTest": "Test verzenden",

--- a/public/locales/pl.json
+++ b/public/locales/pl.json
@@ -2082,6 +2082,7 @@
         "notificationChannelNtfyToken": "Token ntfy",
         "notificationChannelNtfyUsername": "Nazwa użytkownika ntfy",
         "notificationChannelNtfyPassword": "Hasło ntfy",
+        "notificationChannelWebhookToken": "Token Bearer (opcjonalnie)",
         "notificationChannelSave": "Zapisz kanał",
         "notificationChannelSaved": "Kanał zapisany.",
         "notificationChannelTest": "Wyślij test",

--- a/public/locales/pt.json
+++ b/public/locales/pt.json
@@ -2070,6 +2070,7 @@
         "notificationChannelNtfyToken": "Token ntfy",
         "notificationChannelNtfyUsername": "Nome de usuário ntfy",
         "notificationChannelNtfyPassword": "Senha ntfy",
+        "notificationChannelWebhookToken": "Token Bearer (opcional)",
         "notificationChannelSave": "Salvar canal",
         "notificationChannelSaved": "Canal salvo.",
         "notificationChannelTest": "Enviar teste",

--- a/public/locales/ru.json
+++ b/public/locales/ru.json
@@ -2070,6 +2070,7 @@
         "notificationChannelNtfyToken": "Токен ntfy",
         "notificationChannelNtfyUsername": "Имя пользователя ntfy",
         "notificationChannelNtfyPassword": "Пароль ntfy",
+        "notificationChannelWebhookToken": "Bearer-токен (необязательно)",
         "notificationChannelSave": "Сохранить канал",
         "notificationChannelSaved": "Канал сохранён.",
         "notificationChannelTest": "Отправить тест",

--- a/public/locales/sv.json
+++ b/public/locales/sv.json
@@ -2070,6 +2070,7 @@
         "notificationChannelNtfyToken": "ntfy-token",
         "notificationChannelNtfyUsername": "ntfy-användarnamn",
         "notificationChannelNtfyPassword": "ntfy-lösenord",
+        "notificationChannelWebhookToken": "Bearer-token (valfritt)",
         "notificationChannelSave": "Spara kanal",
         "notificationChannelSaved": "Kanal sparad.",
         "notificationChannelTest": "Skicka test",

--- a/public/locales/tr.json
+++ b/public/locales/tr.json
@@ -2070,6 +2070,7 @@
         "notificationChannelNtfyToken": "ntfy tokenı",
         "notificationChannelNtfyUsername": "ntfy kullanıcı adı",
         "notificationChannelNtfyPassword": "ntfy parolası",
+        "notificationChannelWebhookToken": "Bearer tokenı (isteğe bağlı)",
         "notificationChannelSave": "Kanalı kaydet",
         "notificationChannelSaved": "Kanal kaydedildi.",
         "notificationChannelTest": "Test gönder",

--- a/public/locales/uk.json
+++ b/public/locales/uk.json
@@ -2070,6 +2070,7 @@
         "notificationChannelNtfyToken": "Токен ntfy",
         "notificationChannelNtfyUsername": "Ім’я користувача ntfy",
         "notificationChannelNtfyPassword": "Пароль ntfy",
+        "notificationChannelWebhookToken": "Bearer-токен (необов’язково)",
         "notificationChannelSave": "Зберегти канал",
         "notificationChannelSaved": "Канал збережено.",
         "notificationChannelTest": "Надіслати тест",

--- a/public/locales/vi.json
+++ b/public/locales/vi.json
@@ -2070,6 +2070,7 @@
         "notificationChannelNtfyToken": "Token ntfy",
         "notificationChannelNtfyUsername": "Tên người dùng ntfy",
         "notificationChannelNtfyPassword": "Mật khẩu ntfy",
+        "notificationChannelWebhookToken": "Mã Bearer (không bắt buộc)",
         "notificationChannelSave": "Lưu kênh",
         "notificationChannelSaved": "Đã lưu kênh.",
         "notificationChannelTest": "Gửi thử",

--- a/public/locales/zh.json
+++ b/public/locales/zh.json
@@ -2070,6 +2070,7 @@
         "notificationChannelNtfyToken": "ntfy 令牌",
         "notificationChannelNtfyUsername": "ntfy 用户名",
         "notificationChannelNtfyPassword": "ntfy 密码",
+        "notificationChannelWebhookToken": "Bearer 令牌（可选）",
         "notificationChannelSave": "保存频道",
         "notificationChannelSaved": "频道已保存。",
         "notificationChannelTest": "发送测试",

--- a/public/settings/pages/notifications.js
+++ b/public/settings/pages/notifications.js
@@ -12,6 +12,7 @@ import { toggleRowHtml } from '/settings/components.js';
 const DEFAULT_PROVIDERS = [
   { id: 'gotify', name: 'Gotify' },
   { id: 'ntfy', name: 'ntfy' },
+  { id: 'webhook', name: 'Webhook' },
 ];
 
 function selected(value, expected) {
@@ -19,21 +20,31 @@ function selected(value, expected) {
 }
 
 function channelDefaults(provider = 'gotify') {
-  return provider === 'ntfy'
-    ? {
-        provider: 'ntfy',
-        name: '',
-        enabled: false,
-        config: { baseUrl: '', topic: '', priority: 'default', authType: 'none' },
-        secretSet: false,
-      }
-    : {
-        provider: 'gotify',
-        name: '',
-        enabled: false,
-        config: { baseUrl: '', priority: 5 },
-        secretSet: false,
-      };
+  if (provider === 'ntfy') {
+    return {
+      provider: 'ntfy',
+      name: '',
+      enabled: false,
+      config: { baseUrl: '', topic: '', priority: 'default', authType: 'none' },
+      secretSet: false,
+    };
+  }
+  if (provider === 'webhook') {
+    return {
+      provider: 'webhook',
+      name: '',
+      enabled: false,
+      config: { baseUrl: '' },
+      secretSet: false,
+    };
+  }
+  return {
+    provider: 'gotify',
+    name: '',
+    enabled: false,
+    config: { baseUrl: '', priority: 5 },
+    secretSet: false,
+  };
 }
 
 function renderPage(container, user) {
@@ -111,6 +122,7 @@ function renderChannelList(container, channels, providers = DEFAULT_PROVIDERS) {
     const channel = { ...channelDefaults(rawChannel.provider), ...rawChannel, config: { ...channelDefaults(rawChannel.provider).config, ...(rawChannel.config || {}) } };
     const suffix = channel.id ? `existing-${channel.id}` : `new-${index}`;
     const isNtfy = channel.provider === 'ntfy';
+    const isWebhook = channel.provider === 'webhook';
     list.insertAdjacentHTML('beforeend', `
       <form class="settings-card settings-form notification-channel-form" data-channel-index="${index}" data-channel-id="${esc(channel.id ?? '')}">
         <h3 class="settings-card__title">${esc(channel.name || t('settings.notificationChannelAdd'))}</h3>
@@ -133,7 +145,7 @@ function renderChannelList(container, channels, providers = DEFAULT_PROVIDERS) {
           <label class="form-label" for="notification-base-url-${suffix}">${t('settings.notificationChannelBaseUrl')}</label>
           <input class="form-input" id="notification-base-url-${suffix}" name="baseUrl" value="${esc(channel.config.baseUrl)}" required>
         </div>
-        <div class="notification-provider-fields notification-provider-fields--gotify${isNtfy ? ' settings-card--hidden' : ''}">
+        <div class="notification-provider-fields notification-provider-fields--gotify${channel.provider === 'gotify' ? '' : ' settings-card--hidden'}">
           <div class="form-field">
             <label class="form-label" for="notification-gotify-token-${suffix}">${t('settings.notificationChannelGotifyToken')}</label>
             <input class="form-input" id="notification-gotify-token-${suffix}" name="gotifyToken" type="password" autocomplete="new-password" placeholder="${channel.secretSet ? esc(t('settings.notificationChannelSecretKeep')) : ''}">
@@ -141,6 +153,12 @@ function renderChannelList(container, channels, providers = DEFAULT_PROVIDERS) {
           <div class="form-field">
             <label class="form-label" for="notification-gotify-priority-${suffix}">${t('settings.notificationChannelGotifyPriority')}</label>
             <input class="form-input" id="notification-gotify-priority-${suffix}" name="gotifyPriority" type="number" min="1" max="10" value="${esc(channel.config.priority ?? 5)}">
+          </div>
+        </div>
+        <div class="notification-provider-fields notification-provider-fields--webhook${isWebhook ? '' : ' settings-card--hidden'}">
+          <div class="form-field">
+            <label class="form-label" for="notification-webhook-token-${suffix}">${t('settings.notificationChannelWebhookToken')}</label>
+            <input class="form-input" id="notification-webhook-token-${suffix}" name="webhookToken" type="password" autocomplete="new-password" placeholder="${channel.secretSet ? esc(t('settings.notificationChannelSecretKeep')) : ''}">
           </div>
         </div>
         <div class="notification-provider-fields notification-provider-fields--ntfy${isNtfy ? '' : ' settings-card--hidden'}">
@@ -208,6 +226,8 @@ function readChannelForm(form) {
       if (form.elements.ntfyUsername.value) body.secrets.username = form.elements.ntfyUsername.value;
       if (form.elements.ntfyPassword.value) body.secrets.password = form.elements.ntfyPassword.value;
     }
+  } else if (provider === 'webhook') {
+    if (form.elements.webhookToken.value) body.secrets.token = form.elements.webhookToken.value;
   } else {
     body.config.priority = Number(form.elements.gotifyPriority.value || 5);
     if (form.elements.gotifyToken.value) body.secrets.appToken = form.elements.gotifyToken.value;
@@ -220,6 +240,7 @@ function updateProviderVisibility(form) {
   const provider = form.elements.provider.value;
   form.querySelector('.notification-provider-fields--gotify')?.classList.toggle('settings-card--hidden', provider !== 'gotify');
   form.querySelector('.notification-provider-fields--ntfy')?.classList.toggle('settings-card--hidden', provider !== 'ntfy');
+  form.querySelector('.notification-provider-fields--webhook')?.classList.toggle('settings-card--hidden', provider !== 'webhook');
   const auth = form.elements.ntfyAuth?.value || 'none';
   form.querySelector('.notification-ntfy-token-field')?.classList.toggle('settings-card--hidden', auth !== 'token');
   form.querySelectorAll('.notification-ntfy-basic-field').forEach((field) => {

--- a/server/services/notification-channels.js
+++ b/server/services/notification-channels.js
@@ -8,6 +8,7 @@ import * as dbModule from '../db.js';
 export const NOTIFICATION_PROVIDERS = [
   { id: 'gotify', name: 'Gotify' },
   { id: 'ntfy', name: 'ntfy' },
+  { id: 'webhook', name: 'Webhook' },
 ];
 
 const PROVIDER_IDS = new Set(NOTIFICATION_PROVIDERS.map((p) => p.id));
@@ -106,6 +107,14 @@ function validateNtfy({ config, secrets, requireSecrets }) {
   }
 }
 
+function normalizeWebhookConfig(input = {}) {
+  return { baseUrl: normalizeBaseUrl(input.baseUrl) };
+}
+
+function normalizeWebhookSecrets(input = {}) {
+  return { token: String(input.token ?? '').trim() };
+}
+
 export function normalizeChannelInput(input = {}, existing = null) {
   const provider = existing?.provider || normalizeProvider(input.provider);
   normalizeProvider(provider);
@@ -122,10 +131,13 @@ export function normalizeChannelInput(input = {}, existing = null) {
     config = normalizeGotifyConfig(mergedConfig);
     secrets = normalizeGotifySecrets(mergedSecrets);
     validateGotify({ secrets, requireSecrets: !existing });
-  } else {
+  } else if (provider === 'ntfy') {
     config = normalizeNtfyConfig(mergedConfig);
     secrets = normalizeNtfySecrets(mergedSecrets);
     validateNtfy({ config, secrets, requireSecrets: !existing || input.secrets !== undefined });
+  } else {
+    config = normalizeWebhookConfig(mergedConfig);
+    secrets = normalizeWebhookSecrets(mergedSecrets);
   }
 
   return {

--- a/server/services/notification-providers/webhook.js
+++ b/server/services/notification-providers/webhook.js
@@ -1,0 +1,34 @@
+/**
+ * Generic JSON webhook notification provider.
+ */
+
+function httpError(status) {
+  if (status === 401 || status === 403) return new Error('Webhook authentication failed.');
+  if (status === 404) return new Error('Webhook endpoint was not found.');
+  return new Error(`Webhook returned HTTP ${status}`);
+}
+
+export const webhookProvider = {
+  id: 'webhook',
+
+  async send({ channel, payload, fetchImpl = fetch, signal } = {}) {
+    const headers = { 'content-type': 'application/json' };
+    const token = String(channel?.secrets?.token ?? '');
+    if (token) headers.authorization = `Bearer ${token}`;
+
+    const response = await fetchImpl(channel.config.baseUrl, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        event: 'notification',
+        notification: payload,
+        sentAt: new Date().toISOString(),
+      }),
+      signal,
+    });
+    if (!response.ok) throw httpError(response.status);
+    return { ok: true, status: response.status };
+  },
+};
+
+export default webhookProvider;

--- a/server/services/notifications.js
+++ b/server/services/notifications.js
@@ -9,6 +9,7 @@ import { pushService as defaultPushService } from './push.js';
 import { createNotificationChannelStore } from './notification-channels.js';
 import { gotifyProvider } from './notification-providers/gotify.js';
 import { ntfyProvider } from './notification-providers/ntfy.js';
+import { webhookProvider } from './notification-providers/webhook.js';
 import { syncAllBirthdayReminders } from './birthdays.js';
 
 const log = createLogger('Notifications');
@@ -23,6 +24,7 @@ const PROVIDER_TIMEOUT_MS = 8_000;
 export const defaultProviders = {
   gotify: gotifyProvider,
   ntfy: ntfyProvider,
+  webhook: webhookProvider,
 };
 
 function iso(value) {

--- a/test/test-notifications.js
+++ b/test/test-notifications.js
@@ -134,6 +134,7 @@ test('channel store validates providers, URLs, and required secrets', async () =
   assert.throws(() => store.createChannel({ provider: 'ntfy', name: 'Bad', config: { baseUrl: 'https://ntfy.test' }, secrets: {} }), /topic/i);
   assert.throws(() => store.createChannel({ provider: 'ntfy', name: 'Bad', config: { baseUrl: 'https://ntfy.test', topic: 'family', authType: 'token' }, secrets: {} }), /token/i);
   assert.throws(() => store.createChannel({ provider: 'gotify', name: 'Bad', config: { baseUrl: 'file:///tmp/x' }, secrets: { appToken: 'x' } }), /scheme/i);
+  assert.throws(() => store.createChannel({ provider: 'webhook', name: 'Bad', config: { baseUrl: 'javascript:alert(1)' } }), /scheme/i);
   assert.throws(() => store.createChannel({ provider: 'smtp', name: 'Bad', config: {}, secrets: {} }), /provider/i);
 });
 
@@ -201,6 +202,30 @@ test('ntfy provider maps reminder payload with bearer auth', async () => {
   assert.equal(calls[0].options.headers.Click, '/reminders');
   assert.equal(calls[0].options.headers.Authorization, 'Bearer token-value');
   assert.equal(calls[0].options.body, 'Müll rausbringen');
+});
+
+test('webhook provider posts a JSON notification with optional bearer auth', async () => {
+  const { webhookProvider } = await import('../server/services/notification-providers/webhook.js');
+  const calls = [];
+  await webhookProvider.send({
+    channel: {
+      config: { baseUrl: 'https://hooks.example.test/yuvomi' },
+      secrets: { token: 'hook-secret' },
+    },
+    payload: { title: 'Yuvomi', body: 'Task', url: '/reminders', tag: 'reminder-1', priority: 'default' },
+    fetchImpl: async (url, options) => {
+      calls.push({ url, options });
+      return { ok: true, status: 204 };
+    },
+  });
+  assert.equal(calls[0].url, 'https://hooks.example.test/yuvomi');
+  assert.equal(calls[0].options.method, 'POST');
+  assert.equal(calls[0].options.headers.authorization, 'Bearer hook-secret');
+  assert.equal(calls[0].options.headers['content-type'], 'application/json');
+  const body = JSON.parse(calls[0].options.body);
+  assert.equal(body.event, 'notification');
+  assert.equal(body.notification.body, 'Task');
+  assert.match(body.sentAt, /^\d{4}-\d{2}-\d{2}T/);
 });
 
 test('providers throw sanitized HTTP errors', async () => {
@@ -383,6 +408,7 @@ test('admin notification routes manage channels and test sends', async () => {
   const routeProviders = {
     gotify: { id: 'gotify', send: async ({ payload }) => { sent.push(payload); return { ok: true, status: 200 }; } },
     ntfy: { id: 'ntfy', send: async () => ({ ok: true, status: 200 }) },
+    webhook: { id: 'webhook', send: async () => ({ ok: true, status: 204 }) },
   };
   const router = buildRouter({
     database: db,
@@ -406,7 +432,7 @@ test('admin notification routes manage channels and test sends', async () => {
 
   const providers = await call(makeApp(), 'GET', '/notifications/providers');
   assert.equal(providers.status, 200);
-  assert.deepEqual(providers.json.data.map((p) => p.id), ['gotify', 'ntfy']);
+  assert.deepEqual(providers.json.data.map((p) => p.id), ['gotify', 'ntfy', 'webhook']);
 
   const created = await call(makeApp(), 'POST', '/notifications/channels', {
     provider: 'gotify',


### PR DESCRIPTION
# feat(notifications): add generic webhook notification channel

<img width="972" height="697" alt="image" src="https://github.com/user-attachments/assets/944fee74-61ec-4b5d-8b7c-04c27080f392" />

## Discussions
Discord notifications support #660 https://github.com/ulsklyc/yuvomi/discussions/660

## Summary

This Pull Request introduces a new **Webhook** notification provider, allowing Yuvomi to send notifications to external services through configurable HTTP endpoints.

## Changes

- Add **Webhook** as a new notification provider.
- Allow configuring a destination webhook URL.
- Add optional Bearer Token authentication for secured endpoints.
- Enable integration with external services that support HTTP webhooks.

## Motivation

The notification system was previously limited to the providers natively supported by the application.

By introducing a generic webhook provider, users can integrate Yuvomi with a wide variety of third-party services and automation platforms without requiring dedicated integrations.

Examples include:

- Home Assistant
- n8n
- Make
- Zapier
- Discord-compatible endpoints
- Custom APIs
- Self-hosted automation services
- Any service capable of receiving HTTP webhook requests

## How to Test

1. Navigate to **Settings → Notifications**.
2. Create a new notification channel.
3. Select **Webhook** as the provider.
4. Configure the destination webhook URL.
5. (Optional) Configure a Bearer Token.
6. Save the channel.
7. Trigger any notification supported by the application.
8. Verify that the webhook request is successfully delivered to the configured endpoint.

## Expected Result

- Webhook channels can be created and configured successfully.
- Notifications are delivered to the configured webhook endpoint.
- When configured, the Bearer Token is sent using the `Authorization` header.
- Invalid endpoints return an appropriate error without affecting the application's notification flow.