### PR TITLE
fix(backup): WebDAV-Rotation loeschte das neueste Backup (#853)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **WebDAV backup rotation deleted the newest backup instead of the oldest** (#853). On a Synology -
+  and on anything else running Apache `mod_dav` - the file listing was read back without a single
+  timestamp, and the rotation then removed from the wrong end. Every scheduled run uploaded a fresh
+  backup and deleted it seconds later, while the seven oldest stayed. A household could keep the
+  feature switched on for months and never hold a recent remote backup.
+
+  The namespace prefix in a WebDAV answer is the server's to choose. Nextcloud writes
+  `<d:getlastmodified>`; `mod_dav` publishes live properties under a prefix of its own, as
+  `<lp1:getlastmodified>`. The parser insisted on `D:` or `d:`, found no date, and substituted "now"
+  for **every** file - which did not fail, it tied. A tie sorts to nothing, so what was left was the
+  server's own order: by name, oldest first. `slice(keep)` then cut the newest end off.
+
+  Three things changed, and the first one is the fix: the prefix is now read as whatever the server
+  sent, including none. Second, a missing timestamp stays missing instead of becoming "now" - an
+  invented date is worse than an absent one, because it quietly turns a sort into an equality.
+  Third, ordering leans on the timestamp Yuvomi itself wrote into the filename, which no server
+  quirk can touch, and falls back to `getlastmodified` only for files it did not name.
+
+  On top of that the rotation will no longer delete the file it just uploaded, whatever the sort
+  says. Should a server ever confuse the ordering again, that now costs one surplus old backup
+  rather than the only fresh one.
+
+  Also fixed along the way: a server answering with absolute `href`s (which RFC 4918 allows) had its
+  paths pasted onto the base URL, so those `DELETE`s went nowhere and the folder grew without bound.
+
 ## [2.41.0] - 2026-08-25
 
 ### Fixed

--- a/server/services/backup-webdav.js
+++ b/server/services/backup-webdav.js
@@ -35,6 +35,23 @@ function isBackupFile(name) {
     && name.endsWith(BACKUP_FILE_SUFFIX);
 }
 
+// backupFileName() in backup-scheduler.js baut den Namen aus
+// `new Date().toISOString().replace(/[:.]/g, '-')`, also
+// `yuvomi-backup-2026-08-25T05-31-04-624Z.db`. Der Stempel im Namen ist die
+// verlaesslichste Altersquelle, die es gibt: er kommt von uns, ueberlebt jedes
+// Kopieren und haengt an keiner Server-Eigenheit. `getlastmodified` ist nur der
+// Rueckfall fuer Dateien, deren Namen wir nicht gebaut haben.
+const BACKUP_NAME_STAMP_RE =
+  /^(?:yuvomi|oikos)-backup-(\d{4}-\d{2}-\d{2})T(\d{2})-(\d{2})-(\d{2})-(\d{3})Z\.db$/;
+
+/** Zeitpunkt (ms) aus dem Dateinamen, oder null wenn der Name keinen traegt. */
+function timestampFromName(name) {
+  const m = BACKUP_NAME_STAMP_RE.exec(name);
+  if (!m) return null;
+  const ms = Date.parse(`${m[1]}T${m[2]}:${m[3]}:${m[4]}.${m[5]}Z`);
+  return Number.isNaN(ms) ? null : ms;
+}
+
 // ─── DB-Helpers ───────────────────────────────────────────────────────────────
 
 function cfgGet(key) {
@@ -172,31 +189,83 @@ async function davFetch(method, url, { username, password, headers = {}, body } 
   });
 }
 
+// Das Namespace-Praefix in einer WebDAV-Antwort ist frei waehlbar, und Server
+// nutzen das auch: Nextcloud liefert `<d:getlastmodified>`, Apache mod_dav -
+// und damit der WebDAV-Server einer Synology - liefert Live-Properties unter
+// einem eigenen Praefix als `<lp1:getlastmodified>`. Ein Parser, der auf `D:`
+// oder `d:` besteht, liest bei mod_dav KEINEN Zeitstempel; genau daran wurde
+// die Rotation blind und loeschte das frisch hochgeladene Backup (#853).
+// Darum: Praefix beliebig, auch gar keins.
+const NS = '(?:[A-Za-z0-9._-]+:)?';
+const RESPONSE_RE = new RegExp(`<${NS}response[^>]*>([\\s\\S]*?)</${NS}response>`, 'gi');
+const COLLECTION_RE = new RegExp(`<${NS}collection\\s*/?>`, 'i');
+const HREF_RE = new RegExp(`<${NS}href[^>]*>\\s*([\\s\\S]*?)\\s*</${NS}href>`, 'i');
+const LASTMOD_RE = new RegExp(`<${NS}getlastmodified[^>]*>\\s*([\\s\\S]*?)\\s*</${NS}getlastmodified>`, 'i');
+
+/**
+ * Ein href darf laut RFC 4918 relativ ODER absolut sein. joinUrl() haengt aber
+ * an die Basis-URL an - eine absolute Antwort ergaebe `https://host/https://…`.
+ * Also hier einmal auf den Pfad normalisieren, damit der Rest des Moduls es mit
+ * nur einer Form zu tun hat.
+ */
+function hrefToPath(href) {
+  if (/^https?:\/\//i.test(href)) {
+    try { return new URL(href).pathname; } catch { /* fällt unten durch */ }
+  }
+  return href;
+}
+
+/**
+ * Sortierschluessel: der Zeitpunkt aus dem Dateinamen, sonst `getlastmodified`,
+ * sonst null. Bewusst KEIN Ersatzwert "jetzt" - ein erfundenes Datum ist
+ * schlimmer als ein fehlendes, weil es die Sortierung still in eine Gleichheit
+ * kippt statt sie erkennbar scheitern zu lassen.
+ */
+function backupAge(entry) {
+  const fromName = timestampFromName(entry.filename);
+  if (fromName !== null) return fromName;
+  if (!entry.lastmod) return null;
+  const parsed = Date.parse(entry.lastmod);
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+/** Neueste zuerst; undatierte ans Ende, Gleichstand ueber den Namen. */
+function byNewestFirst(a, b) {
+  const ka = backupAge(a);
+  const kb = backupAge(b);
+  if (ka !== null && kb !== null && ka !== kb) return kb - ka;
+  // Eine Datei ohne erkennbares Alter darf keine datierte verdraengen: unser
+  // Scheduler baut den Stempel immer in den Namen, undatiert ist also fremd.
+  if ((ka === null) !== (kb === null)) return ka === null ? 1 : -1;
+  // Letzter Anker, damit die Reihenfolge nie von der Server-Reihenfolge abhaengt.
+  return b.filename.localeCompare(a.filename);
+}
+
 /**
  * Parse a WebDAV PROPFIND Multi-Status XML response.
  * Returns only plain files whose basename matches the backup pattern.
  */
 function parsePropfindXml(xml) {
   const results = [];
-  const responseRe = /<[Dd](?:av)?:response[^>]*>([\s\S]*?)<\/[Dd](?:av)?:response>/g;
+  RESPONSE_RE.lastIndex = 0;
   let m;
-  while ((m = responseRe.exec(xml)) !== null) {
+  while ((m = RESPONSE_RE.exec(xml)) !== null) {
     const block = m[1];
-    if (/<[Dd](?:av)?:collection\s*\/?>/.test(block)) continue; // skip directories
+    if (COLLECTION_RE.test(block)) continue; // skip directories
 
-    const hrefMatch    = block.match(/<[Dd](?:av)?:href[^>]*>\s*(.*?)\s*<\/[Dd](?:av)?:href>/);
-    const lastmodMatch = block.match(/<[Dd](?:av)?:getlastmodified[^>]*>\s*(.*?)\s*<\/[Dd](?:av)?:getlastmodified>/);
+    const hrefMatch    = block.match(HREF_RE);
+    const lastmodMatch = block.match(LASTMOD_RE);
     if (!hrefMatch) continue;
 
-    const href     = decodeURIComponent(hrefMatch[1].trim());
+    const href     = hrefToPath(decodeURIComponent(hrefMatch[1].trim()));
     const basename = href.split('/').filter(Boolean).pop() ?? '';
-    const lastmod  = lastmodMatch ? lastmodMatch[1].trim() : new Date().toUTCString();
+    const lastmod  = lastmodMatch ? lastmodMatch[1].trim() : null;
 
     if (isBackupFile(basename)) {
       results.push({ filename: basename, lastmod, remotePath: href });
     }
   }
-  return results.sort((a, b) => new Date(b.lastmod) - new Date(a.lastmod));
+  return results.sort(byNewestFirst);
 }
 
 /**
@@ -279,7 +348,7 @@ export async function uploadBackup(localFilePath) {
     cfgSet('webdav_backup_last_upload', new Date().toISOString());
     cfgDelete('webdav_backup_last_error');
 
-    await rotateRemoteBackups(cfg);
+    await rotateRemoteBackups(cfg, { protect: fileName });
   } catch (err) {
     log.error('WebDAV upload failed:', err);
     cfgSet('webdav_backup_last_error', err.message ?? String(err));
@@ -290,14 +359,23 @@ export async function uploadBackup(localFilePath) {
 /**
  * Delete oldest remote backups, keeping only the last cfg.keep files.
  * @param {object} [existingCfg]  Pass already-loaded config to avoid a second read
+ * @param {{ protect?: string }} [opts]  Dateiname, der nie rotiert werden darf
  */
-export async function rotateRemoteBackups(existingCfg) {
+export async function rotateRemoteBackups(existingCfg, opts = {}) {
   const cfg = existingCfg ?? getConfig();
+  const { protect } = opts;
   try {
     const files = await listRemoteBackups(cfg);
     if (files.length <= cfg.keep) return;
 
-    for (const f of files.slice(cfg.keep)) {
+    // Zweiter Boden unter der Sortierung: was gerade hochgeladen wurde, ist per
+    // Definition das juengste Backup und darf denselben Lauf nicht mehr
+    // verlassen. Sortiert die Rotation je wieder falsch - weil ein Server ein
+    // Feld anders schreibt, als wir es erwarten -, kostet das dann einen
+    // ueberzaehligen alten Stand und nicht den einzigen frischen (#853).
+    const candidates = files.slice(cfg.keep).filter((f) => f.filename !== protect);
+
+    for (const f of candidates) {
       try {
         const delUrl = joinUrl(cfg.url, f.remotePath);
         const res    = await davFetch('DELETE', delUrl, { username: cfg.username, password: cfg.password });

--- a/test/test-backup-webdav.js
+++ b/test/test-backup-webdav.js
@@ -25,8 +25,13 @@ const MOCK_PORT = 39871;
  * - PUT       → 201 Created
  * - DELETE    → 204 No Content
  * - GET/HEAD  → 200 (for client.exists())
+ *
+ * `liveProp` waehlt das Namespace-Praefix der Live-Properties. Default `D:`
+ * ist der Nextcloud-Stil; `lp1:` ist der von Apache mod_dav und damit der einer
+ * Synology. Beide sind gueltiges WebDAV - der Unterschied ist genau der, an dem
+ * die Rotation in #853 blind wurde, also muss der Mock ihn abbilden koennen.
  */
-function createMockServer({ failAuth = false, failPropfind = false } = {}) {
+function createMockServer({ failAuth = false, failPropfind = false, liveProp = 'D:', absoluteHrefs = false } = {}) {
   // In-memory "filesystem"
   const files = new Map(); // remotePath → { lastmod, size }
 
@@ -47,15 +52,20 @@ function createMockServer({ failAuth = false, failPropfind = false } = {}) {
         return;
       }
 
-      // List files that match the path prefix
+      // List files that match the path prefix. Die Reihenfolge ist die der
+      // Uploads und damit chronologisch aufsteigend - genau wie ein echter
+      // Server sie liefert, der nach Namen sortiert (die Namen tragen ISO-
+      // Stempel). Nur so kann der Test sehen, ob die Sortierung im Modul
+      // wirklich arbeitet oder nur die Serverreihenfolge durchreicht.
       const fileEntries = [...files.entries()].filter(([k]) => k.startsWith(url));
+      const hrefOf = (p) => (absoluteHrefs ? `http://localhost:${MOCK_PORT}${p}` : p);
       const fileXml = fileEntries.map(([filePath, info]) => `
         <D:response>
-          <D:href>${xmlEsc(filePath)}</D:href>
+          <D:href>${xmlEsc(hrefOf(filePath))}</D:href>
           <D:propstat>
             <D:prop>
-              <D:resourcetype/>
-              <D:getlastmodified>${info.lastmod}</D:getlastmodified>
+              <${liveProp}resourcetype/>
+              <${liveProp}getlastmodified>${info.lastmod}</${liveProp}getlastmodified>
               <D:getcontentlength>${info.size}</D:getcontentlength>
             </D:prop>
             <D:status>HTTP/1.1 200 OK</D:status>
@@ -63,12 +73,12 @@ function createMockServer({ failAuth = false, failPropfind = false } = {}) {
         </D:response>`).join('');
 
       const xml = `<?xml version="1.0" encoding="utf-8"?>
-        <D:multistatus xmlns:D="DAV:">
+        <D:multistatus xmlns:D="DAV:" xmlns:lp1="DAV:">
           <D:response>
-            <D:href>${xmlEsc(url)}</D:href>
+            <D:href>${xmlEsc(hrefOf(url))}</D:href>
             <D:propstat>
               <D:prop>
-                <D:resourcetype><D:collection/></D:resourcetype>
+                <${liveProp}resourcetype><D:collection/></${liveProp}resourcetype>
               </D:prop>
               <D:status>HTTP/1.1 200 OK</D:status>
             </D:propstat>
@@ -267,6 +277,117 @@ describe('WebDAV Backup — service module', async () => {
       assert.ok(
         remoteFiles.length <= 3,
         `Should keep at most 3 files, got ${remoteFiles.length}`
+      );
+      // Die Zahl allein war jahrelang gruen, waehrend die falschen Dateien
+      // verschwanden. Ab hier zaehlt, WELCHE bleiben.
+      assert.ok(
+        remoteFiles.some((k) => k.endsWith('oikos-backup-2099-01-04T00-00-00-000Z.db')),
+        'the newest backup must survive rotation'
+      );
+      assert.ok(
+        !remoteFiles.some((k) => k.endsWith('oikos-backup-2099-01-01T00-00-00-000Z.db')),
+        'the oldest backup is the one that goes'
+      );
+    });
+  });
+
+  // #853: Auf einer Synology (Apache mod_dav) kamen die Live-Properties als
+  // `lp1:getlastmodified`. Der Parser bestand auf `D:`/`d:`, las also gar kein
+  // Datum, setzte fuer JEDE Datei ersatzweise "jetzt" ein - und damit sortierte
+  // sich nichts mehr. Uebrig blieb die Reihenfolge des Servers, aufsteigend nach
+  // Namen, und die Rotation loeschte vom falschen Ende: das gerade hochgeladene
+  // Backup, jedes Mal.
+  describe('rotation on an Apache mod_dav server (#853)', async () => {
+    let mockCtx;
+    before(() => new Promise((resolve) => {
+      mockCtx = createMockServer({ liveProp: 'lp1:' });
+      mockCtx.server.listen(MOCK_PORT, resolve);
+    }));
+    after(() => new Promise((resolve) => mockCtx.server.close(resolve)));
+
+    const remoteDbFiles = () => [...mockCtx.files.keys()]
+      .filter((k) => k.startsWith('/oikos/backups/') && k.endsWith('.db'))
+      .map((k) => path.basename(k));
+
+    it('should keep the newest backups and delete the oldest', async () => {
+      const names = [
+        'yuvomi-backup-2099-03-01T00-00-00-000Z.db',
+        'yuvomi-backup-2099-03-02T00-00-00-000Z.db',
+        'yuvomi-backup-2099-03-03T00-00-00-000Z.db',
+        'yuvomi-backup-2099-03-04T00-00-00-000Z.db',
+        'yuvomi-backup-2099-03-05T00-00-00-000Z.db',
+      ];
+      for (const name of names) {
+        await webdav.uploadBackup(await createTempBackup(name));
+      }
+
+      const remaining = remoteDbFiles();
+      assert.deepStrictEqual(
+        remaining.sort(),
+        [
+          'yuvomi-backup-2099-03-03T00-00-00-000Z.db',
+          'yuvomi-backup-2099-03-04T00-00-00-000Z.db',
+          'yuvomi-backup-2099-03-05T00-00-00-000Z.db',
+        ],
+        'keep=3 must leave the three newest, not the three oldest'
+      );
+    });
+
+    it('should never delete the file it just uploaded', async () => {
+      const fresh = 'yuvomi-backup-2099-03-06T00-00-00-000Z.db';
+      await webdav.uploadBackup(await createTempBackup(fresh));
+      assert.ok(
+        remoteDbFiles().includes(fresh),
+        'the freshly uploaded backup must still be there after rotation'
+      );
+    });
+
+    it('should read the timestamp from a mod_dav-prefixed listing', async () => {
+      const listed = await webdav.getRemoteFiles();
+      assert.ok(listed.length > 0, 'listing is not empty');
+      assert.ok(
+        listed.every((f) => typeof f.lastmod === 'string' && !Number.isNaN(Date.parse(f.lastmod))),
+        'every entry carries a parsable getlastmodified, whatever the namespace prefix'
+      );
+      // Neueste zuerst - darauf verlaesst sich die Rotation.
+      const names = listed.map((f) => f.filename);
+      assert.deepStrictEqual(names, [...names].sort().reverse(), 'sorted newest first');
+    });
+  });
+
+  // Ein href darf laut RFC 4918 auch absolut sein. joinUrl() haengt an die
+  // Basis-URL an - unnormalisiert entstuende daraus `http://host/http://host/…`,
+  // und die DELETE-Anfrage ginge ins Leere statt aufs Ziel.
+  describe('rotation on a server that answers with absolute hrefs', async () => {
+    let mockCtx;
+    before(() => new Promise((resolve) => {
+      mockCtx = createMockServer({ absoluteHrefs: true });
+      mockCtx.server.listen(MOCK_PORT, resolve);
+    }));
+    after(() => new Promise((resolve) => mockCtx.server.close(resolve)));
+
+    it('should still delete the oldest file', async () => {
+      const names = [
+        'yuvomi-backup-2099-04-01T00-00-00-000Z.db',
+        'yuvomi-backup-2099-04-02T00-00-00-000Z.db',
+        'yuvomi-backup-2099-04-03T00-00-00-000Z.db',
+        'yuvomi-backup-2099-04-04T00-00-00-000Z.db',
+      ];
+      for (const name of names) {
+        await webdav.uploadBackup(await createTempBackup(name));
+      }
+      const remaining = [...mockCtx.files.keys()]
+        .filter((k) => k.endsWith('.db'))
+        .map((k) => path.basename(k))
+        .sort();
+      assert.deepStrictEqual(
+        remaining,
+        [
+          'yuvomi-backup-2099-04-02T00-00-00-000Z.db',
+          'yuvomi-backup-2099-04-03T00-00-00-000Z.db',
+          'yuvomi-backup-2099-04-04T00-00-00-000Z.db',
+        ],
+        'an absolute href must resolve to the same target as a relative one'
       );
     });
   });


### PR DESCRIPTION
Behebt #853 (BradNut, auf Synology gemessen).

## Was passiert ist

Jeder planmäßige Lauf lud ein frisches Backup hoch und löschte es Sekunden später wieder; die sieben ältesten blieben liegen. Wer die Funktion monatelang eingeschaltet ließ, hatte nie einen aktuellen Fernstand. Die Logs des Melders zeigen es dreimal in Folge: `Rotated remote backup: <die Datei, die gerade hochgeladen wurde>`.

## Die Ursache

Das Namespace-Präfix in einer WebDAV-Antwort gehört dem Server. Nextcloud schreibt `<d:getlastmodified>`, Apache `mod_dav` - und damit der WebDAV-Server einer Synology - veröffentlicht Live-Properties unter einem eigenen Präfix als `<lp1:getlastmodified>`. Der Parser bestand auf `D:` oder `d:`.

Er fand also kein Datum. Und dann kam der eigentlich teure Teil: statt das zu melden, setzte er für **jede** Datei ersatzweise `new Date().toUTCString()` ein. Das scheiterte nicht, es ergab einen Gleichstand - und ein Gleichstand sortiert nichts. Übrig blieb die Reihenfolge des Servers, aufsteigend nach Namen (die Namen tragen ISO-Stempel, also chronologisch), und `slice(cfg.keep)` schnitt davon das **neue** Ende ab.

Nachgestellt mit echtem mod_dav-XML, bevor eine Zeile geändert wurde: bei `keep=2` und drei Dateien fiel exakt die jüngste.

## Was geändert ist

Drei Dinge, und das erste ist der Fix:

1. **Das Präfix wird gelesen, wie der Server es schickt** - auch gar keins.
2. **Ein fehlender Zeitstempel bleibt fehlend** statt „jetzt" zu werden. Ein erfundenes Datum ist schlimmer als ein fehlendes, weil es eine Sortierung still in eine Gleichheit kippt, statt sie erkennbar scheitern zu lassen.
3. **Sortiert wird nach dem Stempel im Dateinamen**, den Yuvomi selbst schreibt. Der überlebt jedes Kopieren und hängt an keiner Server-Eigenheit; `getlastmodified` ist nur noch der Rückfall für Dateien, die wir nicht benannt haben.

Darunter ein zweiter Boden: **was gerade hochgeladen wurde, verlässt denselben Lauf nicht mehr.** Sortiert die Rotation je wieder falsch, weil ein Server ein Feld anders schreibt als erwartet, kostet das dann einen überzähligen alten Stand und nicht den einzigen frischen.

Nebenbei mitgenommen: ein absoluter `href` (RFC 4918 erlaubt ihn) wurde an die Basis-URL gehängt - `http://host/http://host/...`. Diese DELETEs gingen ins Leere, der Ordner wuchs unbegrenzt.

## Zu den Tests

Der bestehende Rotationstest prüfte `remoteFiles.length <= 3`. Er zählte, **wie viele** Dateien blieben, nie **welche** - er war grün, während die falsche verschwand. Genau die blinde Stelle, die den Bug ins Release ließ.

Der Mock spricht jetzt beide Namespace-Stile und liefert absolute wie relative hrefs. Neu:

- Rotation auf mod_dav behält die drei neuesten, nicht die drei ältesten
- Die frisch hochgeladene Datei überlebt die Rotation
- Zeitstempel werden aus einer mod_dav-Auflistung gelesen, Sortierung neueste zuerst
- Absoluter href löscht dasselbe Ziel wie ein relativer
- Der alte Test prüft zusätzlich, welche Datei bleibt und welche geht

**Gegenprobe gefahren** (Fix per `cp` beiseite, alter Stand eingespielt): 5 von 18 Tests rot, darunter der erweiterte Alt-Test. Mit dem Fix 18/18 grün, `test:backup-scheduler` (9) und `test:backup-routes` (17) unverändert grün.