### PR TITLE
fix(calendar): Fix default date selector if in day view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Creating an event from day view now defaults to the day you're looking at.** Clicking an empty slot in the day grid already opened the new-event form on that day, but the "+" button in the toolbar and the floating action button ignored it and always defaulted to today, so switching a few days ahead and reaching for either "+" silently created the event on the wrong day. Both now pass the day currently shown in day view through to the form; the other views are unaffected, since their reference date isn't a specific day the user picked.
+- **A new appointment starts on the day you are looking at, not on today.** Clicking an empty slot already opened the form on the day that was clicked, but the "+" in the toolbar and the floating action button had no day to go on and always fell back to today. In day view that is the reported case: page forward three days, reach for "+", and the appointment is created behind you (#737, reported and diagnosed by @LycidasFfm). The other three views had the same defect, only further away - in month view "+" put the appointment in August while September was on the screen. All four now propose the first day of the period on display, with one exception that keeps the old behaviour where it was right: as long as today is inside that period, today stays the proposal, because the user can see it. The empty state of the search is deliberately left on today, since a result list is not a period. The proposal is a starting value in an open form, not a decision - the date field is right there and editable.
 
 ## [2.10.0] - 2026-08-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Creating an event from day view now defaults to the day you're looking at.** Clicking an empty slot in the day grid already opened the new-event form on that day, but the "+" button in the toolbar and the floating action button ignored it and always defaulted to today, so switching a few days ahead and reaching for either "+" silently created the event on the wrong day. Both now pass the day currently shown in day view through to the form; the other views are unaffected, since their reference date isn't a specific day the user picked.
+
 ## [2.10.0] - 2026-08-14
 
 ### Added

--- a/public/pages/calendar.js
+++ b/public/pages/calendar.js
@@ -1019,7 +1019,7 @@ export async function render(container, { user }) {
   renderView();
   bodyEl.removeAttribute('aria-busy');
 
-  findPageFab('fab-new-event')?.addEventListener('click', () => openEventModal({ mode: 'create' }));
+  findPageFab('fab-new-event')?.addEventListener('click', () => openEventModal({ mode: 'create', date: state.view === 'day' ? state.cursor : undefined }));
 
   if (initialEvent) {
     const targetDate = deepLinkTargetDate(initialEvent, dateParam);
@@ -1130,7 +1130,7 @@ function renderToolbar() {
   bar.querySelector('#cal-prev').addEventListener('click', () => navigate(-1));
   bar.querySelector('#cal-next').addEventListener('click', () => navigate(1));
   bar.querySelector('#cal-today').addEventListener('click', goToday);
-  bar.querySelector('#cal-add').addEventListener('click', () => openEventModal({ mode: 'create' }));
+  bar.querySelector('#cal-add').addEventListener('click', () => openEventModal({ mode: 'create', date: state.view === 'day' ? state.cursor : undefined }));
   bar.querySelector('#cal-search').addEventListener('click', openCalendarSearch);
 
   bar.querySelector('#cal-assigned-me')?.addEventListener('click', (e) => {

--- a/public/pages/calendar.js
+++ b/public/pages/calendar.js
@@ -715,6 +715,37 @@ function getAgendaRange(dateStr) {
   return { from: dateStr, to: addDays(dateStr, 30) };
 }
 
+/**
+ * Vorbelegtes Datum für einen neuen Termin, bei dem niemand einen Tag angeklickt
+ * hat: Toolbar-„+", FAB, Leerzustand der Agenda (#737). Heute gewinnt, solange
+ * die Ansicht heute überhaupt zeigt - sonst der erste Tag des Zeitraums, den der
+ * Nutzer gerade ansieht. Vorher war es immer heute, also legte ein „+" drei
+ * Monate weiter vorne den Termin außerhalb des sichtbaren Zeitraums an.
+ *
+ * Bewusst nicht getRangeForView(): dessen Monatsspanne ist das 42-Tage-Raster
+ * und begänne im Vormonat - der 1. ist hier die richtige Antwort, nicht der 25.
+ */
+function newEventDefaultDate(view, cursor, today, weekStart = 1) {
+  if (!cursor) return today;
+  let from = cursor;
+  let to   = cursor;                                    // day: der Cursor ist der Tag
+  if (view === 'month') {
+    from = `${cursor.slice(0, 7)}-01`;
+    to   = addDays(addMonths(from, 1), -1);
+  } else if (view === 'week') {
+    from = startOfWeekOf(cursor, weekStart);
+    to   = addDays(from, 6);
+  } else if (view === 'agenda') {
+    to   = addDays(cursor, 30);
+  }
+  return (today >= from && today <= to) ? today : from;
+}
+
+/** newEventDefaultDate() für den aktuellen State - der Normalfall an den Aufrufstellen. */
+function newEventDate() {
+  return newEventDefaultDate(state.view, state.cursor, state.today, state.weekStart);
+}
+
 // Per-Render-Pass Day-Buckets. Vermeidet, dass jede der 42 Monats-Zellen die
 // komplette state.events/state.tasks-Liste neu filtert und pro Event ein neues
 // Date parst (O(Zellen × Events) → O(Events + Zellen)).
@@ -1019,7 +1050,7 @@ export async function render(container, { user }) {
   renderView();
   bodyEl.removeAttribute('aria-busy');
 
-  findPageFab('fab-new-event')?.addEventListener('click', () => openEventModal({ mode: 'create', date: state.view === 'day' ? state.cursor : undefined }));
+  findPageFab('fab-new-event')?.addEventListener('click', () => openEventModal({ mode: 'create', date: newEventDate() }));
 
   if (initialEvent) {
     const targetDate = deepLinkTargetDate(initialEvent, dateParam);
@@ -1130,7 +1161,7 @@ function renderToolbar() {
   bar.querySelector('#cal-prev').addEventListener('click', () => navigate(-1));
   bar.querySelector('#cal-next').addEventListener('click', () => navigate(1));
   bar.querySelector('#cal-today').addEventListener('click', goToday);
-  bar.querySelector('#cal-add').addEventListener('click', () => openEventModal({ mode: 'create', date: state.view === 'day' ? state.cursor : undefined }));
+  bar.querySelector('#cal-add').addEventListener('click', () => openEventModal({ mode: 'create', date: newEventDate() }));
   bar.querySelector('#cal-search').addEventListener('click', openCalendarSearch);
 
   bar.querySelector('#cal-assigned-me')?.addEventListener('click', (e) => {
@@ -1962,7 +1993,7 @@ function renderAgendaView(container) {
 
   container.querySelector('#agenda-view').addEventListener('click', (e) => {
     if (e.target.closest('#agenda-empty-cta')) {
-      openEventModal({ mode: 'create' });
+      openEventModal({ mode: 'create', date: newEventDate() });
       return;
     }
     const taskChip = e.target.closest('.cal-task-chip');
@@ -2128,6 +2159,8 @@ function renderCalendarSearchState(kind) {
         <p class="cal-search-status__text">${esc(t('calendar.searchEmpty', { query: searchQuery }))}</p>
         <button class="btn btn--secondary" id="cal-search-empty-cta">${esc(t('calendar.newEvent'))}</button>
       </div>`);
+    // Bewusst ohne newEventDate(): die Trefferliste ersetzt die Ansicht, es steht
+    // gerade kein Zeitraum auf dem Schirm, auf den ein Vorschlag sich beziehen könnte.
     body.querySelector('#cal-search-empty-cta')?.addEventListener('click', () => openEventModal({ mode: 'create' }));
     setSearchLive(t('calendar.searchEmpty', { query: searchQuery }));
   } else if (kind === 'error') {
@@ -2224,6 +2257,7 @@ async function openFoundEvent(ev) {
 export const __test = {
   normalizeCalendarView,
   defaultCalendarViewFromState,
+  newEventDefaultDate,
   filterTasksForCalendar,
   tasksOnDay,
   isMultiDayEvent,

--- a/test/test-calendar.js
+++ b/test/test-calendar.js
@@ -556,6 +556,81 @@ test('Tagesraster: die Dichte kommt aus EINEM Token, nicht aus einer zweiten Zah
     'calendar.js darf die Stundenhöhe nicht als Zahl führen - sie steht in tokens.css');
 });
 
+/* ---------------------------------------------------------------------------
+ * Vorbelegtes Datum eines neuen Termins ohne angeklickten Tag (#737)
+ *
+ * Anlassfall: In der Tagesansicht drei Tage vorblättern, „+" drücken - der
+ * Termin lag auf heute, nicht auf dem Tag auf dem Schirm. Dieselbe Überraschung
+ * gab es in Woche, Monat und Agenda, nur weiter entfernt.
+ *
+ * Regel: Heute gewinnt, solange die Ansicht heute zeigt; sonst der erste Tag des
+ * sichtbaren Zeitraums. Die Fälle „heute sichtbar" stehen mit im Test, sonst
+ * bewiese er nur die halbe Regel und ein `return from` käme grün durch.
+ * ------------------------------------------------------------------------- */
+const newEventDate = calendarHelpers.newEventDefaultDate;
+const TODAY = '2026-08-14';                                   // Freitag
+
+test('Tagesansicht: das „+" nimmt den angezeigten Tag, nicht heute', () => {
+  assert(newEventDate('day', '2026-09-20', TODAY) === '2026-09-20',
+    'ein vorgeblätterter Tag muss der Vorschlag sein');
+  assert(newEventDate('day', TODAY, TODAY) === TODAY,
+    'auf heute stehend bleibt es heute');
+});
+
+test('Monatsansicht: der erste des angezeigten Monats, aber heute wenn heute drin liegt', () => {
+  assert(newEventDate('month', '2026-09-20', TODAY) === '2026-09-01',
+    'im September muss der 1. September herauskommen');
+  assert(newEventDate('month', '2026-08-30', TODAY) === TODAY,
+    'im laufenden Monat bleibt heute der Vorschlag - der Nutzer sieht ihn ja');
+  assert(newEventDate('month', '2026-02-20', TODAY) === '2026-02-01',
+    'auch rückwärts der Monatserste, nicht das Rasterende');
+});
+
+test('Monatsansicht: der Vorschlag ist der Monatserste, nicht der Rasteranfang', () => {
+  // getRangeForView() liefert für den Monat das 42-Tage-Raster und beginnt im
+  // Vormonat. Wer diesen Vorschlag daraus ableitet, legt Termine aus der
+  // September-Ansicht heraus im August an. September 2026 beginnt an einem
+  // Dienstag, das Raster also am 31.08.
+  assert(newEventDate('month', '2026-09-20', TODAY) !== '2026-08-31',
+    'der Rasteranfang des Vormonats darf nie der Vorschlag sein');
+});
+
+test('Wochenansicht: der Wochenstart des angezeigten Zeitraums, im gewählten Wochenstart', () => {
+  assert(newEventDate('week', '2026-09-16', TODAY, 1) === '2026-09-14',
+    'Wochenstart Montag: Mittwoch 16.09. gehört zur Woche ab Montag 14.09.');
+  assert(newEventDate('week', '2026-09-16', TODAY, 0) === '2026-09-13',
+    'Wochenstart Sonntag: dieselbe Woche beginnt am 13.09.');
+  assert(newEventDate('week', '2026-08-12', TODAY, 1) === TODAY,
+    'liegt heute in der angezeigten Woche, gewinnt heute');
+});
+
+test('Agenda: der Listenanfang, sobald heute außerhalb der 30 Tage liegt', () => {
+  assert(newEventDate('agenda', '2026-10-01', TODAY) === '2026-10-01',
+    'vorgeblätterte Agenda schlägt ihren eigenen Anfang vor');
+  assert(newEventDate('agenda', '2026-08-01', TODAY) === TODAY,
+    'heute liegt im 30-Tage-Fenster ab 01.08. und gewinnt');
+});
+
+test('ohne Cursor bleibt es bei heute', () => {
+  assert(newEventDate('month', null, TODAY) === TODAY, 'null-Cursor fällt auf heute zurück');
+  assert(newEventDate('day', '', TODAY) === TODAY, 'leerer Cursor fällt auf heute zurück');
+});
+
+test('jedes „+" ohne angeklickten Tag reicht ein Datum durch (nur die Suche nicht)', () => {
+  const src = readFileSync(new URL('../public/pages/calendar.js', import.meta.url), 'utf8')
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/^\s*\/\/.*$/gm, '');
+  // Regel über ALLE create-Aufrufe, nicht über eine Liste bekannter Zeilen: sonst
+  // deckt der Guard N Fundstellen ab statt der Regel, und ein neuer Knopf fiele
+  // still durch.
+  const creates = src.match(/openEventModal\(\{\s*mode:\s*'create'[^)]*\)/g) || [];
+  assert(creates.length >= 5, `zu wenige create-Aufrufe gefunden (${creates.length}) - Regex greift nicht mehr`);
+  const withoutDate = creates.filter((call) => !/\bdate:/.test(call));
+  assert(withoutDate.length === 1,
+    `genau ein „+" darf ohne Datum öffnen (der Leerzustand der Suche, dort steht kein Zeitraum `
+    + `auf dem Schirm), gefunden: ${withoutDate.length} - ${withoutDate.join(' | ')}`);
+});
+
 // --------------------------------------------------------
 // Ergebnis
 // --------------------------------------------------------


### PR DESCRIPTION
## Summary

Added functionality in the day view of the calendar to directly open a event on that specific day.

## Changes

- 

## Checklist

- [x] `npm test` passes
- [x] Follows [CONTRIBUTING.md](../CONTRIBUTING.md) conventions
- [x] No new frontend dependencies (vanilla JS, no frameworks)
- [x] UI strings use `t('key')` (no hardcoded text)
- [x] CHANGELOG.md updated (if user-facing change)
