### PR TITLE
docs(contributing): say that a rerun cannot pick up a workflow fix

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -227,7 +227,12 @@ tools were refused but not which - re-run with `show_full_output: true` to see t
 the workflow matches the default branch) and makes this check stand aside, so it would turn
 green without any review having run. Report the denied tool instead and let a maintainer add
 it to `claude_args` on `main` - note that the list there **replaces** the review plugin's
-own, so existing entries have to stay - then re-run the original PR.
+own, so existing entries have to stay.
+
+Once that has landed, **"Re-run jobs" on the old run will not pick it up.** A rerun replays
+the same workflow file at the same commit, so it hits the same denial and looks like the fix
+failed. The PR needs a fresh `pull_request` event to be evaluated against the new default
+branch: push to it, or merge `main` into the branch, or close and reopen it.
 
 One limit worth knowing: the check asks whether the PR carries *any* comment from the
 reviewer, not whether *this run* produced one. That is deliberate - the plugin looks for its


### PR DESCRIPTION
## Summary

Befund der Review an #708. Er trifft eine Stelle, an der mein eigener Text
**gegen meine eigene Messung** stand.

Ein „Re-run jobs" spielt denselben Workflow am selben Commit noch einmal ab.
Wer `claude_args` auf `main` ergaenzt und danach den alten Lauf wiederholt,
laeuft in dieselbe Sperre und haelt die Reparatur fuer gescheitert. Der PR
braucht ein frisches `pull_request`-Ereignis, damit er gegen den neuen
Default-Branch bewertet wird.

## Belegt, nicht angenommen

Genau das ist in der Runde passiert, in der dieser Absatz entstand: nach dem
Merge von #709 brachte `gh run rerun` an #708 nichts, und erst ein
`main`-Merge in den Branch loeste einen Lauf gegen die neue Fassung aus. Ich
hatte es gemessen und danach das Gegenteil aufgeschrieben.

## Changes

- Der Absatz nennt jetzt die drei Wege zu einem frischen Ereignis: pushen,
  `main` in den Branch mergen, oder schliessen und wieder oeffnen.

## Checklist

- [x] `npm test` passes (unveraendert, reine Doku)
- [x] Follows [CONTRIBUTING.md](../CONTRIBUTING.md) conventions
- [x] No new frontend dependencies (vanilla JS, no frameworks)
- [x] UI strings use `t('key')` (no hardcoded text)
- [x] CHANGELOG.md updated (if user-facing change) - Doku, nicht nutzersichtbar