### PR TITLE
docs(contributing): say what a red claude-review check means

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -215,11 +215,14 @@ single commit.
 
 **A red `claude-review` check is not a review finding.** The job fails when the review ran
 but left nothing behind - no summary, no inline comment - which for five PRs meant a green
-check over a review that never happened. Almost always the cause is a tool permission: look
-for `permission_denials_count` in the job log and add the missing tool to `claude_args` in
-`.github/workflows/claude-code-review.yml`. The one exception is a PR that edits that
-workflow itself; the action then skips for security reasons and the check steps aside with a
-notice explaining why.
+check over a review that never happened. The likely cause is a tool permission, and the job
+log names it in two steps: `permission_denials_count` in the result object tells you *how
+many* tools were refused but not which, so re-run the workflow with `show_full_output: true`
+to see the name, then add that tool to `claude_args` in
+`.github/workflows/claude-code-review.yml` - the list there **replaces** the review plugin's
+own, so anything you add has to keep the existing entries. The one exception is a PR that
+edits that workflow itself; the action then skips for security reasons and the check steps
+aside with a notice explaining why.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -213,16 +213,27 @@ informational; the maintainer's review decides. PRs from forks are excluded from
 automation. Once approved, PRs are merged by the maintainer, usually squashed into a
 single commit.
 
-**A red `claude-review` check is not a review finding.** The job fails when the review ran
-but left nothing behind - no summary, no inline comment - which for five PRs meant a green
-check over a review that never happened. The likely cause is a tool permission, and the job
-log names it in two steps: `permission_denials_count` in the result object tells you *how
-many* tools were refused but not which, so re-run the workflow with `show_full_output: true`
-to see the name, then add that tool to `claude_args` in
-`.github/workflows/claude-code-review.yml` - the list there **replaces** the review plugin's
-own, so anything you add has to keep the existing entries. The one exception is a PR that
-edits that workflow itself; the action then skips for security reasons and the check steps
-aside with a notice explaining why.
+**A red `claude-review` check is not a review finding.** Open the job and read which step
+failed first - the job goes red for ordinary reasons too (checkout, the action itself, a
+GitHub API call), and only one specific failure is about the review staying silent.
+
+That one is the step **"Die Review muss gesprochen haben"**. It exists because for five PRs
+the check was green over a review that never happened. Its message names the two known
+causes; the second needs the job log, where `permission_denials_count` tells you *how many*
+tools were refused but not which - re-run with `show_full_output: true` to see the name.
+
+**Do not add the tool in the PR that failed.** A PR touching
+`.github/workflows/claude-code-review.yml` makes the action skip itself (it only runs when
+the workflow matches the default branch) and makes this check stand aside, so it would turn
+green without any review having run. Report the denied tool instead and let a maintainer add
+it to `claude_args` on `main` - note that the list there **replaces** the review plugin's
+own, so existing entries have to stay - then re-run the original PR.
+
+One limit worth knowing: the check asks whether the PR carries *any* comment from the
+reviewer, not whether *this run* produced one. That is deliberate - the plugin looks for its
+own earlier comment and will not repeat itself on a later push - but it means a silent rerun
+on a PR that was already reviewed stays green. The assertion covers "this PR was never
+reviewed", not "every run reviewed it".
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -208,10 +208,18 @@ npm test              # All tests pass
 
 PRs are reviewed by the maintainer. Expect feedback within a few days. Same-repo PRs
 additionally get an automated AI review comment (Claude Code) shortly after opening, and
-mentioning `@claude` in an issue or PR comment triggers an AI assistant — both are
+mentioning `@claude` in an issue or PR comment triggers an AI assistant. Their findings are
 informational; the maintainer's review decides. PRs from forks are excluded from the
 automation. Once approved, PRs are merged by the maintainer, usually squashed into a
 single commit.
+
+**A red `claude-review` check is not a review finding.** The job fails when the review ran
+but left nothing behind - no summary, no inline comment - which for five PRs meant a green
+check over a review that never happened. Almost always the cause is a tool permission: look
+for `permission_denials_count` in the job log and add the missing tool to `claude_args` in
+`.github/workflows/claude-code-review.yml`. The one exception is a PR that edits that
+workflow itself; the action then skips for security reasons and the check steps aside with a
+notice explaining why.
 
 ---
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -529,7 +529,7 @@ mehr Trennung vom Near-Black-Grund).
 **Die Glas-ist-Chrome-Regel.** backdrop-filter existiert nur auf Chrome-Elementen:
 Tab-Bar-Kapsel, Sidebar, Sheets/Modals, Toast, Datepicker-Popover, FAB samt seinem
 Backdrop und seinen Aktionen. Inhalte - Karten, Listen, Widgets, Text - sind opak.
-Blur-Stufen kanonisch 2/6/10/20/32/56px (`--blur-2xs..xl`).
+Blur-Stufen kanonisch 2/6/10/20/32px (`--blur-2xs..lg`).
 
 **Der Modulkopf traegt KEIN Glas, und das ist eine begruendete Abweichung vom Kanon, keine
 Auslassung.** Die belegte Liquid-Glass-Linie fuehrt Navigationsleisten transparent; Yuvomi
@@ -949,8 +949,8 @@ Hover geht auf Vollton, der Fallback ist opak. Einblendung als Feder (420ms `--e
 plus Ring-Pulse), reduced-motion-sicher.
 
 ### Monatsgrid-Event-Bars (Signature Component, Kalender)
-Flache Tint-Bars statt satter Farbfelder: Flaeche nach dem Ein-Toenungsrezept
-(16 % Layer-Farbe auf `--color-surface-work`), Tinte
+Flache Tint-Bars statt satter Farbfelder: Flaeche auf `--tint-surface` (Layer-Farbe auf
+`--color-surface-work`, Hover eine Sprosse hoeher auf `--tint-raised`), Tinte
 `color-mix(in srgb, var(--ev-color) 35%, var(--color-text-primary))`; gemessen 7.2-9.5:1
 ueber die Layer-Farben. Keine Borders, Icons oder Avatar-Stacks im Monat (das "wer" traegt
 das title-Attribut). "Heute" ist NUR ein gefuellter Akzent-Kreis auf der Ziffer;
@@ -970,7 +970,10 @@ Text allein.
   `+`-Kombinator trennen (Zeilenlisten-Regel).
 - **Do** in einer Karte zwischen ZEILE (Haarlinie) und KACHEL (Inset-Well) waehlen; nur
   Bedienelemente behalten ihre Kante.
-- **Do** getoente Flaechen mit 16 % auf `--color-surface` mischen - ein Rezept, app-weit.
+- **Do** jede Toenung eine benannte Stufe der Toenungsskala nehmen lassen (`--tint-wash` 8 /
+  `--tint-state` 12 / `--tint-surface` 16 / `--tint-raised` 24 / `--tint-hint` 50 /
+  `--tint-ink` 70 / `--tint-shadow` 20), nie eine eigene Zahl; die vier Flaechenstufen sind
+  eine Leiter, ein Zustand steigt eine Sprosse.
 - **Do** verschachtelte Radien konzentrisch rechnen (`calc(var(--radius-*) - Npx)`).
 - **Do** opake Fallbacks fuer jedes Glas-Element mitliefern (reduced-transparency,
   prefers-contrast, fehlender backdrop-filter).


### PR DESCRIPTION
## Summary

Der Absatz zur automatischen Review nannte sie „informational". Das stimmte,
solange ihr Check nur gruen werden konnte - und auch dann nur der Form nach: er
war fuenf PRs lang gruen ueber einer Review, die nie stattgefunden hat (#707).

Seit sie ihre Wirkung nachweisen muss, kann der Check **rot** werden. Ein roter
Check ist eine Aussage an den Beitragenden; ohne Erklaerung liest er ihn als
Review-Befund und sucht in seinem eigenen Diff nach dem Fehler. Jetzt steht
dort, was er bedeutet, wo die Ursache steht und welche eine Ausnahme es gibt.

## Changes

- `CONTRIBUTING.md`: neuer Absatz unter „Review and merge".

## Kein Release

Das Delta seit v2.0.1 war bis hierhin eine reine CI-Datei, die seit ihrem Merge
ohnehin wirkt - GitHub Actions liest Workflows fuer `pull_request` vom
Default-Branch. Ein Tag haette ein byte-gleiches Image unter neuer Nummer
gebaut und den Umbrel-PR auf eine Version gehoben, die fuer Nutzer nichts
aendert. Diese Zeilen reisen mit der naechsten echten Aenderung mit.

## Dieser PR ist der ausstehende Beweis

#707 konnte die Werkzeug-Reparatur nicht testen: ein PR, der den Review-Workflow
aendert, laesst die Action sich selbst ueberspringen. **Dieser hier fasst den
Workflow nicht an**, also laeuft die Review zum ersten Mal mit
`Read,Grep,Glob`. Zwei moegliche Ausgaenge, beide brauchbar:

- Sie hinterlaesst eine Zusammenfassung -> die fehlenden Lesewerkzeuge waren die
  Ursache.
- Sie bleibt stumm -> der Nachweis-Schritt macht den Check rot und nennt das
  naechste fehlende Werkzeug.

Stilles Gruen ist kein moeglicher Ausgang mehr.

## Checklist

- [x] `npm test` passes (unveraendert, dieser PR fasst keinen Code an)
- [x] Follows [CONTRIBUTING.md](../CONTRIBUTING.md) conventions
- [x] No new frontend dependencies (vanilla JS, no frameworks)
- [x] UI strings use `t('key')` (no hardcoded text)
- [x] CHANGELOG.md updated (if user-facing change) - Doku, nicht nutzersichtbar