### PR TITLE
feat(dashboard): "Heute auf einen Blick" laesst sich abschalten

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **"Heute auf einen Blick" lässt sich abschalten.** Das Kopfband der Übersicht fasst zusammen, was in Aufgaben, Kalender, Mahlzeiten und Einkauf ansteht - nützlich, wenn diese Bereiche nicht ohnehin als Kacheln daliegen, und sonst eine Wiederholung. Bisher verschwand es nur indirekt, nämlich wenn man alle vier Bereiche als Widgets einblendete (#740, gemeldet von @tyboxer87). Jetzt trägt es im Anpassen-Modus denselben Ausblenden-Knopf wie jede Kachel und kommt über dieselbe Chip-Leiste zurück; Speichern, Abbrechen, Rückgängig und Zurücksetzen nehmen es mit, statt es neben dem Zyklus stehen zu lassen. Wie die Kachelanordnung gilt die Entscheidung für den Haushalt, weil die Übersicht eine gemeinsame Seite ist. Im Anpassen-Modus bleibt das Band sichtbar, auch abgeschaltet und auch ohne Inhalt - sonst wäre der Schalter, der es zurückholt, nur da, solange man ihn nicht braucht. Standardmäßig bleibt alles wie bisher.
+
 ## [2.13.1] - 2026-08-15
 
 ### Fixed

--- a/public/pages/dashboard.js
+++ b/public/pages/dashboard.js
@@ -1797,7 +1797,7 @@ function buildTodayCockpitModel(data, cfg = [], { cap = PROGRAM_ROW_CAP } = {}) 
   return { rows: visibleRows, allRows: program.rows, overflow, state, shopping, coda };
 }
 
-function renderTodayCockpit(data, cfg = []) {
+function renderTodayCockpit(data, cfg = [], editing = false) {
   const model = buildTodayCockpitModel(data, cfg);
 
   const parts = [];
@@ -1810,13 +1810,25 @@ function renderTodayCockpit(data, cfg = []) {
   if (model.coda) parts.push(`<div class="today-cockpit__coda">${esc(model.coda)}</div>`);
 
   // Deckt der Nutzer alle vier Domänen über Widgets ab, wäre das Cockpit leer —
-  // dann entfällt der ganze Abschnitt statt einer leeren Kopfzeile.
-  if (!parts.length) return '';
+  // dann entfällt der ganze Abschnitt statt einer leeren Kopfzeile. Im
+  // Bearbeiten-Modus bleibt er stehen, auch ohne Inhalt: sonst wäre der
+  // Schalter, mit dem man ihn abstellt, nur sichtbar solange er etwas zu sagen
+  // hat (#740).
+  if (!parts.length && !editing) return '';
+
+  // Derselbe Ausblenden-Knopf wie an jeder Kachel, damit das Kopfband im
+  // Bearbeiten-Modus keine Sonderbedienung braucht.
+  const hideBtn = editing ? `
+    <button type="button" class="widget-edit-controls__hide" data-glance-hide
+            aria-label="${t('dashboard.customizeHide', { widget: t('dashboard.todayTitle') })}">
+      <i data-lucide="eye-off" aria-hidden="true"></i>
+    </button>` : '';
 
   return `
     <section class="today-cockpit" aria-labelledby="today-cockpit-title">
       <div class="today-cockpit__header">
         <h2 id="today-cockpit-title">${esc(t('dashboard.todayTitle'))}</h2>
+        ${hideBtn}
       </div>
       <div class="today-cockpit__grid">
         ${parts.join('')}
@@ -1943,10 +1955,19 @@ function renderWidgetCustomizeControls(w, index = 0, total = 1) {
 // Edit-Modus ausgeblendetes Widget landet als Chip hier und lässt sich mit einem
 // Klick zurückholen — so ist der Inline-Editor allein vollständig (Zeigen +
 // Verstecken + Größe + Reihenfolge) und das frühere zweite Editor-Modal entfällt.
-function renderHiddenWidgetsTray(cfg) {
+function renderHiddenWidgetsTray(cfg, glanceHidden = false) {
   const hidden = cfg.filter((w) => !w.visible && WIDGET_IDS.includes(w.id) && isWidgetModuleEnabled(w.id));
-  if (!hidden.length) return '';
-  const chips = hidden.map((w) => `
+  if (!hidden.length && !glanceHidden) return '';
+  // Das Kopfband steht mit in dieser Leiste, obwohl es keine Rasterkachel ist:
+  // ausgeblendet waere es sonst nur ueber „Zuruecksetzen" zurueckzuholen.
+  const glanceChip = glanceHidden ? `
+    <button type="button" class="widget-restore-chip" data-glance-show
+            aria-label="${t('dashboard.customizeShow', { widget: t('dashboard.todayTitle') })}">
+      <i data-lucide="sun" class="widget-restore-chip__icon" aria-hidden="true"></i>
+      <span class="widget-restore-chip__label">${t('dashboard.todayTitle')}</span>
+      <i data-lucide="plus" class="widget-restore-chip__add" aria-hidden="true"></i>
+    </button>` : '';
+  const chips = glanceChip + hidden.map((w) => `
     <button type="button" class="widget-restore-chip" data-widget-show="${esc(w.id)}"
             aria-label="${t('dashboard.customizeShow', { widget: widgetLabel(w.id) })}">
       <i data-lucide="${widgetIcon(w.id)}" class="widget-restore-chip__icon" aria-hidden="true"></i>
@@ -1961,7 +1982,7 @@ function renderHiddenWidgetsTray(cfg) {
   `;
 }
 
-function renderDashboardLayout(cfg, data, weather, currency, { editing = false, visibleMealTypes = MEAL_ORDER } = {}) {
+function renderDashboardLayout(cfg, data, weather, currency, { editing = false, visibleMealTypes = MEAL_ORDER, glanceHidden = false } = {}) {
   const widgetById = {
     tasks: () => renderUrgentTasks(data.urgentTasks ?? []),
     calendar: () => renderUpcomingEvents(data.upcomingEvents ?? []),
@@ -2028,7 +2049,7 @@ function renderDashboardLayout(cfg, data, weather, currency, { editing = false, 
   const grid = `<div class="dashboard__grid ${editing ? 'dashboard__grid--editing' : ''}${preserveOrder}" id="dashboard-widget-grid">${gridInner}</div>`;
   // Im Bearbeiten-Modus folgt die Wieder-Einblenden-Leiste dem Grid, damit
   // ausgeblendete Widgets nicht in einer Sackgasse verschwinden.
-  return editing ? `${grid}${renderHiddenWidgetsTray(cfg)}` : grid;
+  return editing ? `${grid}${renderHiddenWidgetsTray(cfg, glanceHidden)}` : grid;
 }
 
 /* DAS SKELETT VERSPRICHT DAS LAYOUT, DAS GLEICH KOMMT (Critique R1, A10).
@@ -2942,6 +2963,13 @@ export async function render(container, { user }) {
   let weatherAutoLocate = false;
   let widgetConfig = DEFAULT_WIDGET_CONFIG;
   let savedWidgetConfig = DEFAULT_WIDGET_CONFIG;
+  // Das Kopfband „Heute auf einen Blick" ist kein Rasterkachel, folgt aber
+  // derselben Anpassen-Grammatik wie die Widgets: ausblenden am Block, zurueck
+  // ueber die Chip-Leiste, und es faehrt in denselben Speicher-, Abbruch- und
+  // Ruecknahme-Zyklus mit (#740). Haushaltweit wie `dashboard_widgets`, weil
+  // die Uebersicht eine gemeinsame Seite ist.
+  let glanceVisible = true;
+  let savedGlanceVisible = true;
   let isCustomizing = false;
   let currency     = 'EUR';
   let visibleMealTypes = MEAL_ORDER;
@@ -2968,6 +2996,8 @@ export async function render(container, { user }) {
     weatherAutoLocate = Boolean(prefsRes.data?.weather_user?.auto_locate ?? prefsRes.data?.weather_auto_locate);
     widgetConfig = normalizeDashboardConfig(prefsRes.data?.dashboard_widgets ?? DEFAULT_WIDGET_CONFIG);
     savedWidgetConfig = widgetConfig.map((w) => ({ ...w }));
+    glanceVisible = prefsRes.data?.dashboard_today_glance !== false;
+    savedGlanceVisible = glanceVisible;
     // Das Skelett des NAECHSTEN Aufrufs lernt hier seine Kachelform.
     rememberLayoutHint(widgetConfig);
     currency     = prefsRes.data?.currency ?? 'EUR';
@@ -3012,8 +3042,10 @@ export async function render(container, { user }) {
   async function persistWidgetConfig(nextConfig) {
     const previousConfig = savedWidgetConfig.map((w) => ({ ...w }));
     widgetConfig = nextConfig.map((w) => ({ ...w }));
-    await api.put('/preferences', { dashboard_widgets: widgetConfig });
+    const previousGlance = savedGlanceVisible;
+    await api.put('/preferences', { dashboard_widgets: widgetConfig, dashboard_today_glance: glanceVisible });
     savedWidgetConfig = widgetConfig.map((w) => ({ ...w }));
+    savedGlanceVisible = glanceVisible;
     rememberLayoutHint(widgetConfig);
     isCustomizing = false;
     // Wird die Zyklus-Kachel gerade erst eingeblendet, ihren owner-only Slice
@@ -3021,13 +3053,15 @@ export async function render(container, { user }) {
     if (widgetConfig.some((w) => w.id === 'cycle' && w.visible)) await ensureCycleSlice();
     rebuildDashboard(widgetConfig);
 
-    const changed = !sameWidgetConfig(previousConfig, widgetConfig);
+    const changed = !sameWidgetConfig(previousConfig, widgetConfig) || previousGlance !== glanceVisible;
     const onUndo = changed
       ? async () => {
           try {
             widgetConfig = previousConfig.map((w) => ({ ...w }));
-            await api.put('/preferences', { dashboard_widgets: widgetConfig });
+            glanceVisible = previousGlance;
+            await api.put('/preferences', { dashboard_widgets: widgetConfig, dashboard_today_glance: glanceVisible });
             savedWidgetConfig = widgetConfig.map((w) => ({ ...w }));
+            savedGlanceVisible = glanceVisible;
             rememberLayoutHint(widgetConfig);
           } catch {
             window.yuvomi?.showToast(t('common.errorGeneric'), 'danger');
@@ -3049,6 +3083,7 @@ export async function render(container, { user }) {
 
   function cancelDashboardConfig() {
     widgetConfig = savedWidgetConfig.map((w) => ({ ...w }));
+    glanceVisible = savedGlanceVisible;
     isCustomizing = false;
     rebuildDashboard(widgetConfig);
   }
@@ -3059,6 +3094,7 @@ export async function render(container, { user }) {
     });
     if (!confirmed) return;
     widgetConfig = DEFAULT_WIDGET_CONFIG.map((w) => ({ ...w }));
+    glanceVisible = true;
     rebuildDashboard(widgetConfig);
   }
 
@@ -3148,6 +3184,17 @@ export async function render(container, { user }) {
       });
     });
 
+    // Kopfband: beide Knoepfe sitzen ausserhalb des Grids (der eine im Masthead,
+    // der andere in der Tray-Leiste), deshalb container-weit gesucht.
+    container.querySelector('[data-glance-hide]')?.addEventListener('click', () => {
+      glanceVisible = false;
+      rebuildDashboard(widgetConfig);
+    });
+    container.querySelector('[data-glance-show]')?.addEventListener('click', () => {
+      glanceVisible = true;
+      rebuildDashboard(widgetConfig);
+    });
+
     // Reorder ohne HTML5-DnD (das feuert nicht per Finger und ist nicht per
     // Tastatur bedienbar). Ein Pfad für drei Auslöser: Touch-Up/Down-Buttons,
     // Desktop-Grip-Pfeiltasten und (indirekt) das Modal — alle über den Nachbarn
@@ -3216,7 +3263,7 @@ export async function render(container, { user }) {
     // Fehlt das Cockpit (alle Domänen als Widgets sichtbar → kein Glance-Inhalt),
     // kollabiert das Band per --slim auf eine schlanke Gruß-Leiste statt ein
     // großes leeres Rechteck zu zeigen (Critique R3 P1).
-    const cockpitHtml = renderTodayCockpit(data, cfg);
+    const cockpitHtml = (glanceVisible || isCustomizing) ? renderTodayCockpit(data, cfg, isCustomizing) : '';
     const mastheadSlim = cockpitHtml ? '' : ' dashboard-masthead--slim';
     // Kein Wetter-Echo: die Masthead-Zeile spricht nur, wenn die Wetter-Karte
     // nicht ohnehin im Raster sichtbar ist (Opt-in fürs Wandtablet).
@@ -3226,7 +3273,7 @@ export async function render(container, { user }) {
         ${renderDashboardOverview(user, isCustomizing, weatherCardShown ? null : weather, lastLoadedAt)}
         ${cockpitHtml}
       </section>
-      ${renderDashboardLayout(cfg, data, weather, currency, { editing: isCustomizing, visibleMealTypes })}
+      ${renderDashboardLayout(cfg, data, weather, currency, { editing: isCustomizing, visibleMealTypes, glanceHidden: !glanceVisible })}
     `);
     wireLinks(container, rerender, { editing: isCustomizing });
     // Retry einer isolierten Widget-Fehlerkachel: da /dashboard aggregiert lädt,

--- a/server/routes/preferences.js
+++ b/server/routes/preferences.js
@@ -327,6 +327,7 @@ router.get('/', (req, res) => {
         language_auto: resolveHouseholdLocale(db.get(), { ignoreExplicit: true }),
         app_name: appName,
         dashboard_widgets: dashboardWidgets,
+        dashboard_today_glance: cfgGet('dashboard_today_glance') !== '0',
         disabled_modules: disabledModules,
         module_order: moduleOrder,
         mobile_nav_order: mobileNavOrder,
@@ -379,7 +380,7 @@ router.get('/', (req, res) => {
 
 router.put('/', (req, res) => {
   try {
-    const { visible_meal_types, currency, date_format, time_format, week_start, region, language, app_name, dashboard_widgets, disabled_modules, module_order, mobile_nav_order, housekeeping_payment_tasks, budget_mode, calendar_default_duration, calendar_default_reminders, calendar_default_assign_me, calendar_default_target, health_cycle_enabled, health_cycle_enabled_user, rewards_require_approval, tasks_subtasks_expanded, tasks_default_points, tasks_default_target, weather_provider, weather_lat, weather_lon, weather_city, weather_units, weather_auto_locate, weather_user, holiday_country, holiday_subdivision, holiday_group, holiday_show_public, holiday_show_school, holiday_public_color, holiday_school_color } = req.body;
+    const { visible_meal_types, currency, date_format, time_format, week_start, region, language, app_name, dashboard_widgets, dashboard_today_glance, disabled_modules, module_order, mobile_nav_order, housekeeping_payment_tasks, budget_mode, calendar_default_duration, calendar_default_reminders, calendar_default_assign_me, calendar_default_target, health_cycle_enabled, health_cycle_enabled_user, rewards_require_approval, tasks_subtasks_expanded, tasks_default_points, tasks_default_target, weather_provider, weather_lat, weather_lon, weather_city, weather_units, weather_auto_locate, weather_user, holiday_country, holiday_subdivision, holiday_group, holiday_show_public, holiday_show_school, holiday_public_color, holiday_school_color } = req.body;
 
     if (visible_meal_types !== undefined) {
       if (!Array.isArray(visible_meal_types)) {
@@ -480,6 +481,13 @@ router.put('/', (req, res) => {
         return res.status(400).json({ error: 'dashboard_widgets enthält ungültige Einträge', code: 400 });
       }
       cfgSet('dashboard_widgets', JSON.stringify(normalized));
+    }
+
+    if (dashboard_today_glance !== undefined) {
+      if (typeof dashboard_today_glance !== 'boolean') {
+        return res.status(400).json({ error: 'dashboard_today_glance muss ein Boolean sein', code: 400 });
+      }
+      cfgSet('dashboard_today_glance', dashboard_today_glance ? '1' : '0');
     }
 
     if (disabled_modules !== undefined) {

--- a/test/test-frontend-audit.js
+++ b/test/test-frontend-audit.js
@@ -1166,6 +1166,43 @@ test('synchronization-by-data-type leaves exist and export async render function
   }
 });
 
+test('das Kopfband faehrt im selben Anpassen-Zyklus wie die Kacheln (#740)', () => {
+  const source = read('../public/pages/dashboard.js');
+
+  // Der eigentliche Fehler waere nicht ein fehlender Schalter, sondern einer,
+  // der neben dem Zyklus steht: Abbrechen holt die Kacheln zurueck und laesst
+  // das Kopfband verschwunden, oder Rueckgaengig kennt es nicht. Geprueft wird
+  // deshalb die KOPPLUNG, nicht die Existenz des Knopfes.
+  // JEDER dieser PUTs, nicht irgendeiner: es gibt zwei (Speichern und
+  // Ruecknahme), und ein Guard, dem einer genuegt, ist blind fuer den anderen.
+  const widgetPuts = [...source.matchAll(/api\.put\('\/preferences',\s*\{[^}]*dashboard_widgets[^}]*\}/g)]
+    .map((m) => m[0]);
+  assert.ok(widgetPuts.length >= 2,
+    `Nur ${widgetPuts.length} dashboard_widgets-PUTs gefunden - das Muster greift nicht mehr`);
+  const withoutGlance = widgetPuts.filter((call) => !call.includes('dashboard_today_glance'));
+  assert.deepEqual(withoutGlance, [],
+    'Kacheln und Kopfband muessen in EINEM PUT gehen - sonst schreibt ein Fehlschlag die Haelfte:\n  '
+    + withoutGlance.join('\n  '));
+  assert.match(source, /function cancelDashboardConfig\(\)[\s\S]{0,200}?glanceVisible = savedGlanceVisible/,
+    'Abbrechen stellt das Kopfband nicht zurueck');
+  assert.match(source, /function resetDashboardConfig[\s\S]{0,600}?glanceVisible = true/,
+    'Zuruecksetzen stellt das Kopfband nicht auf den Standard');
+  assert.match(source, /glanceVisible = previousGlance/,
+    'Rueckgaengig nimmt das Kopfband nicht mit zurueck');
+  assert.match(source, /previousGlance !== glanceVisible/,
+    'wurde NUR das Kopfband umgeschaltet, muss der Toast trotzdem Rueckgaengig anbieten');
+
+  // Im Bearbeiten-Modus bleibt das Kopfband stehen, auch ausgeblendet und auch
+  // ohne Inhalt - sonst waere der Schalter, der es zurueckholt, nur sichtbar
+  // solange es ohnehin da ist.
+  assert.match(source, /\(glanceVisible \|\| isCustomizing\)/,
+    'ausgeblendet verschwindet das Kopfband auch im Bearbeiten-Modus');
+  assert.match(source, /!parts\.length && !editing/,
+    'ohne Inhalt faellt das Kopfband auch im Bearbeiten-Modus weg');
+  assert.match(source, /data-glance-show/,
+    'ausgeblendet fehlt der Weg zurueck ueber die Chip-Leiste');
+});
+
 test('sync-calendar leaf loads CalDAV, Google, and Apple with independent status', () => {
   const source = read('../public/settings/pages/sync-calendar.js');
 

--- a/test/test-preferences-routes.js
+++ b/test/test-preferences-routes.js
@@ -164,6 +164,36 @@ test('PUT dashboard_widgets: ungültige Struktur, doppelte IDs oder zu viele Ein
   }));
   assert.equal((await put({ dashboard_widgets: tooMany })).status, 400);
 });
+// --------------------------------------------------------
+// dashboard_today_glance (#740)
+// --------------------------------------------------------
+test('dashboard_today_glance ist standardmäßig an - der Bestand kennt den Schlüssel nicht', async () => {
+  const res = await get();
+  assert.equal(res.body.data.dashboard_today_glance, true);
+});
+test('PUT dashboard_today_glance: alles ausser Boolean -> 400', async () => {
+  // '0'/'1' waeren die DB-Schreibweise, nicht die der API - wer sie schickt,
+  // meint etwas anderes als er bekaeme.
+  assert.equal((await put({ dashboard_today_glance: '0' })).status, 400);
+  assert.equal((await put({ dashboard_today_glance: 0 })).status, 400);
+  assert.equal((await put({ dashboard_today_glance: null })).status, 400);
+});
+test('dashboard_today_glance haelt beide Richtungen ueber den GET', async () => {
+  assert.equal((await put({ dashboard_today_glance: false })).status, 200);
+  assert.equal((await get()).body.data.dashboard_today_glance, false);
+  assert.equal((await put({ dashboard_today_glance: true })).status, 200);
+  assert.equal((await get()).body.data.dashboard_today_glance, true);
+});
+test('dashboard_today_glance braucht keine Adminrechte - wie die Widgets daneben', async () => {
+  // Die Uebersicht ist eine gemeinsame Seite; wer ihre Kacheln umstellen darf,
+  // darf auch ihr Kopfband abstellen. Waere das eine Admin-Entscheidung, muesste
+  // es dashboard_widgets auch sein.
+  const res = await put({ dashboard_today_glance: false }, { role: 'member', userId: 2 });
+  assert.equal(res.status, 200);
+  assert.equal((await get({ role: 'member', userId: 2 })).body.data.dashboard_today_glance, false);
+  await put({ dashboard_today_glance: true });
+});
+
 test('PUT dashboard_widgets: Teilmenge bleibt beim GET eine Teilmenge', async () => {
   const requested = [{ id: 'notes', visible: false, order: 0, size: '2x1' }];
   const saved = await put({ dashboard_widgets: requested });


### PR DESCRIPTION
Closes discussion #740, reported by @tyboxer87.

## The request

The "Today at a glance" band on the overview could only be removed indirectly: it disappears once all four of its domains (tasks, calendar, meals, shopping) are shown as widgets. Nobody guesses that as a route to "I don't want this section", and the reporter explicitly did not want the shopping list on the home page in *either* form.

## The change

The switch is not next to the customize mode, it is **in** it: the same `eye-off` button every tile carries, and the same restore chip row to bring it back.

The part that actually needed care is the cycle. Customize mode has save, cancel, undo and reset, and a toggle that stands beside them is the likely defect - cancel would restore the tiles and leave the band gone. So:

- both go out in **one** `PUT /preferences`, so a failure cannot write half the state
- `cancelDashboardConfig` restores it alongside the tiles
- `resetDashboardConfig` puts it back to the default
- the undo action in the save toast takes it with it
- the toast offers undo even when *only* the band was toggled

In customize mode the band stays visible, both when switched off and when it has no content. Otherwise the switch that brings it back would only exist while you do not need it.

**Household-wide, without an admin check**, matching `dashboard_widgets` right next to it: the overview is a shared page, and whoever may rearrange its tiles may switch off its header band. Making this one an admin decision would mean `dashboard_widgets` should be one too.

No new i18n keys: `todayTitle`, `customizeHide` and `customizeShow` already exist with `{{widget}}` interpolation.

## Guards

Server-side, four tests in `test-preferences-routes.js`: default on for existing installs that never heard of the key, non-boolean rejected with 400 (`'0'` means something different than it would do), both directions survive a round trip, and a non-admin member may set it.

Client-side, one guard on the **coupling** rather than on the button's existence, since the button is not what breaks.

Worth recording: its first version asked whether *some* `/preferences` PUT carried both keys - and stayed green when I broke exactly that call, because there are two such PUTs (save and undo) and the intact second one satisfied it. It now collects every `dashboard_widgets` PUT, insists on finding at least two, and requires the glance key in **each**. Cross-checked against two separate breakages: dropping the key from one call, and removing the restore line from cancel.

## Testing

Full suite green: 3618 assertions.
