### PR TITLE
chore(ci): keep dependabot off node major bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,3 +27,13 @@ updates:
       day: monday
     labels:
       - dependencies
+    # Node-Majors bleiben Handarbeit. Dependabot schlägt jeden neuen Major vor,
+    # auch solange er "Current" und nicht LTS ist (Node 26 ab April 2026, LTS
+    # erst ab Oktober). Ein selbst gehostetes Image läuft bei den Nutzern
+    # monatelang unangetastet, und die CI testet ausschließlich Node 22.x -
+    # der Bump käme also ungeprüft. Minor- und Patch-Updates der laufenden
+    # LTS-Linie zieht Dependabot weiterhin selbst.
+    ignore:
+      - dependency-name: node
+        update-types:
+          - version-update:semver-major


### PR DESCRIPTION
Dependabot schlägt für das Docker-Ecosystem jeden neuen Node-Major vor, auch solange er noch "Current" ist. #722 (node 24-slim auf 26-slim) ist genau das: Node 24 ist Active LTS ("Krypton"), Node 26 wird erst im Oktober 2026 LTS.

Für ein selbst gehostetes Image, das bei den Nutzern monatelang unangetastet läuft, ist der Tausch von LTS auf Current der falsche Weg. Dazu kommt, dass die CI ausschließlich Node 22.x testet (`ci.yml:19`) und den Image-Unterbau damit überhaupt nicht berührt - ein grüner Check an so einem PR sagt über die neue Laufzeit nichts aus.

Minor- und Patch-Updates der laufenden LTS-Linie zieht Dependabot weiterhin selbst; die Major-Sprünge macht man von Hand, wenn die neue Linie LTS geworden ist.

Schließt #722 beim nächsten Dependabot-Lauf mit.