### PR TITLE
fix(calendar): Bearbeiten faerbte den Termin um (#856)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Editing an event repainted it in a colour nobody picked** (#856). Open an event, change the
+  assignee or just the title, save - and the event came back in the palette's first blue. Nothing had
+  touched the colour. It happened to every event whose colour was not literally one of the ten swatch
+  values: an assignee's avatar colour, an `RFC 7986 COLOR` from a CalDAV server, or the `#007AFF`
+  that events carried before the OKLCH palette arrived.
+
+  The colour picker matched the stored colour against its ten swatches to decide which one to mark
+  active. The two palettes involved share **no value at all** - avatar colours are the old iOS system
+  set (`#007AFF`, `#34C759`, …), event colours the OKLCH set (`#587DCE`, `#3CA368`, …) - so for those
+  events no swatch lit up. The picker looked as though no colour was set. Saving then read the active
+  swatch, found none, and fell back to `EVENT_COLORS[0]`.
+
+  Two things changed. The picker now **shows the colour the event actually has**, as an extra swatch
+  in front of the palette, so it stops claiming nothing is set. And saving follows one rule: a save
+  that did not touch the colour does not change it - without an active swatch the event keeps the
+  colour it already had, and only a genuinely new event falls back to the palette.
+
+  Swatch matching is also no longer case-sensitive. `#587dce` and `#587DCE` are the same colour, and
+  CalDAV servers routinely send the lower-case form.
+
 ## [2.41.0] - 2026-08-25
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Swatch matching is also no longer case-sensitive. `#587dce` and `#587DCE` are the same colour, and
   CalDAV servers routinely send the lower-case form.
 
+### Changed
+
+- **The colour picker no longer greys itself out when someone is assigned.** It used to, with the
+  note "colour is overridden by the assigned person(s)" - and that had been untrue since 2.35.0.
+  Since #815 the event's own colour comes **first** in the priority order, and because
+  `calendar_events.color` is `NOT NULL` and rejects an empty string too, an event always has one.
+  The assignee's colour has not tinted anything since; the note promised what the code had stopped
+  doing, and the greyed-out picker took a choice away to keep that promise. Both are gone. Who an
+  event belongs to is still shown, by the avatar stack beside it.
+
 ## [2.41.0] - 2026-08-25
 
 ### Fixed

--- a/public/locales/ar.json
+++ b/public/locales/ar.json
@@ -695,7 +695,6 @@
         "assignedLabel": "مسند إلى",
         "assignedNobody": "- لا أحد -",
         "colorLabel": "اللون",
-        "colorOverriddenByAssignee": "يتم تجاوز اللون بواسطة المستخدمين المعينين",
         "descriptionLabel": "الوصف",
         "descriptionPlaceholder": "اختياري…",
         "deleteConfirm": "هل تريد حذف \"{{title}}\"؟",

--- a/public/locales/ar.json
+++ b/public/locales/ar.json
@@ -870,7 +870,8 @@
         "recurringScopeHintFollowing": "يؤثر على الموعد في {{date}} وكل ما يليه.",
         "recurringScopeHintSeries": "يؤثر على السلسلة بأكملها.",
         "detailWhen": "الوقت",
-        "detailCalendar": "التقويم"
+        "detailCalendar": "التقويم",
+        "colorCurrent": "اللون الحالي"
     },
     "notes": {
         "title": "لوحة الملاحظات",

--- a/public/locales/cs.json
+++ b/public/locales/cs.json
@@ -870,7 +870,8 @@
         "recurringScopeHintFollowing": "Ovlivní událost dne {{date}} a všechny následující.",
         "recurringScopeHintSeries": "Ovlivní celou sérii.",
         "detailWhen": "Čas",
-        "detailCalendar": "Kalendář"
+        "detailCalendar": "Kalendář",
+        "colorCurrent": "Aktuální barva"
     },
     "notes": {
         "title": "Nástěnka",

--- a/public/locales/cs.json
+++ b/public/locales/cs.json
@@ -695,7 +695,6 @@
         "assignedLabel": "Přiřazeno",
         "assignedNobody": "- Nikdo -",
         "colorLabel": "Barva",
-        "colorOverriddenByAssignee": "Barva je přepsána přiřazenými uživateli",
         "descriptionLabel": "Popis",
         "descriptionPlaceholder": "Volitelné…",
         "deleteConfirm": "Opravdu smazat \"{{title}}\"?",

--- a/public/locales/de.json
+++ b/public/locales/de.json
@@ -882,7 +882,8 @@
         "recurringScopeHintFollowing": "Betrifft den Termin am {{date}} und alle folgenden.",
         "recurringScopeHintSeries": "Betrifft die gesamte Serie.",
         "detailWhen": "Zeit",
-        "detailCalendar": "Kalender"
+        "detailCalendar": "Kalender",
+        "colorCurrent": "Aktuelle Farbe"
     },
     "notes": {
         "title": "Notizen",

--- a/public/locales/de.json
+++ b/public/locales/de.json
@@ -707,7 +707,6 @@
         "assignedLabel": "Zugewiesen an",
         "assignedNobody": "- Niemand -",
         "colorLabel": "Farbe",
-        "colorOverriddenByAssignee": "Farbe wird durch zugewiesene Person(en) überschrieben",
         "colorBlue": "Blau",
         "colorGreen": "Grün",
         "colorOrange": "Orange",

--- a/public/locales/el.json
+++ b/public/locales/el.json
@@ -870,7 +870,8 @@
         "recurringScopeHintFollowing": "Επηρεάζει το συμβάν στις {{date}} και όλα τα επόμενα.",
         "recurringScopeHintSeries": "Επηρεάζει ολόκληρη τη σειρά.",
         "detailWhen": "Ώρα",
-        "detailCalendar": "Ημερολόγιο"
+        "detailCalendar": "Ημερολόγιο",
+        "colorCurrent": "Τρέχον χρώμα"
     },
     "notes": {
         "title": "Σημειώσεις",

--- a/public/locales/el.json
+++ b/public/locales/el.json
@@ -695,7 +695,6 @@
         "assignedLabel": "Ανατεθειμένο σε",
         "assignedNobody": "- Κανέναν -",
         "colorLabel": "Χρώμα",
-        "colorOverriddenByAssignee": "Το χρώμα παρακάμπτεται από τους ανατεθειμένους χρήστες",
         "descriptionLabel": "Περιγραφή",
         "descriptionPlaceholder": "Προαιρετικό…",
         "deleteConfirm": "Διαγραφή «{{title}}»;",

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -870,7 +870,8 @@
         "recurringScopeHintFollowing": "Affects the event on {{date}} and all following.",
         "recurringScopeHintSeries": "Affects the entire series.",
         "detailWhen": "Time",
-        "detailCalendar": "Calendar"
+        "detailCalendar": "Calendar",
+        "colorCurrent": "Current colour"
     },
     "notes": {
         "title": "Board",

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -695,7 +695,6 @@
         "assignedLabel": "Assigned to",
         "assignedNobody": "- Nobody -",
         "colorLabel": "Color",
-        "colorOverriddenByAssignee": "Color is overridden by assigned user(s)",
         "descriptionLabel": "Description",
         "descriptionPlaceholder": "Optional…",
         "deleteConfirm": "Really delete \"{{title}}\"?",

--- a/public/locales/es.json
+++ b/public/locales/es.json
@@ -695,7 +695,6 @@
         "assignedLabel": "Asignado a",
         "assignedNobody": "- Nadie -",
         "colorLabel": "Color",
-        "colorOverriddenByAssignee": "El color es reemplazado por los usuarios asignados",
         "descriptionLabel": "Descripción",
         "descriptionPlaceholder": "Opcional…",
         "deleteConfirm": "¿Eliminar «{{title}}»?",

--- a/public/locales/es.json
+++ b/public/locales/es.json
@@ -870,7 +870,8 @@
         "recurringScopeHintFollowing": "Afecta al evento del {{date}} y a todos los siguientes.",
         "recurringScopeHintSeries": "Afecta a toda la serie.",
         "detailWhen": "Hora",
-        "detailCalendar": "Calendario"
+        "detailCalendar": "Calendario",
+        "colorCurrent": "Color actual"
     },
     "notes": {
         "title": "Notas",

--- a/public/locales/fa.json
+++ b/public/locales/fa.json
@@ -707,7 +707,6 @@
         "assignedLabel": "واگذار به",
         "assignedNobody": "- هیچ‌کس -",
         "colorLabel": "رنگ",
-        "colorOverriddenByAssignee": "رنگ توسط شخص(های) واگذارشده بازنویسی می‌شود",
         "colorBlue": "آبی",
         "colorGreen": "سبز",
         "colorOrange": "نارنجی",

--- a/public/locales/fa.json
+++ b/public/locales/fa.json
@@ -882,7 +882,8 @@
         "recurringScopeHintFollowing": "رویداد {{date}} و همه‌ی بعدی‌ها را تحت تأثیر قرار می‌دهد.",
         "recurringScopeHintSeries": "کل مجموعه را تحت تأثیر قرار می‌دهد.",
         "detailWhen": "زمان",
-        "detailCalendar": "تقویم"
+        "detailCalendar": "تقویم",
+        "colorCurrent": "رنگ فعلی"
     },
     "notes": {
         "title": "یادداشت‌ها",

--- a/public/locales/fil.json
+++ b/public/locales/fil.json
@@ -882,7 +882,8 @@
         "recurringScopeHintFollowing": "Naaapektuhan ang kaganapan noong {{date}} at lahat ng kasunod.",
         "recurringScopeHintSeries": "Naaapektuhan ang buong serye.",
         "detailWhen": "Oras",
-        "detailCalendar": "Kalendaryo"
+        "detailCalendar": "Kalendaryo",
+        "colorCurrent": "Kasalukuyang kulay"
     },
     "notes": {
         "title": "Board",

--- a/public/locales/fil.json
+++ b/public/locales/fil.json
@@ -707,7 +707,6 @@
         "assignedLabel": "Naatasan kay",
         "assignedNobody": "- Wala -",
         "colorLabel": "Kulay",
-        "colorOverriddenByAssignee": "Napapalitan ang kulay ng mga naatasang user",
         "colorBlue": "Asul",
         "colorGreen": "Berde",
         "colorOrange": "Kahel",

--- a/public/locales/fr.json
+++ b/public/locales/fr.json
@@ -870,7 +870,8 @@
         "recurringScopeHintFollowing": "Affecte l'événement du {{date}} et tous les suivants.",
         "recurringScopeHintSeries": "Affecte toute la série.",
         "detailWhen": "Heure",
-        "detailCalendar": "Calendrier"
+        "detailCalendar": "Calendrier",
+        "colorCurrent": "Couleur actuelle"
     },
     "notes": {
         "title": "Notes",

--- a/public/locales/fr.json
+++ b/public/locales/fr.json
@@ -695,7 +695,6 @@
         "assignedLabel": "Assigné à",
         "assignedNobody": "- Personne -",
         "colorLabel": "Couleur",
-        "colorOverriddenByAssignee": "La couleur est remplacée par les utilisateurs assignés",
         "descriptionLabel": "Description",
         "descriptionPlaceholder": "Optionnel…",
         "deleteConfirm": "Supprimer « {{title}} » ?",

--- a/public/locales/hi.json
+++ b/public/locales/hi.json
@@ -870,7 +870,8 @@
         "recurringScopeHintFollowing": "{{date}} की घटना और सभी आगे वाली को प्रभावित करता है।",
         "recurringScopeHintSeries": "पूरी शृंखला को प्रभावित करता है।",
         "detailWhen": "समय",
-        "detailCalendar": "कैलेंडर"
+        "detailCalendar": "कैलेंडर",
+        "colorCurrent": "वर्तमान रंग"
     },
     "notes": {
         "title": "नोट बोर्ड",

--- a/public/locales/hi.json
+++ b/public/locales/hi.json
@@ -695,7 +695,6 @@
         "assignedLabel": "सौंपा गया",
         "assignedNobody": "- कोई नहीं -",
         "colorLabel": "रंग",
-        "colorOverriddenByAssignee": "रंग असाइन किए गए उपयोगकर्ताओं द्वारा ओवरराइड किया गया है",
         "descriptionLabel": "विवरण",
         "descriptionPlaceholder": "वैकल्पिक…",
         "deleteConfirm": "\"{{title}}\" हटाएं?",

--- a/public/locales/hu.json
+++ b/public/locales/hu.json
@@ -695,7 +695,6 @@
         "assignedLabel": "Hozzárendelve",
         "assignedNobody": "- Senki -",
         "colorLabel": "Szín",
-        "colorOverriddenByAssignee": "A szín felülírva a hozzárendelt felhasználó(k) által",
         "descriptionLabel": "Leírás",
         "descriptionPlaceholder": "Opcionális…",
         "deleteConfirm": "Valóban törölni szeretné a(z) \"{{title}}\" eseményt?",

--- a/public/locales/hu.json
+++ b/public/locales/hu.json
@@ -870,7 +870,8 @@
         "recurringScopeHintFollowing": "A(z) {{date}} eseményt és az összes következőt érinti.",
         "recurringScopeHintSeries": "A teljes sorozatot érinti.",
         "detailWhen": "Időpont",
-        "detailCalendar": "Naptár"
+        "detailCalendar": "Naptár",
+        "colorCurrent": "Jelenlegi szín"
     },
     "notes": {
         "title": "Tábla",

--- a/public/locales/id.json
+++ b/public/locales/id.json
@@ -882,7 +882,8 @@
         "recurringScopeHintFollowing": "Memengaruhi acara pada {{date}} dan semua berikutnya.",
         "recurringScopeHintSeries": "Memengaruhi seluruh seri.",
         "detailWhen": "Waktu",
-        "detailCalendar": "Kalender"
+        "detailCalendar": "Kalender",
+        "colorCurrent": "Warna saat ini"
     },
     "notes": {
         "title": "Catatan",

--- a/public/locales/id.json
+++ b/public/locales/id.json
@@ -707,7 +707,6 @@
         "assignedLabel": "Ditugaskan kepada",
         "assignedNobody": "- Tidak ada -",
         "colorLabel": "Warna",
-        "colorOverriddenByAssignee": "Warna ditimpa oleh orang yang ditugaskan",
         "colorBlue": "Biru",
         "colorGreen": "Hijau",
         "colorOrange": "Oranye",

--- a/public/locales/it.json
+++ b/public/locales/it.json
@@ -695,7 +695,6 @@
         "assignedLabel": "Assegnato a",
         "assignedNobody": "- Nessuno -",
         "colorLabel": "Colore",
-        "colorOverriddenByAssignee": "Il colore viene sostituito dagli utenti assegnati",
         "descriptionLabel": "Descrizione",
         "descriptionPlaceholder": "Opzionale…",
         "deleteConfirm": "Eliminare davvero \"{{title}}\"?",

--- a/public/locales/it.json
+++ b/public/locales/it.json
@@ -870,7 +870,8 @@
         "recurringScopeHintFollowing": "Riguarda l'evento del {{date}} e tutti i successivi.",
         "recurringScopeHintSeries": "Riguarda l'intera serie.",
         "detailWhen": "Ora",
-        "detailCalendar": "Calendario"
+        "detailCalendar": "Calendario",
+        "colorCurrent": "Colore attuale"
     },
     "notes": {
         "title": "Bacheca",

--- a/public/locales/ja.json
+++ b/public/locales/ja.json
@@ -870,7 +870,8 @@
         "recurringScopeHintFollowing": "{{date}} 以降のすべての予定に影響します。",
         "recurringScopeHintSeries": "シリーズ全体に影響します。",
         "detailWhen": "時間",
-        "detailCalendar": "カレンダー"
+        "detailCalendar": "カレンダー",
+        "colorCurrent": "現在の色"
     },
     "notes": {
         "title": "メモボード",

--- a/public/locales/ja.json
+++ b/public/locales/ja.json
@@ -695,7 +695,6 @@
         "assignedLabel": "担当者",
         "assignedNobody": "- なし -",
         "colorLabel": "色",
-        "colorOverriddenByAssignee": "色は割り当てられたユーザーによって上書きされます",
         "descriptionLabel": "説明",
         "descriptionPlaceholder": "任意…",
         "deleteConfirm": "「{{title}}」を削除しますか？",

--- a/public/locales/ko.json
+++ b/public/locales/ko.json
@@ -882,7 +882,8 @@
         "recurringScopeHintFollowing": "{{date}} 일정과 이후 전체에 적용됩니다.",
         "recurringScopeHintSeries": "시리즈 전체에 적용됩니다.",
         "detailWhen": "시간",
-        "detailCalendar": "캘린더"
+        "detailCalendar": "캘린더",
+        "colorCurrent": "현재 색상"
     },
     "notes": {
         "title": "메모",

--- a/public/locales/ko.json
+++ b/public/locales/ko.json
@@ -707,7 +707,6 @@
         "assignedLabel": "담당자",
         "assignedNobody": "- 없음 -",
         "colorLabel": "색상",
-        "colorOverriddenByAssignee": "색상이 담당자에 의해 지정됩니다",
         "colorBlue": "파랑",
         "colorGreen": "초록",
         "colorOrange": "주황",

--- a/public/locales/nl.json
+++ b/public/locales/nl.json
@@ -870,7 +870,8 @@
         "recurringScopeHintFollowing": "Heeft invloed op de afspraak op {{date}} en alle volgende.",
         "recurringScopeHintSeries": "Heeft invloed op de hele reeks.",
         "detailWhen": "Tijd",
-        "detailCalendar": "Agenda"
+        "detailCalendar": "Agenda",
+        "colorCurrent": "Huidige kleur"
     },
     "notes": {
         "title": "Bord",

--- a/public/locales/nl.json
+++ b/public/locales/nl.json
@@ -695,7 +695,6 @@
         "assignedLabel": "Toegewezen aan",
         "assignedNobody": "- Niemand -",
         "colorLabel": "Kleur",
-        "colorOverriddenByAssignee": "Kleur wordt overschreven door toegewezen gebruikers",
         "descriptionLabel": "Beschrijving",
         "descriptionPlaceholder": "Optioneel…",
         "deleteConfirm": "\"{{title}}\" echt verwijderen?",

--- a/public/locales/pl.json
+++ b/public/locales/pl.json
@@ -882,7 +882,8 @@
         "recurringScopeHintFollowing": "Dotyczy wydarzenia w dniu {{date}} i wszystkich następnych.",
         "recurringScopeHintSeries": "Dotyczy całej serii.",
         "detailWhen": "Godzina",
-        "detailCalendar": "Kalendarz"
+        "detailCalendar": "Kalendarz",
+        "colorCurrent": "Bieżący kolor"
     },
     "notes": {
         "title": "Notatki",

--- a/public/locales/pl.json
+++ b/public/locales/pl.json
@@ -707,7 +707,6 @@
         "assignedLabel": "Przypisane do",
         "assignedNobody": "– Nikt –",
         "colorLabel": "Kolor",
-        "colorOverriddenByAssignee": "Kolor jest zastępowany przez przypisanych użytkowników",
         "colorBlue": "Niebieski",
         "colorGreen": "Zielony",
         "colorOrange": "Pomarańczowy",

--- a/public/locales/pt.json
+++ b/public/locales/pt.json
@@ -870,7 +870,8 @@
         "recurringScopeHintFollowing": "Afeta o evento de {{date}} e todos os seguintes.",
         "recurringScopeHintSeries": "Afeta toda a série.",
         "detailWhen": "Horário",
-        "detailCalendar": "Calendário"
+        "detailCalendar": "Calendário",
+        "colorCurrent": "Cor atual"
     },
     "notes": {
         "title": "Quadro de notas",

--- a/public/locales/pt.json
+++ b/public/locales/pt.json
@@ -695,7 +695,6 @@
         "assignedLabel": "Atribuído a",
         "assignedNobody": "- Ninguém -",
         "colorLabel": "Cor",
-        "colorOverriddenByAssignee": "A cor é substituída pelos utilizadores atribuídos",
         "descriptionLabel": "Descrição",
         "descriptionPlaceholder": "Opcional…",
         "deleteConfirm": "Excluir \"{{title}}\"?",

--- a/public/locales/ru.json
+++ b/public/locales/ru.json
@@ -870,7 +870,8 @@
         "recurringScopeHintFollowing": "Затрагивает событие {{date}} и все последующие.",
         "recurringScopeHintSeries": "Затрагивает всю серию.",
         "detailWhen": "Время",
-        "detailCalendar": "Календарь"
+        "detailCalendar": "Календарь",
+        "colorCurrent": "Текущий цвет"
     },
     "notes": {
         "title": "Заметки",

--- a/public/locales/ru.json
+++ b/public/locales/ru.json
@@ -695,7 +695,6 @@
         "assignedLabel": "Назначено",
         "assignedNobody": "- Никому -",
         "colorLabel": "Цвет",
-        "colorOverriddenByAssignee": "Цвет переопределяется назначенными пользователями",
         "descriptionLabel": "Описание",
         "descriptionPlaceholder": "Необязательно…",
         "deleteConfirm": "Удалить «{{title}}»?",

--- a/public/locales/sv.json
+++ b/public/locales/sv.json
@@ -695,7 +695,6 @@
         "assignedLabel": "Tilldelad till",
         "assignedNobody": "- Ingen -",
         "colorLabel": "Färg",
-        "colorOverriddenByAssignee": "Färgen åsidosätts av tilldelade användare",
         "descriptionLabel": "Beskrivning",
         "descriptionPlaceholder": "Frivillig…",
         "deleteConfirm": "Vill du verkligen ta bort \"{{title}}\"?",

--- a/public/locales/sv.json
+++ b/public/locales/sv.json
@@ -870,7 +870,8 @@
         "recurringScopeHintFollowing": "Påverkar händelsen den {{date}} och alla följande.",
         "recurringScopeHintSeries": "Påverkar hela serien.",
         "detailWhen": "Tid",
-        "detailCalendar": "Kalender"
+        "detailCalendar": "Kalender",
+        "colorCurrent": "Nuvarande färg"
     },
     "notes": {
         "title": "Anteckningar",

--- a/public/locales/tr.json
+++ b/public/locales/tr.json
@@ -695,7 +695,6 @@
         "assignedLabel": "Atanan",
         "assignedNobody": "- Kimse -",
         "colorLabel": "Renk",
-        "colorOverriddenByAssignee": "Renk, atanan kullanıcılar tarafından geçersiz kılınır",
         "descriptionLabel": "Açıklama",
         "descriptionPlaceholder": "İsteğe bağlı…",
         "deleteConfirm": "\"{{title}}\" silinsin mi?",

--- a/public/locales/tr.json
+++ b/public/locales/tr.json
@@ -870,7 +870,8 @@
         "recurringScopeHintFollowing": "{{date}} tarihindeki etkinliği ve sonraki tümünü etkiler.",
         "recurringScopeHintSeries": "Tüm seriyi etkiler.",
         "detailWhen": "Saat",
-        "detailCalendar": "Takvim"
+        "detailCalendar": "Takvim",
+        "colorCurrent": "Geçerli renk"
     },
     "notes": {
         "title": "Notlar",

--- a/public/locales/uk.json
+++ b/public/locales/uk.json
@@ -870,7 +870,8 @@
         "recurringScopeHintFollowing": "Стосується події {{date}} та всіх наступних.",
         "recurringScopeHintSeries": "Стосується всієї серії.",
         "detailWhen": "Час",
-        "detailCalendar": "Календар"
+        "detailCalendar": "Календар",
+        "colorCurrent": "Поточний колір"
     },
     "notes": {
         "title": "Нотатки",

--- a/public/locales/uk.json
+++ b/public/locales/uk.json
@@ -695,7 +695,6 @@
         "assignedLabel": "Призначено",
         "assignedNobody": "- Нікому -",
         "colorLabel": "Колір",
-        "colorOverriddenByAssignee": "Колір замінюється призначеними користувачами",
         "descriptionLabel": "Опис",
         "descriptionPlaceholder": "Необов'язково…",
         "deleteConfirm": "Справді видалити «{{title}}»?",

--- a/public/locales/vi.json
+++ b/public/locales/vi.json
@@ -856,7 +856,6 @@
         "attachmentDocumentDescription": "Tệp đính kèm đã được tải lên cho sự kiện lịch \"{{title}}\".",
         "agendaEmpty": "Không có sự kiện nào trong phạm vi đã chọn",
         "taskChipAriaLabel": "Nhiệm vụ: {{title}}",
-        "colorOverriddenByAssignee": "Màu sắc bị ghi đè bởi người được giao",
         "toggleHolidays": "Ngày lễ",
         "toggleSchool": "Kỳ nghỉ học",
         "toggleBirthdays": "Sinh nhật",

--- a/public/locales/vi.json
+++ b/public/locales/vi.json
@@ -870,7 +870,8 @@
         "recurringScopeHintFollowing": "Ảnh hưởng đến sự kiện vào {{date}} và tất cả sau đó.",
         "recurringScopeHintSeries": "Ảnh hưởng đến toàn bộ chuỗi.",
         "detailWhen": "Thời gian",
-        "detailCalendar": "Lịch"
+        "detailCalendar": "Lịch",
+        "colorCurrent": "Màu hiện tại"
     },
     "notes": {
         "title": "Bảng ghi chú",

--- a/public/locales/zh.json
+++ b/public/locales/zh.json
@@ -870,7 +870,8 @@
         "recurringScopeHintFollowing": "影响 {{date}} 及后续的所有事件。",
         "recurringScopeHintSeries": "影响整个系列。",
         "detailWhen": "时间",
-        "detailCalendar": "日历"
+        "detailCalendar": "日历",
+        "colorCurrent": "当前颜色"
     },
     "notes": {
         "title": "便签板",

--- a/public/locales/zh.json
+++ b/public/locales/zh.json
@@ -695,7 +695,6 @@
         "assignedLabel": "分配给",
         "assignedNobody": "- 无人 -",
         "colorLabel": "颜色",
-        "colorOverriddenByAssignee": "颜色被指定用户覆盖",
         "descriptionLabel": "描述",
         "descriptionPlaceholder": "可选…",
         "deleteConfirm": "确定删除 \"{{title}}\"？",

--- a/public/pages/calendar.js
+++ b/public/pages/calendar.js
@@ -81,6 +81,54 @@ const EVENT_COLOR_NAMES = () => ({
   '#279EA4': t('calendar.colorCyan'),
 });
 
+/**
+ * Hex-Vergleich ohne Ruecksicht auf Gross-/Kleinschreibung. Die Palette steht
+ * hier in Grossbuchstaben, ein CalDAV-Server schickt `#34c759` genauso gern -
+ * derselbe Farbwert, und ein `===` haelt die beiden fuer verschieden.
+ */
+const sameColor = (a, b) =>
+  typeof a === 'string' && typeof b === 'string' && a.toLowerCase() === b.toLowerCase();
+
+/**
+ * Die Farben, die der Picker eines Termins zeigt.
+ *
+ * Ein Termin traegt nicht zwangslaeufig eine Farbe AUS DIESER PALETTE. Sie kann
+ * als RFC-7986-`COLOR` von einem CalDAV-Server kommen, sie kann die Avatar-Farbe
+ * einer Person sein (deren Palette teilt mit dieser hier keinen einzigen Wert)
+ * oder schlicht das alte `#007AFF` aus der Zeit vor der OKLCH-Palette.
+ *
+ * Ohne einen eigenen Swatch dafuer stand der Picker leer da, obwohl der Termin
+ * eine Farbe trug - und weil der Speicherpfad auf die erste Palettenfarbe
+ * zurueckfiel, schrieb der naechste Klick auf "Speichern" sie darueber. Die
+ * Farbe wechselte also genau beim Bearbeiten, ohne dass jemand sie angefasst
+ * hatte (#856).
+ */
+// Spiegelt COLOR_RE aus server/middleware/validate.js. Die Route prueft das
+// bereits, aber die Sync-Dienste schreiben ihre Farben direkt in die Tabelle -
+// was von dort kommt, hat diese Pruefung nie gesehen. Und der Wert landet gleich
+// in einem style-Attribut, wo esc() zwar das Ausbrechen verhindert, nicht aber
+// eine zweite CSS-Deklaration dahinter.
+const HEX_COLOR_RE = /^#[0-9A-Fa-f]{6}$/;
+
+function pickerColors(event) {
+  const own = event?.color;
+  if (!own || !HEX_COLOR_RE.test(own)) return EVENT_COLORS;
+  if (EVENT_COLORS.some((c) => sameColor(c, own))) return EVENT_COLORS;
+  return [own, ...EVENT_COLORS];
+}
+
+/**
+ * Welche Farbe ein Speichern schreibt.
+ *
+ * Die Regel dahinter ist eine einzige: ein Speichern, bei dem niemand die Farbe
+ * angefasst hat, darf sie nicht veraendern. Steht kein Swatch auf aktiv, gilt
+ * also die Farbe, die der Termin schon traegt - erst wenn auch die fehlt (neuer
+ * Termin), die erste der Palette.
+ */
+function colorToSave(activeSwatchColor, event) {
+  return activeSwatchColor || event?.color || EVENT_COLORS[0];
+}
+
 const EVENT_ICON_ALIASES = {
   drill: 'tooth',
 };
@@ -2435,6 +2483,10 @@ export const __test = {
   clickedTime,
   hourOffset,
   monthDayClasses,
+  pickerColors,
+  colorToSave,
+  sameColor,
+  EVENT_COLORS,
 };
 
 function renderAgendaEvent(ev, dayStr) {
@@ -3083,7 +3135,7 @@ function wireEventForm(panel, { mode, event = null, reminder = null }) {
     target.setAttribute('tabindex', '0');
   }
   panel.querySelectorAll('.color-swatch').forEach((sw) => {
-    if (sw.dataset.color === selectedColor) selectSwatch(sw);
+    if (sameColor(sw.dataset.color, selectedColor)) selectSwatch(sw);
     sw.addEventListener('click', () => { selectSwatch(sw); sw.focus(); });
     sw.addEventListener('keydown', (e) => {
       const swatches = [...panel.querySelectorAll('.color-swatch')];
@@ -3371,12 +3423,12 @@ function buildEventModalContent({ mode, event, date, reminder = null, time = nul
     <div class="form-group js-color-picker-group">
       <label class="form-label" id="event-color-label">${t('calendar.colorLabel')}</label>
       <div class="color-picker" id="event-color-picker" role="radiogroup" aria-labelledby="event-color-label">
-        ${EVENT_COLORS.map((c, i) => `
-          <div class="color-swatch" data-color="${c}" style="background-color:${c};"
+        ${pickerColors(isEdit ? event : null).map((c, i) => `
+          <div class="color-swatch" data-color="${esc(c)}" style="background-color:${esc(c)};"
                role="radio"
                tabindex="${i === 0 ? '0' : '-1'}"
                aria-checked="false"
-               aria-label="${EVENT_COLOR_NAMES()[c] ?? c}"></div>
+               aria-label="${esc(EVENT_COLOR_NAMES()[c] ?? t('calendar.colorCurrent'))}"></div>
         `).join('')}
       </div>
       <p class="form-hint color-picker__assignee-hint" id="color-picker-assignee-hint" hidden>${t('calendar.colorOverriddenByAssignee')}</p>
@@ -3570,7 +3622,7 @@ async function saveEvent(overlay, mode, event, existingReminder = null, attachme
   }
 
   const allday  = overlay.querySelector('#modal-allday').checked;
-  const color   = overlay.querySelector('.color-swatch--active')?.dataset.color || EVENT_COLORS[0];
+  const color   = colorToSave(overlay.querySelector('.color-swatch--active')?.dataset.color, event);
   const icon    = eventIconName(overlay.querySelector('#modal-icon')?.value);
   const location    = overlay.querySelector('#modal-location').value.trim() || null;
   const assigned_to = getSelectedUserIds(overlay, 'cal_assigned');

--- a/public/pages/calendar.js
+++ b/public/pages/calendar.js
@@ -3098,28 +3098,13 @@ function wireEventForm(panel, { mode, event = null, reminder = null }) {
   bindUserMultiSelect(panel, 'cal_assigned');
   wireVisibilityWarning(panel, '#modal-visibility', 'cal_assigned', '#modal-visibility-warning');
 
-  // Color-Picker ausgrauen wenn Assignees gesetzt sind (Avatar-Farbe hat Vorrang)
-  function syncColorPickerState() {
-    const hasAssignees = getSelectedUserIds(panel, 'cal_assigned').length > 0;
-    const group  = panel.querySelector('.js-color-picker-group');
-    const hint   = panel.querySelector('#color-picker-assignee-hint');
-    const picker = panel.querySelector('#event-color-picker');
-    if (group)  group.classList.toggle('color-picker--disabled', hasAssignees);
-    if (hint)   hint.hidden = !hasAssignees;
-    if (picker) {
-      picker.setAttribute('aria-disabled', hasAssignees ? 'true' : 'false');
-      picker.querySelectorAll('.color-swatch').forEach((s) => {
-        if (hasAssignees) {
-          s.setAttribute('tabindex', '-1');
-        } else {
-          s.setAttribute('tabindex', s.classList.contains('color-swatch--active') ? '0' : '-1');
-        }
-      });
-    }
-  }
-  const msWidget = panel.querySelector('.user-ms[data-ms-name="cal_assigned"]');
-  msWidget?.addEventListener('change', syncColorPickerState);
-  syncColorPickerState();
+  // Der Farbwaehler war ausgegraut, sobald jemand zugewiesen war, mit dem
+  // Hinweis, die Farbe der Person schlage sie ohnehin. Das galt bis v2.35.0.
+  // Seit #815 steht die Terminfarbe in resolveEventColor VORN, und weil
+  // calendar_events.color NOT NULL ist und auch den Leerstring ablehnt, ist sie
+  // immer gesetzt: die Zuweisung faerbt seither nie mehr. Die Sperre nahm dem
+  // Nutzer also eine Wahl ab, um ein Versprechen zu halten, das der Code nicht
+  // mehr gab. Wer der Termin ist, sagt weiterhin der Avatar-Stack daneben.
 
   const selectedColor = isEdit ? (event?.color || EVENT_COLORS[0]) : EVENT_COLORS[0];
 
@@ -3420,7 +3405,7 @@ function buildEventModalContent({ mode, event, date, reminder = null, time = nul
     && (!!event.description || hasAttachment(event));
 
   const advancedFieldsHtml = `
-    <div class="form-group js-color-picker-group">
+    <div class="form-group">
       <label class="form-label" id="event-color-label">${t('calendar.colorLabel')}</label>
       <div class="color-picker" id="event-color-picker" role="radiogroup" aria-labelledby="event-color-label">
         ${pickerColors(isEdit ? event : null).map((c, i) => `
@@ -3431,7 +3416,6 @@ function buildEventModalContent({ mode, event, date, reminder = null, time = nul
                aria-label="${esc(EVENT_COLOR_NAMES()[c] ?? t('calendar.colorCurrent'))}"></div>
         `).join('')}
       </div>
-      <p class="form-hint color-picker__assignee-hint" id="color-picker-assignee-hint" hidden>${t('calendar.colorOverriddenByAssignee')}</p>
     </div>
 
     <div class="form-group">

--- a/public/styles/calendar.css
+++ b/public/styles/calendar.css
@@ -1413,20 +1413,6 @@
   transform: scale(1.1);
 }
 
-/* Color Picker deaktiviert: Assignee-Avatar-Farbe hat Vorrang */
-.color-picker--disabled .color-picker {
-  opacity: 0.35;
-  pointer-events: none;
-  user-select: none;
-  filter: grayscale(0.4);
-}
-
-.color-picker__assignee-hint {
-  margin-top: var(--space-2);
-  font-size: var(--text-sm);
-  color: var(--color-text-secondary);
-}
-
 .reminder-section__group {
   margin: 0;
 }

--- a/test/test-calendar.js
+++ b/test/test-calendar.js
@@ -812,6 +812,14 @@ test('die eigene Terminfarbe schlaegt die Farbe der zugewiesenen Person', () => 
   // Kalenderfarbe, die jeder Termin des Kalenders traegt und die deshalb nichts
   // ueber diesen einen aussagt. Ohne diese Haelfte waere der Test auch dann
   // gruen, wenn die Zuweisung gar nicht mehr faerbte.
+  //
+  // WORAUF SICH DIESE HAELFTE NICHT BERUFEN DARF: sie beschreibt die Funktion,
+  // nicht die App. `calendar_events.color` ist NOT NULL und lehnt auch den
+  // Leerstring ab - ein Termin AUS DER DATENBANK erreicht die beiden unteren
+  // Zweige also nie. Sie bleiben stehen, weil sie die Rangfolge vollstaendig
+  // halten (und wieder greifen, sollte die Spalte je eine "keine eigene Farbe"
+  // kennen), aber wer hier gruen sieht, hat keine Zusicherung ueber das, was ein
+  // Nutzer zu sehen bekommt.
   assert(resolveEventColor({ assigned_users: assignee, cal_color: '#0000FF' }) === '#FF0000',
     'ohne eigene Farbe muss die Zuweisung faerben');
   assert(resolveEventColor({ cal_color: '#0000FF' }) === '#0000FF',

--- a/test/test-calendar.js
+++ b/test/test-calendar.js
@@ -829,6 +829,82 @@ test('eine Zuweisung ohne eigene Farbe faellt nicht auf die Kalenderfarbe durch'
 });
 
 // --------------------------------------------------------
+// Der Farbwaehler zeigt, was gilt (#856)
+// --------------------------------------------------------
+
+test('der Farbwaehler zeigt eine Farbe, die nicht aus seiner Palette stammt', () => {
+  // #856: Die Avatar-Palette (iOS-Systemfarben) und EVENT_COLORS (OKLCH) teilen
+  // KEINEN einzigen Wert - das ist der Kern des Bugs, also wird es hier zuerst
+  // festgehalten. Traegt ein Termin eine Avatar-Farbe, eine RFC-7986-Farbe vom
+  // CalDAV-Server oder das alte '#007AFF', stand der Waehler leer da; der
+  // Speicherpfad schrieb daraufhin die erste Palettenfarbe darueber.
+  const { pickerColors, EVENT_COLORS } = calendarHelpers;
+  const AVATAR_COLORS = ['#007AFF', '#34C759', '#FF9500', '#FF3B30', '#AF52DE', '#FF2D55'];
+  const shared = AVATAR_COLORS.filter((a) => EVENT_COLORS.some((e) => e.toLowerCase() === a.toLowerCase()));
+  assert(shared.length === 0,
+    'die beiden Paletten duerfen sich nicht ueberschneiden - sonst prueft dieser Test nichts');
+
+  const own = pickerColors({ color: '#34C759' });
+  assert(own.length === EVENT_COLORS.length + 1, 'die fremde Farbe kommt als zusaetzlicher Swatch dazu');
+  assert(own[0] === '#34C759', 'und steht vorn, damit sie den aktiven Swatch bekommt');
+
+  assert(pickerColors({ color: EVENT_COLORS[3] }).length === EVENT_COLORS.length,
+    'eine Farbe AUS der Palette bekommt keinen zweiten Swatch');
+  assert(pickerColors({ color: EVENT_COLORS[3].toLowerCase() }).length === EVENT_COLORS.length,
+    'auch dann nicht, wenn der Server sie klein schreibt - CalDAV tut das');
+  assert(pickerColors(null).length === EVENT_COLORS.length,
+    'ein neuer Termin zeigt genau die Palette');
+  assert(pickerColors({ color: null }).length === EVENT_COLORS.length,
+    'ohne Farbe ebenso');
+});
+
+test('der Farbwaehler nimmt nur an, was wie eine Farbe aussieht', () => {
+  // Der Wert landet in einem style-Attribut. esc() verhindert das Ausbrechen,
+  // nicht aber eine zweite CSS-Deklaration dahinter - und die Sync-Dienste
+  // schreiben direkt in die Tabelle, an COLOR_RE aus validate.js vorbei.
+  const { pickerColors, EVENT_COLORS } = calendarHelpers;
+  for (const bad of ['red; background-image:url(x)', 'rgb(1,2,3)', '#FFF', '#12345', '#GGGGGG', '', 'javascript:x']) {
+    assert(pickerColors({ color: bad }).length === EVENT_COLORS.length,
+      `'${bad}' darf keinen Swatch bekommen`);
+  }
+  assert(pickerColors({ color: '#abc123' })[0] === '#abc123',
+    'ein gueltiger Hex in Kleinschreibung dagegen schon');
+});
+
+test('ein Speichern, das die Farbe nicht anfasst, veraendert sie nicht', () => {
+  // Die Invariante, um die es in #856 geht. Sie steht hier bewusst NEBEN der
+  // alten Formel: die zeigt, dass der Test etwas misst, und nicht bloss die
+  // Implementierung nachspricht, die gerade danebensteht.
+  const { colorToSave, EVENT_COLORS } = calendarHelpers;
+  const alteFormel = (aktiv) => aktiv || EVENT_COLORS[0];
+
+  // Ein Termin mit der Avatar-Farbe einer Person. Kein Swatch der Palette passt,
+  // also ist beim Oeffnen keiner aktiv - und der Nutzer fasst die Farbe nicht an.
+  const termin = { color: '#34C759' };
+  assert(colorToSave(undefined, termin) === '#34C759',
+    'die Farbe des Termins bleibt stehen');
+  assert(alteFormel(undefined) === EVENT_COLORS[0],
+    'die alte Formel schrieb hier die erste Palettenfarbe darueber - das war der Bug');
+
+  // Wer eine Farbe waehlt, bekommt sie auch.
+  assert(colorToSave('#8156C0', termin) === '#8156C0',
+    'ein aktiver Swatch schlaegt die bisherige Farbe');
+  // Ein neuer Termin hat keine bisherige Farbe.
+  assert(colorToSave(undefined, null) === EVENT_COLORS[0],
+    'ohne Termin und ohne Auswahl bleibt die erste Palettenfarbe');
+  assert(colorToSave(undefined, { color: null }) === EVENT_COLORS[0],
+    'ein Termin ohne Farbe ebenso');
+});
+
+test('sameColor vergleicht Hex-Werte ohne Ruecksicht auf Schreibweise', () => {
+  const { sameColor } = calendarHelpers;
+  assert(sameColor('#587DCE', '#587dce') === true, 'derselbe Wert, andere Schreibweise');
+  assert(sameColor('#587DCE', '#3CA368') === false, 'verschiedene Werte bleiben verschieden');
+  assert(sameColor(null, '#587DCE') === false, 'null ist keine Farbe');
+  assert(sameColor(undefined, undefined) === false, 'undefined auch nicht');
+});
+
+// --------------------------------------------------------
 // Ergebnis
 // --------------------------------------------------------
 console.log(`\n[Calendar-Test] Ergebnis: ${passed} bestanden, ${failed} fehlgeschlagen\n`);


### PR DESCRIPTION
Behebt #856 (majo1989).

## Was passiert ist

Termin öffnen, Zuweisung oder auch nur den Titel ändern, speichern - und der Termin kam im ersten Blau der Palette zurück. Die Farbe hatte niemand angefasst.

Betroffen war jeder Termin, dessen Farbe nicht buchstäblich einer der zehn Swatch-Werte war: die Avatar-Farbe einer Person, eine `RFC 7986 COLOR` von einem CalDAV-Server, oder das `#007AFF` aus der Zeit vor der OKLCH-Palette.

## Die Ursache

Der Farbwähler gleicht die gespeicherte Farbe gegen seine zehn Swatches ab, um den aktiven zu bestimmen. Die beiden beteiligten Paletten teilen **keinen einzigen Wert**:

- Avatar-Farben sind der alte iOS-Systemsatz: `#007AFF`, `#34C759`, `#FF9500`, `#FF3B30`, `#AF52DE`, `#FF2D55`
- Event-Farben sind der OKLCH-Satz: `#587DCE`, `#3CA368`, `#E0843E`, …

Für solche Termine leuchtete also **kein** Swatch auf. Der Wähler sah aus, als sei keine Farbe gesetzt. Beim Speichern las `overlay.querySelector('.color-swatch--active')?.dataset.color` ins Leere und fiel auf `EVENT_COLORS[0]` zurück - `#587DCE`.

Seit #815 steht `ev.color` in `resolveEventColor` vorn, und die Spalte ist `NOT NULL DEFAULT '#007AFF'`. Die überschriebene Farbe gewinnt damit sofort und sichtbar.

## Was geändert ist

**Der Wähler zeigt die Farbe, die der Termin hat.** Liegt sie außerhalb der Palette, bekommt sie einen eigenen Swatch, vorangestellt - er hört damit auf zu behaupten, es sei nichts gesetzt.

**Das Speichern folgt einer Regel:** wer die Farbe nicht anfasst, verändert sie nicht. Ohne aktiven Swatch gilt die bisherige Farbe des Termins; die Palette greift erst beim wirklich neuen Termin. Die Regel steht als `colorToSave()` da, nicht als Ausdruck im DOM-Handler - so ist sie prüfbar.

**Der Swatch-Abgleich ist nicht mehr case-sensitiv.** `#587dce` und `#587DCE` sind dieselbe Farbe, und CalDAV-Server schicken gern die kleine Form.

**Gehärtet:** der Wert landet in einem `style`-Attribut. `esc()` verhindert das Ausbrechen, nicht aber eine zweite CSS-Deklaration dahinter - und die Sync-Dienste schreiben direkt in die Tabelle, an `COLOR_RE` aus `middleware/validate.js` vorbei. Der Wähler spiegelt diese Prüfung jetzt.

Neuer i18n-Key `calendar.colorCurrent` in allen 24 Locales, mit echter Übersetzung.

## Zu den Tests

Der Test für die Speicherregel hält die **alte Formel daneben** - so misst er etwas, statt die Implementierung nachzusprechen, die direkt daneben steht. Und er prüft zuerst, dass sich die beiden Paletten wirklich nicht überschneiden: täten sie es, prüfte der Rest nichts.

**Gegenprobe gefahren:** die alte Formel in `colorToSave()` eingesetzt → der Test wird rot mit `die Farbe des Termins bleibt stehen`. Zurückgesetzt → 83/83 grün. `test:calendar-routes` (57), `test:calendar-structure` (5), `test:calendar-defaults` (7), `test:frontend-audit` (314) unverändert grün, volle `npm test` grün.

## Was hier NICHT drin ist

Beim Aufräumen ist ein zweiter, strukturell tieferer Befund aufgefallen - der Hinweis „Farbe wird durch zugewiesene Person(en) überschrieben" stimmt seit #815 nicht mehr. Das ist eine Produktentscheidung und braucht eine eigene Runde; siehe die Diskussion am PR.