### PR TITLE
chore(ci): turn on show_full_output for one diagnostic run

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -67,6 +67,23 @@ jobs:
           # vorher haette er auch einen sauberen PR rot gefaerbt.
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment'
           allowed_bots: 'dependabot[bot]'
+          # VORUEBERGEHEND, NUR ZUR DIAGNOSE - gehoert im naechsten PR wieder raus.
+          #
+          # Der Lauf an #711 brach nach VIER Turns und 15 Sekunden ab, mit einer
+          # Verweigerung und ohne etwas zu posten. Zum Vergleich der erfolgreiche
+          # Lauf an #708: 29 Turns, 4:45 min, zehn Verweigerungen - und er hat
+          # gepostet. Die Sperre sitzt hier also ganz am Anfang, nicht am Ende.
+          #
+          # Ich habe die Ursache dreimal geraten und dreimal falsch gelegen.
+          # `permission_denials_count` ist eine Zahl und nennt kein Werkzeug;
+          # diese Zeile ist der einzige Weg, den Namen zu sehen, und sowohl die
+          # Fehlermeldung des Nachweis-Schritts als auch CONTRIBUTING schreiben
+          # sie fuer genau diesen Fall vor.
+          #
+          # Der Preis: die volle SDK-Ausgabe steht im Actions-Log eines
+          # oeffentlichen Repos. Inhalt ist ein Review oeffentlicher Dateien,
+          # Secrets maskiert Actions ohnehin. Von Ulas fuer EINEN Lauf freigegeben.
+          show_full_output: true
           # DIESE LISTE ERSETZT, SIE ERGÄNZT NICHT. Das war die Annahme, die den
           # zweiten Anlauf gekostet hat: `--allowed-tools` verdrängt die acht
           # Werkzeuge, die das Plugin `code-review@claude-code-plugins` in seinem


### PR DESCRIPTION
## Summary

**Voruebergehend.** Der naechste PR nimmt es wieder heraus und traegt dafuer das
Werkzeug nach, das dieser Lauf benennt.

| Lauf | Turns | Dauer | Verweigerungen | gepostet |
|---|---|---|---|---|
| #708 (erfolgreich) | 29 | 4:45 min | 10 | **ja** |
| #711 | **4** | **15 s** | 1 | nein |

Die Sperre sitzt hier am Anfang, nicht am Ende - vier Turns sind Prompt lesen,
ein, zwei Aufrufe, abbrechen. Ein Doku-Diff von sieben Zeilen ist kein Grund
dafuer.

## Warum messen statt raten

Ich habe die Ursache dreimal geraten. Erst fehlende Lesewerkzeuge (das war ein
echter, eigener Defekt: 10 -> 23 Turns), dann die verdraengte Plugin-Liste,
dann das fehlende `--comment` (das war die Stille). Jede Erklaerung war
plausibel und hat eine Runde gekostet.

`permission_denials_count` ist eine Zahl und nennt kein Werkzeug. Diese Zeile
ist der einzige Weg zum Namen - und sowohl der Fehlertext des Nachweis-Schritts
als auch CONTRIBUTING schreiben sie fuer genau diesen Fall vor. Ich habe sie
dreimal umgangen.

## Der Preis, benannt

Die volle SDK-Ausgabe steht danach im Actions-Log eines oeffentlichen Repos.
Inhalt ist ein Review oeffentlicher Dateien; Secrets maskiert Actions ohnehin.
Von Ulas fuer **einen** Lauf freigegeben.

## Ablauf

1. Diesen PR mergen (er aendert den Workflow, kann sich also nicht selbst
   testen - die Action ueberspringt sich, der Nachweis tritt beiseite).
2. Ein frisches `pull_request`-Ereignis an #711 ausloesen. **Kein Rerun** - der
   spielt denselben Workflow am selben Commit ab, siehe #711 selbst.
3. Den Namen aus dem Log lesen.
4. Zweiter PR: `show_full_output` raus, Werkzeug rein.

## Checklist

- [x] `npm test` passes (unveraendert, dieser PR fasst keinen Code an)
- [x] Follows [CONTRIBUTING.md](../CONTRIBUTING.md) conventions
- [x] No new frontend dependencies (vanilla JS, no frameworks)
- [x] UI strings use `t('key')` (no hardcoded text)
- [x] CHANGELOG.md updated (if user-facing change) - CI-intern