### PR TITLE
docs: AI Assistance in CONTRIBUTING (#687)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -297,6 +297,38 @@ Format: imperative mood, one line per change, user-oriented language. Use `-` ra
 
 ---
 
+## AI Assistance
+
+Asked for in [#687](https://github.com/ulsklyc/yuvomi/discussions/687). Yuvomi holds a household's calendar, health notes, documents and finances, so it is fair to ask who - or what - wrote the code that handles them.
+
+### How this project is built
+
+**AI coding agents are used here, extensively and openly.** Much of the code in this repository was drafted with them. Two of them also review pull requests automatically, and you will see their comments on yours: a Claude Code workflow and an OpenAI Codex connector.
+
+That is worth stating plainly rather than leaving to inference. An automated review comment on your PR is not a maintainer's verdict; it is a second pair of eyes with no authority to merge anything.
+
+### What a human guarantees
+
+**Nothing reaches `main` without a human deciding that it should.** Every merge in this repository is performed by the maintainer, including automated dependency updates and contributions from others. There is no path by which an agent merges its own work.
+
+Beyond that decision, three things are mechanical and hold for every change regardless of who or what wrote it:
+
+- The full test suite runs on every pull request, and a red build is not merged.
+- The [Hard Constraints](#hard-constraints) above are enforced by tests, not by good intentions - a framework import or an `innerHTML` call fails the build.
+- Behaviour that is claimed to be fixed carries a test that fails against the state before the fix. A guard that was never seen red is not evidence.
+
+**On "a human has read and understood every merged line":** for a one-person project shipping several releases a week, that sentence would be a promise nobody could keep, and a promise that cannot be kept is worse than none - it invites exactly the trust it does not earn. What is true instead: the maintainer reviews every change before merging it, decides whether it goes in, and is answerable for it either way. Where a change touches something sensitive - authentication, permissions, storage, anything reaching the network - that review goes line by line.
+
+### If you contribute
+
+**Say so if an agent wrote it.** One line in the PR description is enough ("drafted with Claude Code", "Copilot-assisted"). It is not a mark against the contribution and it will not slow the review down.
+
+The reason is practical rather than moral: it tells the reviewer where to look. Generated code fails in different places than hand-written code does - plausible-looking APIs that do not exist, tests that assert what the implementation happens to do rather than what it should, an edge case handled in the comment but not in the branch. Knowing to check for that is worth more than any policy about it.
+
+What is expected of the contribution itself does not change: you understand what you are submitting, you can explain why it works, and you can answer questions about it in review. If you cannot, the tool you used is not the problem.
+
+---
+
 ## Reporting Issues
 
 ### Bugs


### PR DESCRIPTION
Entwurf zu Discussion #687 (thesoundhead, LEON-BROTHER stimmt zu). **Bitte lies ihn als Vorschlag, nicht als Tatsachenbehauptung** - es sind Aussagen über deine Praxis, und zwei davon kann nur du bestätigen.

## Was gefragt war

thesoundhead wollte drei Dinge geklärt haben:

1. Welche Rolle AI-Agenten in der Entwicklung spielen
2. Ob menschliches Review vor jedem Merge Pflicht ist - *"I'd argue it should be, and that saying so is the single most valuable sentence in the whole document"*
3. Ob Beitragende AI-Nutzung offenlegen sollen

## Was der Entwurf sagt

**Zu 1:** offen, dass hier extensiv mit Agenten gearbeitet wird, und dass zwei davon auch automatisch PRs reviewen. Das steht ohnehin sichtbar in `.github/workflows/` und in jedem Codex-Kommentar - es nicht zu sagen wäre die auffälligere Entscheidung.

**Zu 2 - hier weiche ich bewusst von der Bitte ab.** Der verlangte Satz ("ein Mensch hat jede gemergte Zeile gelesen und verstanden") steht **nicht** drin. Bei mehreren Releases pro Woche und einem Maintainer wäre das ein Versprechen, das niemand hält - und ein unhaltbares Versprechen wirbt genau das Vertrauen ein, das es nicht verdient. Das ist schlechter als keine Aussage.

Stattdessen stehen dort nur nachprüfbare Zusagen:

- Kein Merge ohne menschliche Entscheidung (belegbar: jeder Merge im Repo ist von dir, auch Dependabot und externe PRs)
- Roter Build wird nicht gemergt
- Hard Constraints per Test, nicht per Vorsatz
- Ein Fix trägt einen Test, der gegen den Stand davor rot ist
- **Zeilenweise Durchsicht bei Auth, Rechten, Speicher, Netz**

**Zu 3:** Bitte um eine Zeile in der PR-Beschreibung, praktisch begründet statt moralisch - generierter Code fällt an anderen Stellen um, und der Reviewer soll wissen, wo er hinsehen muss.

## Was du bestätigen musst

Zwei Sätze sind Aussagen über dich, die ich nicht für dich treffen kann:

1. *"the maintainer reviews every change before merging it, decides whether it goes in, and is answerable for it either way"*
2. *"Where a change touches something sensitive - authentication, permissions, storage, anything reaching the network - that review goes line by line."*

Wenn eine davon zu stark oder zu schwach ist, sag es - lieber eine schwächere Aussage, die stimmt.

Kein CHANGELOG-Eintrag: keine Verhaltensänderung an der App.

Ich habe in #687 noch nicht geantwortet - das wollte ich erst tun, wenn der Text steht, den du mittragen kannst.