### PR TITLE
ci(review): keep show_full_output on so a silent run can be diagnosed

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -50,6 +50,23 @@ jobs:
           claude_code_oauth_token: ${{ env.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
+          # DAUERHAFT AN, WEIL DER NACHWEIS-SCHRITT SONST NUR MELDET, DASS ETWAS
+          # FEHLT, UND NIE WAS. Der Fehlertext unten schickt einen selbst hierher
+          # ("mit show_full_output: true erneut laufen lassen") - das kostete
+          # jedesmal einen zweiten Anlauf mit geaendertem Workflow, und genau der
+          # ist der teuerste: ein PR, der DIESE Datei anfasst, laesst die Action
+          # sich selbst ueberspringen (Workflow-Validierung, siehe der Schritt
+          # "Prueft die Review-Datei sich selbst?"). Die Diagnose muss also immer
+          # erst nach main, bevor sie ueberhaupt etwas messen kann.
+          #
+          # Der Anlass (PR #794, 2026-08-17): 14 Turns, `is_error: false`,
+          # NULL Verweigerungen, kein Kommentar - ein Muster, das in keiner der
+          # vier hier dokumentierten Runden vorkam, denn alle vorherigen
+          # Fehlschlaege hatten Verweigerungen > 0. Ohne die volle Ausgabe ist
+          # nicht zu sehen, was die Review in diesen 14 Turns getan hat.
+          #
+          # Kosten: laengere Job-Logs. Die faellt nur an, wenn jemand sie liest.
+          show_full_output: true
           # `--comment` IST DER GRUND, WARUM SIE NIE ETWAS GESAGT HAT. Die
           # Anleitung des Plugins steuert das Posten ueber genau dieses Argument:
           #


### PR DESCRIPTION
Diagnose-Schalter, damit der Fehlerfall auf #794 überhaupt messbar wird.

## Warum das ein eigener PR ist und nicht Teil von #794

Der Nachweis-Schritt weiter unten in dieser Datei schickt einen bei einem stillen Lauf selbst hierher: „mit `show_full_output: true` erneut laufen lassen". Nur kostet das jedes Mal einen Umweg, denn ein PR, der **diese Datei** anfasst, lässt die Action sich selbst überspringen (Workflow-Validierung, siehe den Schritt *Prueft die Review-Datei sich selbst?*). Die Diagnose muss also erst auf `main` liegen, bevor sie irgendetwas messen kann — im PR, der sie einträgt, läuft sie prinzipbedingt nicht.

Deshalb steht der Schalter hier allein und dauerhaft, statt in #794 mitzureisen: dort hätte er die Review abgeschaltet statt sie zu erklären.

## Der Anlass

`claude-review` ist auf #794 zweimal rot, ohne etwas zu hinterlassen. Die `result`-Objekte:

| Lauf | Turns | `is_error` | Verweigerungen | Kommentar |
|---|---|---|---|---|
| erster | 14 | false | **0** | keiner |
| Rerun | 5 | false | **0** | keiner |

Das passt zu keiner der vier in dieser Datei dokumentierten Runden: `#706` (5 Verweigerungen), `#708` (1), `#724` (3), `#725` (11) — **jeder** frühere Fehlschlag hatte Verweigerungen über null, und genau daran ließ er sich festmachen. Hier ist die Werkzeugliste offenbar vollständig, und trotzdem kommt nichts an. Ausgeschlossen sind außerdem die beiden anderen bekannten Ursachen: `--comment` steht im Prompt, `pull-requests: write` ist gesetzt, und auf #794 hat weder claude kommentiert noch gibt es eine Review oder eine Inline-Anmerkung, die das Plugin zum Abbruch bewegen würde.

Ohne die volle Ausgabe ist nicht zu sehen, was die Review in diesen 14 Turns getan hat.

## Nach dem Merge

`claude-review` auf #794 einmal neu laufen lassen; dann steht das `tool_use_result` je Schritt im Job-Log und die Ursache lässt sich benennen statt raten.

## Nebenbei ein Test der Selbst-Ausnahme

Dieser PR ändert den Review-Workflow, also müsste der Schritt *Prueft die Review-Datei sich selbst?* hier greifen und den Nachweis aussetzen. Wenn `claude-review` an diesem PR grün ist, ohne dass ein Kommentar entsteht, hat die Ausnahme wie beschrieben funktioniert — das bestätigt die Annahme, auf der die Begründung oben steht, ohne einen extra Lauf zu kosten.
