### PR TITLE
fix(pwa): send credentials with manifest fetch so install works behind auth proxies

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -24,7 +24,7 @@
   <title>Yuvomi</title>
 
   <!-- PWA -->
-  <link rel="manifest" href="/manifest.webmanifest" />
+  <link rel="manifest" href="/manifest.webmanifest" crossorigin="use-credentials" />
   <link rel="apple-touch-icon" href="/icons/icon-192.png" />
   <link rel="icon" type="image/x-icon" href="/favicon.ico" />
   <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />


### PR DESCRIPTION
## Problem

When Yuvomi is served behind an authenticating reverse proxy (Cloudflare Access, Authelia, Authentik, basic auth), PWA installation is never offered.

**Settings → Personal → This device** shows *"Installation is not available in this browser right now"* with the button disabled, and the floating install banner never appears. The app itself works completely normally, which makes this look like a browser quirk rather than a manifest problem.

## Cause

`<link rel="manifest">` is fetched with its credentials mode set to **omit** by default — even for a same-origin manifest. So the proxy's session cookie is not sent, the proxy answers with a redirect to its login page, and the browser receives HTML where it expects JSON.

With no valid manifest, Chrome never fires `beforeinstallprompt`. `deferredInstallPrompt` in `public/utils/pwa-install.js` therefore stays `null`, and:

```js
supported: !installed && (ios || !!deferredInstallPrompt)
```

evaluates to `false` on desktop — which is exactly the disabled-button state.

The reason this is easy to misdiagnose is that ordinary page navigations *do* carry the session cookie, so everything except installation behaves correctly.

Nothing else is at fault. `public/sw.js` registers `install`, `activate` and `fetch` handlers, and `manifest.webmanifest` has all required fields plus 192/512 icons — the PWA is otherwise correctly built.

## Fix

Add `crossorigin="use-credentials"` to the manifest link so the request carries the session cookie.

```diff
-  <link rel="manifest" href="/manifest.webmanifest" />
+  <link rel="manifest" href="/manifest.webmanifest" crossorigin="use-credentials" />
```

## Verification

Reproduced on a Cloudflare Access deployment:

| | DevTools → Application → Manifest | Install button |
|---|---|---|
| Before, via proxied hostname | empty | disabled |
| Before, via origin directly on LAN | parsed correctly | n/a (insecure origin) |
| After, via proxied hostname | parsed correctly | enabled, installs |

The contrast between the first two rows isolates it to the manifest fetch rather than the manifest content.

Note that if a service worker is already registered, `/index.html` is in the precache list (`sw.js`), so the old HTML may be served from cache — unregistering the service worker or clearing site data is needed to observe the change.

## Impact on deployments without a proxy

None. With nothing to authenticate against, a same-origin credentialed manifest fetch behaves identically to the current one.
