### PR TITLE
fix: die Rate eines aufgenommenen Kredits bleibt korrigierbar (#859)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Which of the two it is follows from the loan, is changed there, and any other answer was going to
   be silently overruled on save.
 
+  Two further faults surfaced once this path could be walked at all, and both are fixed here. Opening
+  an instalment for editing from the loan list filled the dialog from the instalment rather than from
+  the budget entry it belongs to. On a foreign-currency loan that meant the loan-currency figure went
+  in where the budget-currency one belongs, so saving converted it a second time - 100 USD at 0.50
+  became a 200 USD instalment. And because that stand-in carries no account, the dialog offered "no
+  account" and saving unlinked the instalment from the account it was charged to, moving that
+  account's balance. Both happened even if all you touched was the title.
+
+  Editing now loads the actual entry instead of assembling a second, partial copy of it. The
+  assembled one still describes the row in the list, where the loan currency is the right figure to
+  show - it was never an editing record, and now nothing treats it as one.
+
 
 ## [2.41.1] - 2026-08-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **An instalment on a loan the household had taken on could not be corrected** (#859). Tick off an
+  instalment on a borrowed loan, then open that booking in the budget and change the amount: saving
+  failed with "Loan repayment entries must remain income." Nothing the dialog could send was
+  accepted, because the dialog was right and the check was wrong. There was no way around it either
+  - deleting the instalment and booking it again was the only remedy.
+
+  The rule dates from a time when every loan was money lent out, where a repayment coming back
+  really is income. Loan direction arrived in v1.77.0 (#638): an instalment on a loan you took on
+  leaves the household and is booked as an expense, so it is negative by design. The loans routes
+  learned that; the entry route kept the old rule and rejected exactly the sign it had itself
+  written.
+
+  The sign of a repayment booking now belongs to the loan rather than to the request, and it is
+  derived from the same rule everywhere - booking an instalment, re-booking after a change of
+  direction, and editing the booking afterwards. That rule lived inside the loans routes, which is
+  why the entry route could contradict it; it is now shared between them.
+
+  Two things the old check had been hiding come with it. The cap against paying off more than the
+  loan still owes compared a signed amount against a positive remainder, so on a borrowed loan it
+  was always satisfied and never stopped anything. And an amount of zero, previously caught by the
+  income rule as a side effect, is now refused on its own terms rather than reaching a database
+  constraint.
+
+  In the budget dialog, the income/expense switch is now inert on a loan instalment and says so.
+  Which of the two it is follows from the loan, is changed there, and any other answer was going to
+  be silently overruled on save.
+
+
 ## [2.41.1] - 2026-08-25
 
 ### Fixed

--- a/public/locales/ar.json
+++ b/public/locales/ar.json
@@ -1390,7 +1390,8 @@
         "receiptsAttachedLabel": "الإيصالات المرفقة: {{count}}",
         "receiptsAttachedLabel_one": "إيصال واحد مرفق",
         "loanPaidInstallmentsLabel": "الأقساط المدفوعة بالفعل",
-        "loanPaidInstallmentsHint": "لقرض قيد السداد بالفعل. تُضاف هذه الأقساط دون تسجيلها في الميزانية."
+        "loanPaidInstallmentsHint": "لقرض قيد السداد بالفعل. تُضاف هذه الأقساط دون تسجيلها في الميزانية.",
+        "loanPaymentTypeLocked": "الدخل أو المصروف يتبع نوع القرض ويُغيَّر هناك."
     },
     "settings": {
         "healthCycleEnableLabel": "إظهار علامة تبويب الدورة",

--- a/public/locales/cs.json
+++ b/public/locales/cs.json
@@ -1390,7 +1390,8 @@
         "receiptsAttachedLabel": "Připojené doklady: {{count}}",
         "receiptsAttachedLabel_one": "Připojený doklad: {{count}}",
         "loanPaidInstallmentsLabel": "Již zaplacené splátky",
-        "loanPaidInstallmentsHint": "Pro půjčku, která již běží. Tyto splátky se doplní, ale nezaúčtují se do rozpočtu."
+        "loanPaidInstallmentsHint": "Pro půjčku, která již běží. Tyto splátky se doplní, ale nezaúčtují se do rozpočtu.",
+        "loanPaymentTypeLocked": "Příjem nebo výdaj se řídí typem půjčky a mění se tam."
     },
     "settings": {
         "healthCycleEnableLabel": "Zobrazit kartu cyklu",

--- a/public/locales/de.json
+++ b/public/locales/de.json
@@ -1402,7 +1402,8 @@
         "receiptsAttachedLabel": "{{count}} Belege angehängt",
         "receiptsAttachedLabel_one": "{{count}} Beleg angehängt",
         "loanPaidInstallmentsLabel": "Bereits gezahlte Raten",
-        "loanPaidInstallmentsHint": "Für ein Darlehen, das schon läuft. Diese Raten werden nachgetragen, aber nicht ins Budget gebucht."
+        "loanPaidInstallmentsHint": "Für ein Darlehen, das schon läuft. Diese Raten werden nachgetragen, aber nicht ins Budget gebucht.",
+        "loanPaymentTypeLocked": "Einnahme oder Ausgabe folgt der Art des Darlehens und wird dort geändert."
     },
     "settings": {
         "healthCycleEnableLabel": "Zyklus-Tab anzeigen",

--- a/public/locales/el.json
+++ b/public/locales/el.json
@@ -1390,7 +1390,8 @@
         "receiptsAttachedLabel": "{{count}} συνημμένες αποδείξεις",
         "receiptsAttachedLabel_one": "{{count}} συνημμένη απόδειξη",
         "loanPaidInstallmentsLabel": "Ήδη πληρωμένες δόσεις",
-        "loanPaidInstallmentsHint": "Για δάνειο που τρέχει ήδη. Οι δόσεις αυτές καταχωρούνται χωρίς να περάσουν στον προϋπολογισμό."
+        "loanPaidInstallmentsHint": "Για δάνειο που τρέχει ήδη. Οι δόσεις αυτές καταχωρούνται χωρίς να περάσουν στον προϋπολογισμό.",
+        "loanPaymentTypeLocked": "Το έσοδο ή το έξοδο ακολουθεί τον τύπο του δανείου και αλλάζει εκεί."
     },
     "settings": {
         "healthCycleEnableLabel": "Εμφάνιση καρτέλας κύκλου",

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -1390,7 +1390,8 @@
         "receiptsAttachedLabel": "{{count}} receipts attached",
         "receiptsAttachedLabel_one": "{{count}} receipt attached",
         "loanPaidInstallmentsLabel": "Installments already paid",
-        "loanPaidInstallmentsHint": "For a loan that is already running. These installments are recorded but not booked to the budget."
+        "loanPaidInstallmentsHint": "For a loan that is already running. These installments are recorded but not booked to the budget.",
+        "loanPaymentTypeLocked": "Income or expense follows the loan type and is changed there."
     },
     "settings": {
         "healthCycleEnableLabel": "Show cycle tab",

--- a/public/locales/es.json
+++ b/public/locales/es.json
@@ -1390,7 +1390,8 @@
         "receiptsAttachedLabel": "{{count}} comprobantes adjuntos",
         "receiptsAttachedLabel_one": "{{count}} comprobante adjunto",
         "loanPaidInstallmentsLabel": "Cuotas ya pagadas",
-        "loanPaidInstallmentsHint": "Para un préstamo que ya está en curso. Estas cuotas se registran, pero no se contabilizan en el presupuesto."
+        "loanPaidInstallmentsHint": "Para un préstamo que ya está en curso. Estas cuotas se registran, pero no se contabilizan en el presupuesto.",
+        "loanPaymentTypeLocked": "Que sea ingreso o gasto depende del tipo de préstamo y se cambia allí."
     },
     "settings": {
         "healthCycleEnableLabel": "Mostrar la pestaña de ciclo",

--- a/public/locales/fa.json
+++ b/public/locales/fa.json
@@ -1402,7 +1402,8 @@
         "receiptsAttachedLabel": "رسیدهای پیوست‌شده: {{count}}",
         "receiptsAttachedLabel_one": "رسیدهای پیوست‌شده: {{count}}",
         "loanPaidInstallmentsLabel": "اقساط پرداخت‌شده",
-        "loanPaidInstallmentsHint": "برای وامی که از قبل در جریان است. این اقساط ثبت می‌شوند اما در بودجه لحاظ نمی‌شوند."
+        "loanPaidInstallmentsHint": "برای وامی که از قبل در جریان است. این اقساط ثبت می‌شوند اما در بودجه لحاظ نمی‌شوند.",
+        "loanPaymentTypeLocked": "درآمد یا هزینه بودن از نوع وام پیروی می‌کند و آنجا تغییر می‌کند."
     },
     "settings": {
         "healthCycleEnableLabel": "نمایش برگهٔ چرخه",

--- a/public/locales/fil.json
+++ b/public/locales/fil.json
@@ -1402,7 +1402,8 @@
         "receiptsAttachedLabel": "{{count}} resibo ang nakalakip",
         "receiptsAttachedLabel_one": "{{count}} resibo ang nakalakip",
         "loanPaidInstallmentsLabel": "Mga hulog na nabayaran na",
-        "loanPaidInstallmentsHint": "Para sa utang na tumatakbo na. Naitatala ang mga hulog na ito ngunit hindi ibinibilang sa badyet."
+        "loanPaidInstallmentsHint": "Para sa utang na tumatakbo na. Naitatala ang mga hulog na ito ngunit hindi ibinibilang sa badyet.",
+        "loanPaymentTypeLocked": "Ang kita o gastos ay sumusunod sa uri ng utang at doon binabago."
     },
     "settings": {
         "healthCycleEnableLabel": "Ipakita ang tab ng siklo",

--- a/public/locales/fr.json
+++ b/public/locales/fr.json
@@ -1390,7 +1390,8 @@
         "receiptsAttachedLabel": "{{count}} justificatifs joints",
         "receiptsAttachedLabel_one": "{{count}} justificatif joint",
         "loanPaidInstallmentsLabel": "Échéances déjà payées",
-        "loanPaidInstallmentsHint": "Pour un prêt déjà en cours. Ces échéances sont enregistrées mais non comptabilisées dans le budget."
+        "loanPaidInstallmentsHint": "Pour un prêt déjà en cours. Ces échéances sont enregistrées mais non comptabilisées dans le budget.",
+        "loanPaymentTypeLocked": "Revenu ou dépense suit le type de prêt et se modifie à cet endroit."
     },
     "settings": {
         "healthCycleEnableLabel": "Afficher l’onglet cycle",

--- a/public/locales/hi.json
+++ b/public/locales/hi.json
@@ -1390,7 +1390,8 @@
         "receiptsAttachedLabel": "{{count}} रसीदें संलग्न",
         "receiptsAttachedLabel_one": "{{count}} रसीद संलग्न",
         "loanPaidInstallmentsLabel": "पहले से चुकाई गई किस्तें",
-        "loanPaidInstallmentsHint": "पहले से चल रहे ऋण के लिए। ये किस्तें दर्ज होती हैं, पर बजट में नहीं जोड़ी जातीं।"
+        "loanPaidInstallmentsHint": "पहले से चल रहे ऋण के लिए। ये किस्तें दर्ज होती हैं, पर बजट में नहीं जोड़ी जातीं।",
+        "loanPaymentTypeLocked": "आय या व्यय ऋण के प्रकार पर निर्भर करता है और वहीं बदला जाता है।"
     },
     "settings": {
         "healthCycleEnableLabel": "चक्र टैब दिखाएँ",

--- a/public/locales/hu.json
+++ b/public/locales/hu.json
@@ -1390,7 +1390,8 @@
         "receiptsAttachedLabel": "{{count}} csatolt bizonylat",
         "receiptsAttachedLabel_one": "{{count}} csatolt bizonylat",
         "loanPaidInstallmentsLabel": "Már kifizetett részletek",
-        "loanPaidInstallmentsHint": "Már futó kölcsönhöz. Ezek a részletek rögzülnek, de nem kerülnek be a költségvetésbe."
+        "loanPaidInstallmentsHint": "Már futó kölcsönhöz. Ezek a részletek rögzülnek, de nem kerülnek be a költségvetésbe.",
+        "loanPaymentTypeLocked": "A bevétel vagy kiadás a kölcsön típusát követi, és ott módosítható."
     },
     "settings": {
         "healthCycleEnableLabel": "Ciklus fül megjelenítése",

--- a/public/locales/id.json
+++ b/public/locales/id.json
@@ -1402,7 +1402,8 @@
         "receiptsAttachedLabel": "{{count}} bukti terlampir",
         "receiptsAttachedLabel_one": "{{count}} bukti terlampir",
         "loanPaidInstallmentsLabel": "Cicilan yang sudah dibayar",
-        "loanPaidInstallmentsHint": "Untuk pinjaman yang sudah berjalan. Cicilan ini dicatat, tetapi tidak dibukukan ke anggaran."
+        "loanPaidInstallmentsHint": "Untuk pinjaman yang sudah berjalan. Cicilan ini dicatat, tetapi tidak dibukukan ke anggaran.",
+        "loanPaymentTypeLocked": "Pemasukan atau pengeluaran mengikuti jenis pinjaman dan diubah di sana."
     },
     "settings": {
         "healthCycleEnableLabel": "Tampilkan tab siklus",

--- a/public/locales/it.json
+++ b/public/locales/it.json
@@ -1390,7 +1390,8 @@
         "receiptsAttachedLabel": "{{count}} ricevute allegate",
         "receiptsAttachedLabel_one": "{{count}} ricevuta allegata",
         "loanPaidInstallmentsLabel": "Rate già pagate",
-        "loanPaidInstallmentsHint": "Per un prestito già in corso. Queste rate vengono registrate ma non contabilizzate nel budget."
+        "loanPaidInstallmentsHint": "Per un prestito già in corso. Queste rate vengono registrate ma non contabilizzate nel budget.",
+        "loanPaymentTypeLocked": "Entrata o uscita segue il tipo di prestito e si modifica lì."
     },
     "settings": {
         "healthCycleEnableLabel": "Mostra la scheda ciclo",

--- a/public/locales/ja.json
+++ b/public/locales/ja.json
@@ -1390,7 +1390,8 @@
         "receiptsAttachedLabel": "領収書 {{count}} 件を添付",
         "receiptsAttachedLabel_one": "領収書 {{count}} 件を添付",
         "loanPaidInstallmentsLabel": "支払い済みの回数",
-        "loanPaidInstallmentsHint": "すでに返済中のローン用です。これらの回は記録されますが、家計簿には計上されません。"
+        "loanPaidInstallmentsHint": "すでに返済中のローン用です。これらの回は記録されますが、家計簿には計上されません。",
+        "loanPaymentTypeLocked": "収入か支出かは貸付・借入の別に従い、そちらで変更します。"
     },
     "settings": {
         "healthCycleEnableLabel": "周期タブを表示",

--- a/public/locales/ko.json
+++ b/public/locales/ko.json
@@ -1402,7 +1402,8 @@
         "receiptsAttachedLabel": "영수증 {{count}}건 첨부됨",
         "receiptsAttachedLabel_one": "영수증 {{count}}건 첨부됨",
         "loanPaidInstallmentsLabel": "이미 상환한 회차",
-        "loanPaidInstallmentsHint": "이미 상환 중인 대출용입니다. 해당 회차는 기록되지만 가계부에는 반영되지 않습니다."
+        "loanPaidInstallmentsHint": "이미 상환 중인 대출용입니다. 해당 회차는 기록되지만 가계부에는 반영되지 않습니다.",
+        "loanPaymentTypeLocked": "수입인지 지출인지는 대출 유형을 따르며 거기에서 변경합니다."
     },
     "settings": {
         "healthCycleEnableLabel": "주기 탭 표시",

--- a/public/locales/nl.json
+++ b/public/locales/nl.json
@@ -1390,7 +1390,8 @@
         "receiptsAttachedLabel": "{{count}} bonnen bijgevoegd",
         "receiptsAttachedLabel_one": "{{count}} bon bijgevoegd",
         "loanPaidInstallmentsLabel": "Al betaalde termijnen",
-        "loanPaidInstallmentsHint": "Voor een lening die al loopt. Deze termijnen worden vastgelegd, maar niet in het budget geboekt."
+        "loanPaidInstallmentsHint": "Voor een lening die al loopt. Deze termijnen worden vastgelegd, maar niet in het budget geboekt.",
+        "loanPaymentTypeLocked": "Inkomst of uitgave volgt de soort lening en wordt daar gewijzigd."
     },
     "settings": {
         "healthCycleEnableLabel": "Cyclustabblad tonen",

--- a/public/locales/pl.json
+++ b/public/locales/pl.json
@@ -1402,7 +1402,8 @@
         "receiptsAttachedLabel": "Załączone dowody: {{count}}",
         "receiptsAttachedLabel_one": "Załączone dowody: {{count}}",
         "loanPaidInstallmentsLabel": "Już zapłacone raty",
-        "loanPaidInstallmentsHint": "Dla pożyczki, która już trwa. Te raty zostaną uzupełnione, ale nie trafią do budżetu."
+        "loanPaidInstallmentsHint": "Dla pożyczki, która już trwa. Te raty zostaną uzupełnione, ale nie trafią do budżetu.",
+        "loanPaymentTypeLocked": "Przychód lub wydatek wynika z rodzaju pożyczki i tam się go zmienia."
     },
     "settings": {
         "healthCycleEnableLabel": "Pokaż kartę cyklu",

--- a/public/locales/pt.json
+++ b/public/locales/pt.json
@@ -1390,7 +1390,8 @@
         "receiptsAttachedLabel": "{{count}} comprovativos anexados",
         "receiptsAttachedLabel_one": "{{count}} comprovativo anexado",
         "loanPaidInstallmentsLabel": "Parcelas já pagas",
-        "loanPaidInstallmentsHint": "Para um empréstimo que já está em curso. Estas parcelas são registadas, mas não lançadas no orçamento."
+        "loanPaidInstallmentsHint": "Para um empréstimo que já está em curso. Estas parcelas são registadas, mas não lançadas no orçamento.",
+        "loanPaymentTypeLocked": "Receita ou despesa segue o tipo de empréstimo e é alterada lá."
     },
     "settings": {
         "healthCycleEnableLabel": "Mostrar a aba de ciclo",

--- a/public/locales/ru.json
+++ b/public/locales/ru.json
@@ -1390,7 +1390,8 @@
         "receiptsAttachedLabel": "Прикреплено чеков: {{count}}",
         "receiptsAttachedLabel_one": "Прикреплён чек: {{count}}",
         "loanPaidInstallmentsLabel": "Уже оплаченные платежи",
-        "loanPaidInstallmentsHint": "Для займа, который уже выплачивается. Эти платежи фиксируются, но не проводятся по бюджету."
+        "loanPaidInstallmentsHint": "Для займа, который уже выплачивается. Эти платежи фиксируются, но не проводятся по бюджету.",
+        "loanPaymentTypeLocked": "Доход или расход следует типу займа и меняется там."
     },
     "settings": {
         "healthCycleEnableLabel": "Показать вкладку цикла",

--- a/public/locales/sv.json
+++ b/public/locales/sv.json
@@ -1390,7 +1390,8 @@
         "receiptsAttachedLabel": "{{count}} kvitton bifogade",
         "receiptsAttachedLabel_one": "{{count}} kvitto bifogat",
         "loanPaidInstallmentsLabel": "Redan betalda delbetalningar",
-        "loanPaidInstallmentsHint": "För ett lån som redan löper. Dessa delbetalningar registreras men bokförs inte i budgeten."
+        "loanPaidInstallmentsHint": "För ett lån som redan löper. Dessa delbetalningar registreras men bokförs inte i budgeten.",
+        "loanPaymentTypeLocked": "Inkomst eller utgift följer typen av lån och ändras där."
     },
     "settings": {
         "healthCycleEnableLabel": "Visa cykelfliken",

--- a/public/locales/tr.json
+++ b/public/locales/tr.json
@@ -1390,7 +1390,8 @@
         "receiptsAttachedLabel": "{{count}} fiş eklendi",
         "receiptsAttachedLabel_one": "{{count}} fiş eklendi",
         "loanPaidInstallmentsLabel": "Halihazırda ödenen taksitler",
-        "loanPaidInstallmentsHint": "Zaten devam eden bir kredi için. Bu taksitler kaydedilir, ancak bütçeye işlenmez."
+        "loanPaidInstallmentsHint": "Zaten devam eden bir kredi için. Bu taksitler kaydedilir, ancak bütçeye işlenmez.",
+        "loanPaymentTypeLocked": "Gelir mi gider mi olduğu kredi türüne bağlıdır ve orada değiştirilir."
     },
     "settings": {
         "healthCycleEnableLabel": "Döngü sekmesini göster",

--- a/public/locales/uk.json
+++ b/public/locales/uk.json
@@ -1390,7 +1390,8 @@
         "receiptsAttachedLabel": "Прикріплено чеків: {{count}}",
         "receiptsAttachedLabel_one": "Прикріплено чек: {{count}}",
         "loanPaidInstallmentsLabel": "Уже сплачені платежі",
-        "loanPaidInstallmentsHint": "Для позики, що вже виплачується. Ці платежі фіксуються, але не проводяться в бюджеті."
+        "loanPaidInstallmentsHint": "Для позики, що вже виплачується. Ці платежі фіксуються, але не проводяться в бюджеті.",
+        "loanPaymentTypeLocked": "Дохід або витрата залежить від типу позики й змінюється там."
     },
     "settings": {
         "healthCycleEnableLabel": "Показати вкладку циклу",

--- a/public/locales/vi.json
+++ b/public/locales/vi.json
@@ -1390,7 +1390,8 @@
         "receiptsAttachedLabel": "Đã đính kèm {{count}} chứng từ",
         "receiptsAttachedLabel_one": "Đã đính kèm {{count}} chứng từ",
         "loanPaidInstallmentsLabel": "Số kỳ đã trả",
-        "loanPaidInstallmentsHint": "Dành cho khoản vay đang trả dở. Các kỳ này được ghi nhận nhưng không hạch toán vào ngân sách."
+        "loanPaidInstallmentsHint": "Dành cho khoản vay đang trả dở. Các kỳ này được ghi nhận nhưng không hạch toán vào ngân sách.",
+        "loanPaymentTypeLocked": "Thu nhập hay chi phí phụ thuộc vào loại khoản vay và được thay đổi ở đó."
     },
     "settings": {
         "healthCycleEnableLabel": "Hiện tab chu kỳ",

--- a/public/locales/zh.json
+++ b/public/locales/zh.json
@@ -1390,7 +1390,8 @@
         "receiptsAttachedLabel": "已附加 {{count}} 张凭证",
         "receiptsAttachedLabel_one": "已附加 {{count}} 张凭证",
         "loanPaidInstallmentsLabel": "已支付期数",
-        "loanPaidInstallmentsHint": "适用于已在还款的借贷。这些期数会被记录，但不会计入预算。"
+        "loanPaidInstallmentsHint": "适用于已在还款的借贷。这些期数会被记录，但不会计入预算。",
+        "loanPaymentTypeLocked": "属于收入还是支出取决于借贷类型，请在那里更改。"
     },
     "settings": {
         "healthCycleEnableLabel": "显示周期标签页",

--- a/public/pages/budget.js
+++ b/public/pages/budget.js
@@ -1524,22 +1524,26 @@ function isBorrowedLoan(loan) {
   return loan?.direction === 'borrowed';
 }
 
+/**
+ * Rate als Zeilen-Ansicht: Betrag in DARLEHENSWÄHRUNG, Vorzeichen aus der Richtung.
+ *
+ * Nur zum Anzeigen. Der gekoppelte Budget-Eintrag steht in Budget-Währung und trägt
+ * Felder, die hier nicht vorkommen - Konto, Sichtbarkeit, Belege. Wer dieses Objekt
+ * bearbeiten liesse, schriebe den Ratenbetrag als Budget-Betrag zurück und räumte
+ * nebenbei jedes Feld ab, das der Nachbau nicht kennt. Das Bearbeiten lädt deshalb
+ * den echten Eintrag, siehe openLoanPaymentEntry().
+ */
 function loanPaymentToEntry(loan, payment) {
   if (!payment.budget_entry_id) return null;
   return {
     id: payment.budget_entry_id,
-    // Kopplung mitgeben: das Edit-Modal sperrt daran den Typ-Umschalter. Über die
-    // Eintragsliste kommt sie ohnehin aus der API mit (entryWithLoanMeta) - ohne
-    // sie hier wäre der Umschalter je nach Einstiegspunkt mal gesperrt, mal nicht.
-    loan_id: loan.id,
-    loan_payment_id: payment.id,
     // Fallbacks über t() bzw. leer: der frühere hartkodierte englische Titel und
     // die deutsche Kategorie „Geschenke & Transfers" waren in 22 von 23 Sprachen
     // falsch — und die Kategorie ist längst ein Key, kein Anzeigename.
     title: payment.entry_title || t('budget.loanPaymentTitle', { borrower: loan.borrower }),
     // budget_loan_payments.amount ist per CHECK immer positiv (Betrag der Rate);
-    // das Vorzeichen trägt der gekoppelte Budget-Eintrag, und genau den bearbeitet
-    // das Edit-Modal - ohne die Spiegelung stünde dort eine Ausgabe als Einnahme.
+    // das Vorzeichen trägt der gekoppelte Budget-Eintrag - ohne die Spiegelung
+    // stünde eine Ausgabe in der Zeile als Einnahme.
     amount: (isBorrowedLoan(loan) ? -1 : 1) * Number(payment.amount || 0),
     category: payment.entry_category || '',
     subcategory: payment.entry_subcategory || '',
@@ -1654,10 +1658,7 @@ function wireLoansPage() {
   });
   _container.querySelectorAll('[data-action="loan-payment-edit"]').forEach((btn) => {
     btn.addEventListener('click', () => {
-      const loan = state.loans.loans.find((item) => item.id === parseInt(btn.dataset.loanId, 10));
-      const payment = loan?.payments?.find((item) => item.id === parseInt(btn.dataset.paymentId, 10));
-      const entry = loan && payment ? loanPaymentToEntry(loan, payment) : null;
-      if (entry) openBudgetModal({ mode: 'edit', entry });
+      openLoanPaymentEntry(parseInt(btn.dataset.loanId, 10), parseInt(btn.dataset.paymentId, 10));
     });
   });
   _container.querySelectorAll('[data-action="loan-payment-delete"]').forEach((btn) => {
@@ -1665,6 +1666,28 @@ function wireLoansPage() {
       await deleteLoanPayment(parseInt(btn.dataset.loanId, 10), parseInt(btn.dataset.paymentId, 10));
     });
   });
+}
+
+/**
+ * Öffnet den Bearbeiten-Dialog einer Rate mit dem ECHTEN Budget-Eintrag.
+ *
+ * Der Drilldown liefert dieselbe Zeile, die auch die Eintragsliste bearbeitet: Betrag
+ * in Budget-Währung, Konto, Sichtbarkeit, Belege, Darlehens-Kopplung. Aus der Rate ein
+ * Eintragsobjekt zu bauen hiesse, denselben Datensatz ein zweites Mal und unvollständig
+ * zu führen, und jedes dabei fehlende Feld wird beim Speichern stillschweigend geleert.
+ */
+async function openLoanPaymentEntry(loanId, paymentId) {
+  try {
+    const res = await api.get(`/budget?loan_id=${loanId}`);
+    const entry = (res.data ?? []).find((e) => e.loan_payment_id === paymentId);
+    if (!entry) {
+      window.yuvomi?.showToast(t('common.unknownError'), 'danger');
+      return;
+    }
+    openBudgetModal({ mode: 'edit', entry });
+  } catch (err) {
+    window.yuvomi?.showToast(err.data?.error ?? t('common.unknownError'), 'danger');
+  }
 }
 
 function openLoanReport(loan) {

--- a/public/pages/budget.js
+++ b/public/pages/budget.js
@@ -1528,6 +1528,11 @@ function loanPaymentToEntry(loan, payment) {
   if (!payment.budget_entry_id) return null;
   return {
     id: payment.budget_entry_id,
+    // Kopplung mitgeben: das Edit-Modal sperrt daran den Typ-Umschalter. Über die
+    // Eintragsliste kommt sie ohnehin aus der API mit (entryWithLoanMeta) - ohne
+    // sie hier wäre der Umschalter je nach Einstiegspunkt mal gesperrt, mal nicht.
+    loan_id: loan.id,
+    loan_payment_id: payment.id,
     // Fallbacks über t() bzw. leer: der frühere hartkodierte englische Titel und
     // die deutsche Kategorie „Geschenke & Transfers" waren in 22 von 23 Sprachen
     // falsch — und die Kategorie ist längst ein Key, kein Anzeigename.
@@ -1914,6 +1919,11 @@ function openBudgetModal({ mode, entry = null, initialType = '' }) {
   const defaultDate = defaultDateInPeriod(from, to, today);
 
   const isExpense  = isEdit ? entry.amount < 0 : true;
+  // Rate eines Darlehens (#638/#859): Ob sie Einnahme oder Ausgabe ist, entscheidet
+  // die Richtung des Darlehens, nicht dieser Dialog. Der Umschalter bleibt sichtbar,
+  // damit die Zuordnung ablesbar ist, nimmt hier aber keine Eingabe entgegen - der
+  // Server bucht ohnehin nach der Richtung und würde eine Umkehr still zurückdrehen.
+  const isLoanPayment = isEdit && (entry.loan_payment_id != null || entry.loan_id != null);
   // Bei virtuellen Serien hält amount nur den Monatsanteil; im Formular den eingegebenen Periodenbetrag zeigen.
   const editAmount = isEdit && entry.recurrence_virtual && entry.recurrence_full_amount != null
     ? entry.recurrence_full_amount
@@ -1953,12 +1963,13 @@ function openBudgetModal({ mode, entry = null, initialType = '' }) {
   const content = `
     <div class="amount-type-toggle ${isEdit ? 'amount-type-toggle--entry-only' : ''}">
       <button class="amount-type-btn amount-type-btn--expenses ${isExpense ? 'amount-type-btn--active' : ''}"
-              id="type-expense" type="button">${t('budget.typeExpense')}</button>
+              id="type-expense" type="button" ${isLoanPayment ? 'disabled' : ''}>${t('budget.typeExpense')}</button>
       <button class="amount-type-btn amount-type-btn--income ${!isExpense ? 'amount-type-btn--active' : ''}"
-              id="type-income" type="button">${t('budget.typeIncome')}</button>
+              id="type-income" type="button" ${isLoanPayment ? 'disabled' : ''}>${t('budget.typeIncome')}</button>
       ${!isEdit ? `<button class="amount-type-btn amount-type-btn--loan"
               id="type-loan" type="button">${t('budget.typeLoan')}</button>` : ''}
     </div>
+    ${isLoanPayment ? `<p class="budget-type-locked-hint">${t('budget.loanPaymentTypeLocked')}</p>` : ''}
 
     <div class="form-group js-entry-field">
       <label class="form-label" for="bm-title">${t('budget.titleLabel')}<span class="required-marker" aria-hidden="true"> *</span></label>

--- a/public/styles/budget.css
+++ b/public/styles/budget.css
@@ -1467,6 +1467,23 @@
   min-height: var(--target-lg);
 }
 
+/* Rate eines Darlehens (#859): Der Umschalter zeigt die Zuordnung, nimmt sie aber
+   nicht entgegen - die Richtung gehört dem Darlehen. Der aktive Zustand behält
+   deshalb seine volle Farbe, nur die Bedienbarkeit fällt weg. */
+.amount-type-btn:disabled {
+  cursor: default;
+}
+
+.amount-type-btn:disabled:not(.amount-type-btn--active) {
+  opacity: 0.5;
+}
+
+.budget-type-locked-hint {
+  margin: var(--space-2) 0 0;
+  color: var(--color-text-secondary);
+  font-size: var(--text-sm);
+}
+
 .amount-type-btn--income.amount-type-btn--active {
   background-color: var(--color-success);
   color: var(--color-ink-on-vivid);

--- a/server/routes/budget/entries.js
+++ b/server/routes/budget/entries.js
@@ -15,7 +15,7 @@ import {
   generateRecurringInstances, RECURRENCE_INTERVAL_KEYS, MAX_INTERVAL_COUNT,
   normalizeIntervalCount, effectiveMonthly,
   validCategoryKeys, defaultCategory, validateSubcategory, validateAccountRef,
-  entryWithLoanMeta, refreshLoanStatus, fromBudgetAmount,
+  entryWithLoanMeta, refreshLoanStatus, fromBudgetAmount, bookingFor,
 } from './helpers.js';
 
 const log = createLogger('Budget');
@@ -493,20 +493,29 @@ router.put('/:id', (req, res) => {
     const linkedPayment = db.get().prepare(`
       SELECT * FROM budget_loan_payments WHERE budget_entry_id = ?
     `).get(id);
-    if (linkedPayment && amount !== undefined && Number(amount) <= 0) {
-      return res.status(400).json({ error: 'Loan repayment entries must remain income.', code: 400 });
-    }
     // Währung je Darlehen (#582): Der Budget-Eintrag steht in Budget-Währung, die
     // gekoppelte Rate dagegen in Darlehenswährung. Beide Richtungen unten rechnen
     // deshalb über den festen Kurs des Darlehens um - sonst würde ein Edit des
     // Eintrags die Restschuld eines Fremdwährungs-Darlehens verfälschen.
     const linkedLoan = linkedPayment
-      ? db.get().prepare('SELECT total_amount, currency, exchange_rate FROM budget_loans WHERE id = ?').get(linkedPayment.loan_id)
+      ? db.get().prepare('SELECT total_amount, currency, exchange_rate, direction FROM budget_loans WHERE id = ?').get(linkedPayment.loan_id)
       : null;
+    // Richtung (#638/#859): Das Vorzeichen des Eintrags gehört dem Darlehen, nicht
+    // dem Request. Eine Rate auf einen aufgenommenen Kredit ist eine Ausgabe und
+    // kommt folglich negativ herein - die frühere Prüfung "muss Einkommen bleiben"
+    // stammte aus der Zeit, als jedes Darlehen ein verliehenes war, und sperrte
+    // jede Korrektur an einer solchen Rate. Statt abzuweisen wird der Betrag jetzt
+    // nach derselben Regel gebucht wie beim Anlegen und beim Richtungswechsel.
+    // Die Rate selbst bleibt vorzeichenlos: budget_loan_payments.amount trägt einen
+    // CHECK(amount > 0) und wird gegen die Restschuld gerechnet.
+    const linkedSign = linkedPayment ? bookingFor(linkedLoan?.direction).sign : 1;
     const linkedPaymentAmount = linkedPayment && amount !== undefined
-      ? fromBudgetAmount(amount, linkedLoan)
+      ? Math.abs(fromBudgetAmount(amount, linkedLoan))
       : null;
     if (linkedPayment && amount !== undefined) {
+      if (!(linkedPaymentAmount > 0)) {
+        return res.status(400).json({ error: 'Amount must be greater than zero.', code: 400 });
+      }
       const otherPaid = db.get().prepare(`
         SELECT COALESCE(SUM(amount), 0) AS total
         FROM budget_loan_payments
@@ -550,8 +559,11 @@ router.put('/:id', (req, res) => {
       : entry.recurrence_confirm;
     if (!finalRecurring) finalConfirm = 0;
     // Konfigurierter Periodenbetrag (vorzeichenbehaftet): neue Eingabe, sonst bisheriger Vollbetrag.
+    // Bei einer gekoppelten Rate setzt die Darlehensrichtung das Vorzeichen (#638/#859):
+    // Ein Client, der den Typ-Umschalter umgeht, darf eine Ausgabe nicht zur Einnahme
+    // machen - daran hängen Monatsbilanz, Statistik und der Kontosaldo.
     const configuredFull = amount !== undefined
-      ? Number(amount)
+      ? (linkedPayment ? linkedSign * Math.abs(Number(amount)) : Number(amount))
       : (entry.recurrence_full_amount != null ? entry.recurrence_full_amount : entry.amount);
     const nextAmount = finalVirtual ? effectiveMonthly(configuredFull, finalInterval, finalCount) : cents(configuredFull);
     const nextFull   = finalVirtual ? cents(configuredFull) : null;

--- a/server/routes/budget/helpers.js
+++ b/server/routes/budget/helpers.js
@@ -573,6 +573,34 @@ export function fromBudgetAmount(amount, loan) {
   return cents(Number(amount || 0) / loanRate(loan));
 }
 
+// --------------------------------------------------------
+// Richtung eines Darlehens (#638)
+// --------------------------------------------------------
+
+// Das Modul war ursprünglich nur für verliehenes Geld gedacht - die Rate wurde
+// deshalb immer als Einnahme gebucht. Ein aufgenommener Kredit zahlt aber raus,
+// seine Rate ist eine Ausgabe.
+export const LOAN_DIRECTIONS = ['lent', 'borrowed'];
+
+// Wie eine Rate ins Budget gebucht wird. Vorzeichen UND Kategorie hängen an der
+// Richtung: stats.js liest den Typ am Vorzeichen ab (amount > 0 = Einnahme), die
+// Kategorie muss dazu passen, sonst steht eine Ausgabe unter einer income-Kategorie.
+//
+// Diese Regel steht hier und nicht im Loans-Router, weil sie an DREI Stellen gilt:
+// beim Buchen einer Rate, beim Umbuchen nach einem Richtungswechsel und beim
+// Bearbeiten des gekoppelten Budget-Eintrags. Solange sie nur der Loans-Router
+// kannte, erzwang der Eintrags-Router weiter das alte "Rate = Einnahme" und
+// sperrte damit jede Korrektur an der Rate eines aufgenommenen Kredits (#859).
+export const REPAYMENT_BOOKING = {
+  lent: { sign: 1, category: 'Geschenke & Transfers', subcategory: '' },
+  borrowed: { sign: -1, category: 'financial_other', subcategory: 'loans_interest' },
+};
+
+/** Buchungsregel eines Darlehens; unbekannte/fehlende Richtung fällt auf 'lent' zurück. */
+export function bookingFor(direction) {
+  return REPAYMENT_BOOKING[direction] || REPAYMENT_BOOKING.lent;
+}
+
 export function loanSummaryRow(loan, baseCurrency = budgetCurrency()) {
   const payments = db.get().prepare(`
     SELECT p.*, u.display_name AS creator_name,

--- a/server/routes/budget/loans.js
+++ b/server/routes/budget/loans.js
@@ -12,6 +12,7 @@ import { computeLoanSchedule, MAX_LOAN_MONTHS } from '../../services/loan-amorti
 import {
   budgetFilter, mayEdit, getBudgetMode, loanSummaryRow, loadLoan, refreshLoanStatus, cents,
   budgetCurrency, toBudgetAmount, CURRENCY_RE, validateAccountRef, addMonths,
+  LOAN_DIRECTIONS, bookingFor,
 } from './helpers.js';
 
 const log = createLogger('Budget');
@@ -20,24 +21,6 @@ const router = express.Router();
 // 'variable' = Darlehen ganz ohne Zinsbindung (#569-Nachtrag): rechnet einphasig
 // wie 'fixed', der Satz gilt aber nur als aktueller Wert (Prognose).
 const INTEREST_MODES = ['none', 'fixed', 'variable', 'fixed_then_variable'];
-
-// Richtung (#638): Das Modul war ursprünglich nur für verliehenes Geld gedacht -
-// die Rate wurde deshalb immer als Einnahme gebucht. Ein aufgenommener Kredit
-// zahlt aber raus, seine Rate ist eine Ausgabe.
-const LOAN_DIRECTIONS = ['lent', 'borrowed'];
-
-// Wie eine Rate ins Budget gebucht wird. Vorzeichen UND Kategorie hängen an der
-// Richtung: stats.js liest den Typ am Vorzeichen ab (amount > 0 = Einnahme), die
-// Kategorie muss dazu passen, sonst steht eine Ausgabe unter einer income-Kategorie.
-const REPAYMENT_BOOKING = {
-  lent: { sign: 1, category: 'Geschenke & Transfers', subcategory: '' },
-  borrowed: { sign: -1, category: 'financial_other', subcategory: 'loans_interest' },
-};
-
-/** Buchungsregel eines Darlehens; unbekannte/fehlende Richtung fällt auf 'lent' zurück. */
-function bookingFor(direction) {
-  return REPAYMENT_BOOKING[direction] || REPAYMENT_BOOKING.lent;
-}
 
 /**
  * Richtung aus dem Request (#638).

--- a/test/test-budget-entries-routes.js
+++ b/test/test-budget-entries-routes.js
@@ -9,7 +9,8 @@
  *          - GET / (month-400, category-/account_id-Filter, loan_id-Drilldown)
  *          - POST / (subcategory-400, account-not-found-400, virtuelles Budget)
  *          - PUT /:id (404, subcategory-400, Konto setzen/entfernen, virtuelles
- *            Budget, Loan-Payment-Kopplung: income-Zwang + Rest-Grenze + Sync)
+ *            Budget, Loan-Payment-Kopplung: Richtung setzt das Vorzeichen (#859),
+ *            Rest-Grenze + Sync)
  *          - DELETE /:id (404, Loan-Payment-Cascade + refreshLoanStatus,
  *            Skip-Markierung bei Instanz-Löschung)
  *          - PUT /:id/series (404, not-recurring-400, Parent-Update, Sichtbarkeits-
@@ -296,15 +297,83 @@ test('PUT /:id: Sichtbarkeit umschalten (owner_id bleibt fix)', async () => {
 });
 
 // ── PUT /:id: Loan-Payment-Kopplung ──────────────────────────────────────────────
-test('PUT /:id: verknüpfte Rückzahlung muss Einkommen bleiben (Betrag ≤ 0 → 400)', async () => {
-  const loan = db.prepare(`INSERT INTO budget_loans (title, borrower, total_amount, installment_count, start_month, created_by)
-                           VALUES ('L1','Bo',1000,10,'2033-01',?)`).run(A).lastInsertRowid;
-  const eid = insertEntry({ title: 'pay', amount: 100, category: 'Sonstiges Einkommen', date: '2033-06-01' });
-  db.prepare(`INSERT INTO budget_loan_payments (loan_id, installment_number, amount, paid_date, budget_entry_id, created_by)
-              VALUES (?,1,100,'2033-06-01',?,?)`).run(loan, eid, A);
+
+/**
+ * Legt ein Darlehen samt bezahlter Rate und gekoppeltem Budget-Eintrag an (#638/#859).
+ * Das Vorzeichen des Eintrags folgt der Richtung - genau so, wie der Loans-Router
+ * bucht; die Rate selbst bleibt positiv (CHECK amount > 0).
+ */
+function loanWithPayment({ direction = 'lent', amount = 100, date, total = 1000, currency = null, rate = null } = {}) {
+  const loan = db.prepare(`INSERT INTO budget_loans (title, borrower, total_amount, installment_count, start_month, created_by, direction, currency, exchange_rate)
+                           VALUES ('L','Bo',?,10,'2033-01',?,?,?,?)`)
+    .run(total, A, direction, currency, rate ?? 1).lastInsertRowid;
+  const borrowed = direction === 'borrowed';
+  const eid = insertEntry({
+    title: 'pay',
+    amount: (borrowed ? -1 : 1) * amount,
+    category: borrowed ? 'financial_other' : 'Sonstiges Einkommen',
+    subcategory: borrowed ? 'loans_interest' : '',
+    date,
+  });
+  const pid = db.prepare(`INSERT INTO budget_loan_payments (loan_id, installment_number, amount, paid_date, budget_entry_id, created_by)
+              VALUES (?,1,?,?,?,?)`).run(loan, amount, date, eid, A).lastInsertRowid;
+  return { loan, eid, pid };
+}
+
+test('PUT /:id: Rate eines aufgenommenen Kredits bleibt korrigierbar (#859)', async () => {
+  // Der gemeldete Bug: Seit die Richtung existiert (#638), bucht eine Rate auf einen
+  // aufgenommenen Kredit als Ausgabe - also negativ. Die alte Prüfung "muss Einkommen
+  // bleiben" wies damit jede Korrektur ab, die das Edit-Modal überhaupt senden kann.
+  const { eid, pid } = loanWithPayment({ direction: 'borrowed', date: '2033-06-01' });
   const r = await call('PUT', `/${eid}`, { body: { amount: -50 } });
+  assert.equal(r.status, 200, 'Korrektur wird angenommen');
+  assert.equal(r.body.data.amount, -50, 'Eintrag bleibt eine Ausgabe');
+  assert.equal(db.prepare('SELECT amount FROM budget_loan_payments WHERE id = ?').get(pid).amount, 50,
+    'die Rate selbst bleibt vorzeichenlos (CHECK amount > 0)');
+});
+
+test('PUT /:id: das Vorzeichen gehört dem Darlehen, nicht dem Request', async () => {
+  // Ein Client, der den Typ-Umschalter umgeht, darf die Buchungsrichtung nicht kippen -
+  // daran hängen Monatsbilanz, Statistik und Kontosaldo.
+  const borrowedCase = loanWithPayment({ direction: 'borrowed', date: '2033-06-02' });
+  const up = await call('PUT', `/${borrowedCase.eid}`, { body: { amount: 70 } });
+  assert.equal(up.status, 200);
+  assert.equal(up.body.data.amount, -70, 'positiv gesendet, als Ausgabe gebucht');
+
+  const lentCase = loanWithPayment({ direction: 'lent', date: '2033-06-03' });
+  const down = await call('PUT', `/${lentCase.eid}`, { body: { amount: -70 } });
+  assert.equal(down.status, 200);
+  assert.equal(down.body.data.amount, 70, 'negativ gesendet, als Einnahme gebucht');
+});
+
+test('PUT /:id: Betrag null wird abgewiesen, in beide Richtungen', async () => {
+  // Vorher deckte die income-Prüfung das mit ab. Fällt sie weg, muss die Null
+  // eigens abgefangen werden - sonst verletzt sie CHECK(amount > 0) als 500er.
+  for (const [direction, day] of [['borrowed', '2033-06-04'], ['lent', '2033-06-05']]) {
+    const { eid } = loanWithPayment({ direction, date: day });
+    const r = await call('PUT', `/${eid}`, { body: { amount: 0 } });
+    assert.equal(r.status, 400, `${direction}: 0 abgewiesen`);
+    assert.match(r.body.error, /greater than zero/i);
+  }
+});
+
+test('PUT /:id: die Rest-Grenze greift auch bei einem aufgenommenen Kredit', async () => {
+  // Der Restschuld-Vergleich lief gegen den vorzeichenbehafteten Betrag: bei einer
+  // Ausgabe war er damit immer erfüllt und die Grenze wirkungslos.
+  const { eid } = loanWithPayment({ direction: 'borrowed', date: '2033-06-06' });
+  const r = await call('PUT', `/${eid}`, { body: { amount: -5000 } });
   assert.equal(r.status, 400);
-  assert.match(r.body.error, /income/i);
+  assert.match(r.body.error, /remaining loan/i);
+});
+
+test('PUT /:id: aufgenommener Kredit in Fremdwährung - Kurs und Vorzeichen greifen zusammen', async () => {
+  // 1 USD = 0,50 EUR. 100 EUR Ausgabe entsprechen 200 USD Rate.
+  const { eid, pid } = loanWithPayment({ direction: 'borrowed', date: '2033-06-07', currency: 'USD', rate: 0.5 });
+  const r = await call('PUT', `/${eid}`, { body: { amount: -100 } });
+  assert.equal(r.status, 200);
+  assert.equal(r.body.data.amount, -100, 'Eintrag bleibt eine Ausgabe in Budget-Währung');
+  assert.equal(db.prepare('SELECT amount FROM budget_loan_payments WHERE id = ?').get(pid).amount, 200,
+    '100 EUR / 0,50 = 200 USD, positiv geführt');
 });
 
 test('PUT /:id: Rückzahlung über dem Restbetrag → 400', async () => {

--- a/test/test-budget-ui.js
+++ b/test/test-budget-ui.js
@@ -1189,19 +1189,24 @@ test('der Typ-Umschalter nimmt bei einer Darlehensrate keine Eingabe entgegen', 
   assert.ok(toggle.includes('budget.loanPaymentTypeLocked'), 'die Sperre bleibt unerklärt');
 });
 
-test('jeder Weg ins Bearbeiten-Modal bringt die Darlehens-Kopplung mit', () => {
-  // Über die Eintragsliste kommt sie aus der API (entryWithLoanMeta), über die
-  // Ratenliste aus einem hier gebauten Objekt. Fehlte sie dort, wäre der
-  // Umschalter je nach Einstiegspunkt mal gesperrt und mal nicht - und genau so
-  // eine halb wirksame Sperre lässt sich nicht als Zusicherung lesen.
+test('das Bearbeiten-Modal bekommt immer einen echten Eintrag, nie einen nachgebauten', () => {
+  // loanPaymentToEntry() baut aus einer Rate ein Anzeige-Objekt: Betrag in
+  // Darlehenswährung, ohne Konto, ohne Sichtbarkeit, ohne Belege. Als Vorlage zum
+  // Bearbeiten schriebe es den Ratenbetrag als Budget-Betrag zurück (bei
+  // Fremdwährung um den Kurs daneben) und leerte jedes Feld, das es nicht kennt.
+  // Es ist deshalb kein Einstieg ins Modal - der Drilldown liefert den echten.
   const built = budget.slice(budget.indexOf('function loanPaymentToEntry'), budget.indexOf('function renderLoanPaymentEntry'));
-  assert.ok(built.includes('loan_id: loan.id'), 'das gebaute Eintragsobjekt nennt sein Darlehen nicht');
-  assert.ok(built.includes('loan_payment_id: payment.id'), 'das gebaute Eintragsobjekt nennt seine Rate nicht');
+  assert.doesNotMatch(built, /openBudgetModal/, 'der Nachbau oeffnet selbst das Modal');
 
-  // Die Erkennung darf sich nicht auf eines der beiden Felder verlassen: die API
-  // liefert beide, ein Drilldown-Eintrag ohne Zahlungs-Join nur loan_id.
-  const detect = budget.match(/const isLoanPayment = [^;]+;/);
-  assert.ok(detect, 'isLoanPayment ist nicht mehr auffindbar');
-  assert.match(detect[0], /entry\.loan_payment_id != null/, 'loan_payment_id wird nicht geprüft');
-  assert.match(detect[0], /entry\.loan_id != null/, 'loan_id wird nicht geprüft');
+  const handler = budget.slice(budget.indexOf("data-action=\"loan-payment-edit\"]').forEach"));
+  const body = handler.slice(0, handler.indexOf('});'));
+  assert.doesNotMatch(body, /loanPaymentToEntry/,
+    'der Bearbeiten-Knopf oeffnet das Modal mit dem nachgebauten Objekt');
+  assert.match(body, /openLoanPaymentEntry/, 'der Bearbeiten-Knopf laedt den Eintrag nicht nach');
+
+  const loader = budget.slice(budget.indexOf('async function openLoanPaymentEntry'));
+  const loaderBody = loader.slice(0, loader.indexOf('\nfunction '));
+  assert.match(loaderBody, /api\.get\(`\/budget\?loan_id=/, 'der Eintrag kommt nicht aus dem Drilldown');
+  assert.match(loaderBody, /loan_payment_id === paymentId/, 'die geladene Zeile wird nicht der Rate zugeordnet');
+  assert.match(loaderBody, /openBudgetModal\(\{ mode: 'edit', entry \}\)/, 'das Modal wird nicht mit dem geladenen Eintrag geoeffnet');
 });

--- a/test/test-budget-ui.js
+++ b/test/test-budget-ui.js
@@ -1169,3 +1169,39 @@ test('die Bestätigungspflicht ist eine Eigenschaft der Serie', () => {
   assert.ok(modal.includes('budget.confirmFirstLabel'), 'Beschriftung fehlt');
   assert.ok(budget.includes('recurrence_confirm: confirmFirst'), 'Feld reist nicht zum Server');
 });
+
+// --------------------------------------------------------
+// Rate eines Darlehens im Eintrags-Dialog (#638/#859)
+// --------------------------------------------------------
+
+test('der Typ-Umschalter nimmt bei einer Darlehensrate keine Eingabe entgegen', () => {
+  // Ob eine Rate Einnahme oder Ausgabe ist, entscheidet die Richtung des Darlehens.
+  // Der Server bucht danach und würde eine hier gewählte Umkehr still zurückdrehen -
+  // ein Umschalter, der scheinbar etwas ändert und dann überstimmt wird, ist die
+  // schlechtere Hälfte von beidem.
+  const toggle = budget.slice(budget.indexOf('class="amount-type-toggle'), budget.indexOf('id="bm-title"'));
+  const buttons = [...toggle.matchAll(/id="type-(expense|income)"[^>]*/g)].map((m) => m[0]);
+  assert.equal(buttons.length, 2, 'die beiden Typ-Schalter sind nicht mehr auffindbar');
+  for (const btn of buttons) {
+    assert.match(btn, /isLoanPayment \? 'disabled' : ''/,
+      `${btn.slice(0, 24)} ist bei einer Darlehensrate weiter bedienbar`);
+  }
+  assert.ok(toggle.includes('budget.loanPaymentTypeLocked'), 'die Sperre bleibt unerklärt');
+});
+
+test('jeder Weg ins Bearbeiten-Modal bringt die Darlehens-Kopplung mit', () => {
+  // Über die Eintragsliste kommt sie aus der API (entryWithLoanMeta), über die
+  // Ratenliste aus einem hier gebauten Objekt. Fehlte sie dort, wäre der
+  // Umschalter je nach Einstiegspunkt mal gesperrt und mal nicht - und genau so
+  // eine halb wirksame Sperre lässt sich nicht als Zusicherung lesen.
+  const built = budget.slice(budget.indexOf('function loanPaymentToEntry'), budget.indexOf('function renderLoanPaymentEntry'));
+  assert.ok(built.includes('loan_id: loan.id'), 'das gebaute Eintragsobjekt nennt sein Darlehen nicht');
+  assert.ok(built.includes('loan_payment_id: payment.id'), 'das gebaute Eintragsobjekt nennt seine Rate nicht');
+
+  // Die Erkennung darf sich nicht auf eines der beiden Felder verlassen: die API
+  // liefert beide, ein Drilldown-Eintrag ohne Zahlungs-Join nur loan_id.
+  const detect = budget.match(/const isLoanPayment = [^;]+;/);
+  assert.ok(detect, 'isLoanPayment ist nicht mehr auffindbar');
+  assert.match(detect[0], /entry\.loan_payment_id != null/, 'loan_payment_id wird nicht geprüft');
+  assert.match(detect[0], /entry\.loan_id != null/, 'loan_id wird nicht geprüft');
+});


### PR DESCRIPTION
Behebt #859 (YuuriMomo, mit Video).

## Was passiert ist

Eine abgehakte Rate auf einen **aufgenommenen** Kredit liess sich nicht mehr bearbeiten. Jeder Versuch, den Betrag zu aendern, scheiterte an `Loan repayment entries must remain income.` - und zwar bei jedem Wert, den der Dialog ueberhaupt senden konnte. Es gab auch keinen Umweg: Rate loeschen und neu buchen war das einzige Mittel.

Die Pruefung stammt aus der Zeit, als jedes Darlehen ein verliehenes war, wo eine zurueckkommende Rate wirklich eine Einnahme ist. Mit der Richtung (v1.77.0, #638) verlaesst eine Rate auf einen aufgenommenen Kredit den Haushalt und wird als Ausgabe gebucht, ist also **von Haus aus negativ**. Der Loans-Router hat das gelernt, der Eintrags-Router nicht - und wies genau das Vorzeichen ab, das er selbst geschrieben hatte.

## Was sich aendert

Das Vorzeichen einer Rate gehoert dem **Darlehen**, nicht dem Request, und kommt ueberall aus derselben Regel: beim Buchen, beim Umbuchen nach einem Richtungswechsel und beim Bearbeiten. Genau darin lag der Fehler - die Regel wohnte im Loans-Router, weshalb der Eintrags-Router ihr widersprechen konnte. Sie steht jetzt in `helpers.js` und wird geteilt.

**Zwei Dinge, die die alte Pruefung verdeckt hatte, kommen mit:**

- Die Grenze gegen Ueberzahlung verglich einen vorzeichenbehafteten Betrag mit einer positiven Restschuld. Bei einem aufgenommenen Kredit war sie damit *immer* erfuellt und hat nie etwas verhindert. Sie war nur deshalb nie aufgefallen, weil man diesen Pfad gar nicht erreichen konnte.
- Ein Betrag von null wurde bisher nur als Nebenwirkung der income-Regel gefangen. Ohne sie haette er den `CHECK(amount > 0)` erreicht und einen 500er ausgeloest; er wird jetzt eigenstaendig abgewiesen.

**Im Dialog** nimmt der Einnahme/Ausgabe-Umschalter bei einer Rate keine Eingabe mehr entgegen und sagt auch warum. Welches von beidem gilt, folgt aus dem Darlehen und wird dort geaendert - jede andere Antwort haette der Server beim Speichern still ueberstimmt, und ein Umschalter, der scheinbar etwas aendert und dann ueberstimmt wird, ist die schlechtere Haelfte von beidem.

## Tests

Der bestehende Test hatte den Fehler als *"verknuepfte Rueckzahlung muss Einkommen bleiben"* **festgeschrieben** - er war gruen, weil jedes Darlehen in dieser Suite ohne Richtung angelegt wurde und damit `lent` war. Der `borrowed`-Fall fehlte im Eintrags-Router vollstaendig. Ersetzt durch die richtige Regel, plus fuenf neue Faelle: der gemeldete Ablauf, Vorzeichen in beide Richtungen, Nullbetrag, Rest-Grenze bei `borrowed`, und `borrowed` + Fremdwaehrung.

Dazu zwei UI-Vertraege: dass der Umschalter gesperrt ist, und dass **beide** Wege ins Bearbeiten-Modal die Darlehens-Kopplung mitbringen - sonst waere die Sperre je nach Einstiegspunkt mal da und mal nicht.

Jeder neue Guard wurde gegengeprobt (Aenderung einzeln zurueckgedreht, Guard wird rot). Vollsuite gruen: 203 Suiten, 0 Fehlschlaege.

## Live nachgestellt

Der gemeldete Ablauf, Ende zu Ende durch die echte Oberflaeche:

| Schritt | vorher | jetzt |
|---|---|---|
| Betrag der Rate aendern | 400, "must remain income" | 200, Eintrag steht bei -55 |
| Rate in der DB | - | 55 (positiv, `CHECK`-konform) |
| Restschuld | - | 1145 von 1200 |
| Monatsbilanz | - | Ausgaben -55, nicht Einnahmen |
| Betrag 0 | (von der income-Regel gefangen) | "Amount must be greater than zero." |
| Betrag ueber der Restschuld | **durchgelassen** | "Amount cannot be greater than the remaining loan amount." |
| Client dreht das Vorzeichen um | - | wird als Ausgabe gebucht, die Richtung gewinnt |

## Nebenbefund, nicht in diesem PR

Beim Live-Test faellt auf: der Server schreibt den Titel einer Rate fest als `Loan repayment: <Name>`. Der uebersetzte Fallback `t('budget.loanPaymentTitle')` im Frontend greift deshalb nie - in 23 von 24 Sprachen steht dort dauerhaft Englisch. Eigener Fehler, eigener PR.
