### PR TITLE
fix(ci): let the code review start its own subagents

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -94,13 +94,28 @@ jobs:
           # Modell die Review, mal ueber 29 Turns mit Ergebnis, mal Abbruch nach
           # vier. Dieselbe Messung nannte `gh repo view` als zweiten Treffer.
           #
-          # Reihenfolge: Skill, dann die acht des Plugins, dann was es nicht
-          # deklariert, aber braucht. Read/Grep/Glob geben ihr den Quelltext um
-          # den Diff herum; `git rev-parse` verlangt seine eigene Anleitung für
-          # die SHA-gebundenen Codelinks.
+          # `Task` IST DER DRITTE GRUND, UND ER STAND DIE GANZE ZEIT IM PLUGIN.
+          # Dessen Anleitung besteht fast nur aus Subagenten: "Launch a haiku
+          # agent to check ...", "Launch 4 agents in parallel to review ...",
+          # dazu je ein Bewertungs-Agent pro Befund - acht Starts und mehr pro
+          # Lauf. Das Werkzeug dafuer fehlte in dieser Liste UND im Frontmatter
+          # des Plugins, und weil die Liste ERSETZT, war jeder einzelne Start
+          # gesperrt. Gemessen an den result-Objekten:
+          #   #724 (10 Zeilen YAML):  14 Turns,  3 Verweigerungen, Kommentar da.
+          #   #725 (413 Zeilen Lock): 24 Turns, 11 Verweigerungen, nichts.
+          # Ohne Subagenten improvisiert das Modell die Review selbst. Bei einem
+          # winzigen Diff geht das aus, bei einem grossen nicht - deshalb sah es
+          # aus, als scheitere die Review an Lockfiles. Die Diffgroesse war nur
+          # der Ausloeser, nicht die Ursache.
+          #
+          # Reihenfolge: Skill und Task zuerst (ohne die beiden kann die Review
+          # weder ihr Kommando noch ihre Agenten starten), dann die acht des
+          # Plugins, dann was es nicht deklariert, aber braucht. Read/Grep/Glob
+          # geben ihr den Quelltext um den Diff herum; `git rev-parse` verlangt
+          # seine eigene Anleitung für die SHA-gebundenen Codelinks.
           claude_args: >-
             --allowed-tools
-            "Skill,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh repo view:*),mcp__github_inline_comment__create_inline_comment,Read,Grep,Glob,Bash(git rev-parse:*),Bash(git log:*),Bash(git diff:*)"
+            "Skill,Task,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh repo view:*),mcp__github_inline_comment__create_inline_comment,Read,Grep,Glob,Bash(git rev-parse:*),Bash(git log:*),Bash(git diff:*)"
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 
@@ -170,7 +185,15 @@ jobs:
           echo "Zusammenfassungen: $issue · Reviews: $review · Inline-Anmerkungen: $inline"
           if [ "$((issue + review + inline))" -eq 0 ]; then
             echo "::error::Die Review ist durchgelaufen, hat aber nichts hinterlassen." \
-                 "Zwei Ursachen sind bekannt, in dieser Reihenfolge pruefen." \
+                 "Drei Ursachen sind bekannt, in dieser Reihenfolge pruefen." \
+                 "(0) SIEH ZUERST AUF num_turns IM result-OBJEKT. Unter etwa zehn" \
+                 "Turns bei NULL Verweigerungen hat die Review gar nicht erst" \
+                 "angefangen: Schritt 1 des Plugins bricht bei geschlossenen," \
+                 "Entwurfs-, automatisierten und trivialen PRs ab, ebenso wenn" \
+                 "claude hier schon kommentiert hat - 'stop and do not proceed'." \
+                 "Das ist kein Fehler des Plugins, sondern eine Zusicherung, die" \
+                 "es nie gegeben hat. Viele Turns MIT Verweigerungen heissen" \
+                 "dagegen: sie hat gearbeitet und ist am Abliefern gescheitert." \
                  "(1) FEHLT --comment IM PROMPT? Ohne das Argument prueft das Plugin" \
                  "vollstaendig und schweigt danach absichtlich - das war die Ursache," \
                  "als dieser Schritt entstand, und sie sieht einer Sperre zum Verwechseln" \


### PR DESCRIPTION
## Befund

Die Review konnte **keinen einzigen Subagenten starten**. Die Anleitung des Plugins besteht fast nur aus ihnen:

> 1. Launch a haiku agent to check if any of the following are true …
> 4. Launch 4 agents in parallel to independently review the changes …

Das sind acht Starts und mehr pro Lauf. `Task` fehlte aber sowohl im Frontmatter des Plugins als auch in unserer `claude_args`-Liste - und diese Liste **ersetzt** die des Plugins, statt sie zu ergänzen. Jeder Startversuch war damit eine Verweigerung.

Ohne Subagenten improvisiert das Modell die Review selbst. Das ging bei winzigen Diffs aus und bei großen nicht:

| PR | Diff | Turns | Verweigerungen | Ergebnis |
|---|---|---|---|---|
| #724 | 10 Zeilen YAML | 14 | 3 | Kommentar da, Job grün |
| #725 | 413 Zeilen Lockfile | 24 | 11 | nichts hinterlassen, Job rot |
| #720, #721 | Lockfile | - | - | nichts hinterlassen, Job rot |

Deshalb sah es aus, als scheitere die Review an Lockfiles. Die Diffgröße war nur der Auslöser, nicht die Ursache.

## Der andere Fehlergrund

Ein zweites Fehlerbild gehört nicht hierher, aber in den Hinweistext: Schritt 1 des Plugins bricht bei geschlossenen, Entwurfs-, **automatisierten und trivialen** PRs bewusst ab, ebenso wenn claude schon kommentiert hat - „stop and do not proceed". Der Lauf an #719 zeigt genau das: **5 Turns, 0 Verweigerungen**, also nie angefangen. Der Nachweis-Schritt verlangt dort eine Zusicherung, die das Plugin nie gegeben hat.

Der Hinweistext nennt das jetzt als Ursache (0) und sagt, woran man die beiden unterscheidet: wenige Turns ohne Verweigerungen heißt „nie angefangen", viele Turns mit Verweigerungen heißt „am Abliefern gescheitert".

## Wie sich das prüfen lässt

Nicht an diesem PR - die Action überspringt sich selbst, wenn ein PR den Review-Workflow anfasst. Nach dem Merge greift sie beim nächsten PR wieder scharf; dann sollten die Verweigerungen auf oder nahe null fallen.

Offen bleibt die Frage, ob der Nachweis-Schritt einen bewussten Screening-Abbruch weiterhin rot färben soll. Das ist eine eigene Entscheidung und steckt nicht in diesem PR.