### PR TITLE
fix(ci): pass --comment so the review actually posts its result

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -50,7 +50,22 @@ jobs:
           claude_code_oauth_token: ${{ env.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          # `--comment` IST DER GRUND, WARUM SIE NIE ETWAS GESAGT HAT. Die
+          # Anleitung des Plugins steuert das Posten ueber genau dieses Argument:
+          #
+          #   "If `--comment` argument was NOT provided, stop here.
+          #    Do not post any GitHub comments."
+          #
+          # Ohne das Flag prueft es also vollstaendig und schweigt danach
+          # absichtlich - genau das Bild, das die Laeufe zeigten: 20 Turns,
+          # fuenf Minuten, `is_error: false`, kein Kommentar. Es war die ganze
+          # Zeit gehorsam, nicht kaputt.
+          #
+          # Mit dem Flag postet es IMMER: eine Zusammenfassung, wenn es nichts
+          # findet, und Inline-Anmerkungen, wenn doch. Erst dadurch wird der
+          # Nachweis-Schritt weiter unten zu einer richtigen Zusicherung -
+          # vorher haette er auch einen sauberen PR rot gefaerbt.
+          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment'
           allowed_bots: 'dependabot[bot]'
           # DIESE LISTE ERSETZT, SIE ERGÄNZT NICHT. Das war die Annahme, die den
           # zweiten Anlauf gekostet hat: `--allowed-tools` verdrängt die acht
@@ -142,9 +157,15 @@ jobs:
           echo "Zusammenfassungen: $issue · Reviews: $review · Inline-Anmerkungen: $inline"
           if [ "$((issue + review + inline))" -eq 0 ]; then
             echo "::error::Die Review ist durchgelaufen, hat aber nichts hinterlassen." \
-                 "Fast immer sind das Werkzeug-Sperren: im Job-Log steht" \
-                 "\"permission_denials_count\" im result-Objekt. Mit show_full_output: true" \
-                 "erneut laufen lassen, um zu sehen, WELCHES Werkzeug verweigert wurde," \
-                 "und es in claude_args nachtragen. Ein gruener Haken ohne Befund ist keiner."
+                 "Zwei Ursachen sind bekannt, in dieser Reihenfolge pruefen." \
+                 "(1) FEHLT --comment IM PROMPT? Ohne das Argument prueft das Plugin" \
+                 "vollstaendig und schweigt danach absichtlich - das war die Ursache," \
+                 "als dieser Schritt entstand, und sie sieht einer Sperre zum Verwechseln" \
+                 "aehnlich: is_error false, zwanzig Turns, kein Kommentar." \
+                 "(2) EINE WERKZEUG-SPERRE: im result-Objekt des Job-Logs steht" \
+                 "\"permission_denials_count\". Mit show_full_output: true erneut laufen" \
+                 "lassen, um zu sehen, WELCHES Werkzeug verweigert wurde, und es in" \
+                 "claude_args nachtragen - die Liste dort ERSETZT die des Plugins." \
+                 "Ein gruener Haken ohne Befund ist keiner."
             exit 1
           fi


### PR DESCRIPTION
## Summary

**Die Review war nie kaputt. Sie war gehorsam.**

Die Anleitung des Plugins `code-review@claude-code-plugins` steuert das Posten
ueber genau ein Argument:

> "If `--comment` argument was NOT provided, stop here.
> **Do not post any GitHub comments.**"

Unser Prompt uebergab es nicht. Das Plugin hat also jedes Mal vollstaendig
geprueft und danach absichtlich geschwiegen.

## Warum das so lange wie eine Sperre aussah

| Lauf | Turns | Dauer | Verweigerungen | gepostet |
|---|---|---|---|---|
| #706, ohne `claude_args` | 10 | 28 s | 5 | nichts |
| #708, mit `Read,Grep,Glob` | 23 | 4,5 min | 1 | nichts |
| #708 erneut, volle Werkzeugliste | 20 | 5,0 min | 2 | nichts |

Ich habe das dreimal als Werkzeug-Sperre gelesen. Die ersten beiden Male lag
ich nicht ganz daneben - der Sprung von 10 auf 23 Turns beweist, dass die
fehlenden Lesewerkzeuge ein echter Defekt waren, und der ist behoben. **Die
Stille hatte aber eine eigene, einfachere Ursache**, und die Zahlen sagten es
die ganze Zeit: eine Review, die an einer Sperre stirbt, arbeitet nicht fuenf
Minuten lang zu Ende und meldet `is_error: false`.

Die dritte Zeile ist der Beleg: mehr Werkzeuge, trotzdem nichts gepostet, und
die Verweigerungen stiegen sogar von 1 auf 2. Damit war die Sperren-Erklaerung
widerlegt.

## Changes

- `--comment` im Prompt. Mit dem Flag postet das Plugin **immer**: eine
  Zusammenfassung, wenn es nichts findet, Inline-Anmerkungen, wenn doch.
- Der Fehlertext des Nachweis-Schritts nennt jetzt **beide** Ursachen in der
  Reihenfolge, in der man sie pruefen sollte, statt nur der, auf die ich zuerst
  getippt habe.

## Erst dadurch wird der Nachweis-Schritt richtig

Ohne `--comment` haette er auch einen **sauberen** PR rot gefaerbt - ein
Fehlalarm, den man sich nach zwei Mal abgewoehnt, und dann waere die
Zusicherung wieder wertlos gewesen. Mit dem Flag bedeutet "nichts gepostet"
tatsaechlich "etwas ist schiefgegangen".

## Was dieser PR nicht kann

Er aendert den Workflow, also ueberspringt sich die Action selbst und der
Nachweis-Schritt tritt per Ausnahme beiseite. Der Beweis kommt danach: `main`
in #708 mergen und den Lauf dort ansehen - der PR fasst den Workflow nicht an.

## Checklist

- [x] `npm test` passes (unveraendert, dieser PR fasst keinen Code an)
- [x] Follows [CONTRIBUTING.md](../CONTRIBUTING.md) conventions
- [x] No new frontend dependencies (vanilla JS, no frameworks)
- [x] UI strings use `t('key')` (no hardcoded text)
- [x] CHANGELOG.md updated (if user-facing change) - CI-intern