### PR TITLE
fix: der Titel einer gebuchten Rate folgt der Haushaltssprache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Editing now loads the actual entry instead of assembling a second, partial copy of it. The
   assembled one still describes the row in the list, where the loan currency is the right figure to
   show - it was never an editing record, and now nothing treats it as one.
+- **A booked loan instalment was titled in English, whatever the household language** (found while
+  verifying #859). Ticking off an instalment writes a budget entry called `Loan repayment: <name>`,
+  and that string was fixed in the source. In 23 of the 24 languages it has read as English ever
+  since - in the entry list, in the CSV export, in search results and over the API.
+
+  There is a translated title, and it has been there for a while, but it only ever applied when the
+  stored title was empty. Regular instalments always have one, so it never got a turn. Where it did
+  work was instalments backdated on an existing loan, which carry no budget entry at all - so the
+  same list could show a translated title next to an English one, for two instalments of the same
+  loan.
+
+  The title is now written in the household's data language, the same way birthday events have been
+  since v1.x (#524, #631, #632), and for the same reason: that row is what the REST API, the CSV
+  export, the search index and MCP read, and none of those paths pass through the translation that
+  happens in the browser. The translated fallback stays where it earns its keep - on backdated
+  instalments.
+
+  Existing entries keep their titles. The title of a budget entry is yours to edit, and rewriting
+  one on a language change would overwrite a decision somebody may well have made on purpose.
 
 
 ## [2.41.1] - 2026-08-25

--- a/server/routes/budget/loans.js
+++ b/server/routes/budget/loans.js
@@ -9,6 +9,7 @@ import * as db from '../../db.js';
 import { str, num, date as validateDate, month as validateMonth, collectErrors, MAX_TITLE, MAX_SHORT } from '../../middleware/validate.js';
 import { normalizeObjectVisibility } from '../../services/budget-visibility.js';
 import { computeLoanSchedule, MAX_LOAN_MONTHS } from '../../services/loan-amortization.js';
+import { translate, resolveHouseholdLocale } from '../../utils/i18n.js';
 import {
   budgetFilter, mayEdit, getBudgetMode, loanSummaryRow, loadLoan, refreshLoanStatus, cents,
   budgetCurrency, toBudgetAmount, CURRENCY_RE, validateAccountRef, addMonths,
@@ -541,6 +542,15 @@ router.post('/loans/:id/payments', (req, res) => {
     // angewandt: eine spätere Kursänderung lässt gebuchte Raten unberührt.
     const budgetAmount = toBudgetAmount(paymentAmount, loan);
     const foreign = loan.is_foreign_currency ? ` (${loan.currency})` : '';
+    // Der Titel wird in der Datensprache des Haushalts gespeichert, wie schon bei
+    // Geburtstagsterminen (#524/#631/#632). Grund ist derselbe: die Zeile in
+    // budget_entries ist das, was REST-API, CSV-Export, FTS-Suchindex und MCP zu
+    // sehen bekommen - keiner dieser Kanäle durchläuft die Client-Übersetzung.
+    // Vorher stand hier ein fest englischer Titel; der übersetzte Fallback in
+    // public/pages/budget.js kam nie zum Zug, weil er nur bei LEEREM Titel greift.
+    // Er bleibt trotzdem, denn nachgetragene Raten (#813) haben gar keinen
+    // Budget-Eintrag - genau dort trägt er.
+    const title = translate(resolveHouseholdLocale(db.get()), 'budget.loanPaymentTitle', { borrower: loan.borrower }) + foreign;
     // Richtung (#638): Bei einem aufgenommenen Kredit verlässt die Rate den Haushalt -
     // negativer Betrag und eine expense-Kategorie. Beides muss zusammen wechseln,
     // sonst steht eine Ausgabe unter „Geschenke & Transfers" (income).
@@ -553,7 +563,7 @@ router.post('/loans/:id/payments', (req, res) => {
         INSERT INTO budget_entries (title, amount, category, subcategory, date, is_recurring, created_by, owner_id, visibility, account_id)
         VALUES (?, ?, ?, ?, ?, 0, ?, ?, ?, ?)
       `).run(
-        `Loan repayment: ${loan.borrower}${foreign}`,
+        title,
         booking.sign * budgetAmount,
         booking.category,
         booking.subcategory,

--- a/test/test-budget-loans-routes.js
+++ b/test/test-budget-loans-routes.js
@@ -15,6 +15,7 @@ process.env.DB_PATH = ':memory:';
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import express from 'express';
+import { readFileSync } from 'node:fs';
 
 const dbmod = await import('../server/db.js');
 const { default: loansRouter } = await import('../server/routes/budget/loans.js');
@@ -824,6 +825,100 @@ test('#813: unbrauchbare Werte werden abgewiesen', async () => {
   const ok = await call('POST', '/loans', { as: AA, body: { ...base, paid_installments: '' } });
   assert.equal(ok.status, 201);
   assert.equal(ok.body.data.paid_installments, 0);
+});
+
+// ── Titel einer gebuchten Rate: Datensprache des Haushalts ───────────────────────
+//
+// Der Titel in budget_entries ist das, was REST-API, CSV-Export, FTS-Suchindex und
+// MCP zu sehen bekommen - keiner dieser Kanäle durchläuft die Client-Übersetzung.
+// Genau dieselbe Begründung wie bei Geburtstagsterminen (#524/#631/#632).
+//
+// Der übersetzte Fallback in public/pages/budget.js greift nur bei LEEREM Titel und
+// kam deshalb nie zum Zug; er bleibt für nachgetragene Raten (#813), die gar keinen
+// Budget-Eintrag haben.
+
+function setLanguage(value) {
+  if (value === null) {
+    db.prepare("DELETE FROM sync_config WHERE key = 'language'").run();
+    return;
+  }
+  db.prepare(`INSERT INTO sync_config (key, value) VALUES ('language', ?)
+              ON CONFLICT(key) DO UPDATE SET value = excluded.value`).run(value);
+}
+
+function setRegion(value) {
+  if (value === null) {
+    db.prepare("DELETE FROM sync_config WHERE key = 'region'").run();
+    return;
+  }
+  db.prepare(`INSERT INTO sync_config (key, value) VALUES ('region', ?)
+              ON CONFLICT(key) DO UPDATE SET value = excluded.value`).run(value);
+}
+
+async function titleOfBookedInstalment(loanBody = {}) {
+  const id = await createDirectedLoan({ borrower: 'Sparkasse', ...loanBody });
+  const r = await call('POST', `/loans/${id}/payments`, {
+    as: AA, body: { installment_number: 1, amount: 100, paid_date: '2026-01-15' },
+  });
+  assert.equal(r.status, 201, JSON.stringify(r.body));
+  const entryId = r.body.data.payment.budget_entry_id;
+  return db.prepare('SELECT title FROM budget_entries WHERE id = ?').get(entryId).title;
+}
+
+/** Erwarteter Titel aus DER Locale-Datei, die auch der Server liest. Ein zweites
+ *  Mal hingeschriebene Übersetzung wäre eine zweite Wahrheit: sie bricht bei jeder
+ *  Korrektur am Wortlaut, ohne dass am Verhalten etwas falsch wäre. Geprüft wird,
+ *  dass der Titel AUS der Locale kommt - nicht, wie sie gerade formuliert ist. */
+function expectedTitle(locale, borrower) {
+  const dict = JSON.parse(readFileSync(new URL(`../public/locales/${locale}.json`, import.meta.url), 'utf8'));
+  return dict.budget.loanPaymentTitle.replace('{{borrower}}', borrower);
+}
+
+test('der gespeicherte Titel folgt der Datensprache des Haushalts', async () => {
+  setLanguage('de');
+  const de = await titleOfBookedInstalment();
+  assert.equal(de, expectedTitle('de', 'Sparkasse'));
+  assert.doesNotMatch(de, /Loan repayment/, 'der englische Titel steht noch in der Zeile');
+
+  setLanguage('fr');
+  const fr = await titleOfBookedInstalment();
+  assert.equal(fr, expectedTitle('fr', 'Sparkasse'));
+  assert.notEqual(fr, de, 'die Sprache wirkt sich auf den gespeicherten Titel nicht aus');
+});
+
+test('ohne gesetzte Sprache leitet die Region sie ab', async () => {
+  setLanguage(null);
+  setRegion('es-ES');
+  assert.equal(await titleOfBookedInstalment(), expectedTitle('es', 'Sparkasse'));
+});
+
+test('ohne Sprache und ohne Region gilt Englisch, nicht die Referenz-Locale', async () => {
+  // de ist die Referenz-Locale der Übersetzungsdateien, aber nicht der Default
+  // eines Haushalts, der nie etwas eingestellt hat. Diese eine Erwartung steht
+  // absichtlich wörtlich da: sie ist die Aussage, nicht die Übersetzung.
+  setLanguage(null);
+  setRegion(null);
+  assert.equal(await titleOfBookedInstalment(), 'Loan repayment: Sparkasse');
+});
+
+test('der Währungszusatz bleibt am übersetzten Titel', async () => {
+  setLanguage('de');
+  setBudgetCurrency('EUR');
+  const title = await titleOfBookedInstalment({ currency: 'USD', exchange_rate: 0.92 });
+  assert.equal(title, 'Darlehensrückzahlung: Sparkasse (USD)',
+    'die Währung sagt, in welcher Einheit die Rate geführt wird - sie darf mit der Übersetzung nicht wegfallen');
+  setLanguage(null);
+  setRegion(null);
+});
+
+test('kein fest verdrahteter Anzeigetext mehr im Loans-Router', () => {
+  // Ein Literal hier wäre wieder in 23 von 24 Sprachen falsch, und keiner der
+  // Kanäle, die diese Zeile lesen, könnte es nachträglich übersetzen.
+  const source = readFileSync(new URL('../server/routes/budget/loans.js', import.meta.url), 'utf8');
+  assert.doesNotMatch(source, /'Loan repayment|`Loan repayment/,
+    'der englische Titel steht wieder im Quelltext');
+  assert.match(source, /translate\(resolveHouseholdLocale\(/,
+    'der Titel läuft nicht mehr über die Haushaltssprache');
 });
 
 test('teardown: Server schließen', async () => {


### PR DESCRIPTION
Gefunden beim Verifizieren von #859, eigener Fehler und deshalb ein eigener PR.

## Was passiert ist

Eine abgehakte Rate schreibt einen Budget-Eintrag namens `Loan repayment: <Name>` - und diese Zeichenkette stand fest im Quelltext. In 23 von 24 Sprachen liest sie sich seither englisch: in der Eintragsliste, im CSV-Export, in Suchergebnissen und ueber die API.

Ein uebersetzter Titel existiert (`budget.loanPaymentTitle`), aber er greift nur bei **leerem** gespeicherten Titel. Regulaer gebuchte Raten haben immer einen, also kam er nie zum Zug.

Wo er funktioniert, sind **nachgetragene** Raten (#813) - die tragen gar keinen Budget-Eintrag. Dieselbe Liste konnte damit einen uebersetzten neben einem englischen Titel zeigen, fuer zwei Raten desselben Darlehens.

## Was sich aendert

Der Titel wird in der Datensprache des Haushalts geschrieben, genau wie Geburtstagstermine seit #524/#631/#632, und aus derselben Begruendung - die steht schon woertlich in `server/services/birthdays.js`:

> die Zeile in `calendar_events` ist das, was REST-API, ICS-Feed, CalDAV-/Google-Outbound und der FTS-Suchindex zu sehen bekommen - keiner dieser Kanaele durchlaeuft die clientseitige Uebersetzung

Fuer `budget_entries` gilt dasselbe: REST-API, CSV-Export, Suchindex, MCP. Kein neues Muster, nur eine Stelle, die es noch nicht hatte. Der Fallback im Frontend bleibt - er traegt bei nachgetragenen Raten.

## Bestandsdaten bleiben, wie sie sind

Bei Geburtstagsterminen benennt ein Sprachwechsel die Bestandstermine um. **Hier bewusst nicht.** Der Titel eines Budget-Eintrags ist ein bearbeitbares Feld: er umzuschreiben wuerde eine Entscheidung ueberschreiben, die jemand bewusst getroffen haben kann. Einen Geburtstagstermin benennt dagegen niemand von Hand - das ist der Unterschied, und er ist der Grund, hier keine Migration zu fahren.

## Tests

Der Titel war nie geprueft - das war die Luecke, durch die er fuenf Releases lang englisch bleiben konnte. Jetzt vier Faelle: der Titel folgt der gesetzten Sprache, die Region leitet sie ab, ohne beides gilt **Englisch** (nicht die Referenz-Locale `de`), und der Waehrungszusatz `(USD)` faellt mit der Uebersetzung nicht weg. Dazu ein Guard gegen ein neues Literal im Loans-Router.

Die Erwartungswerte kommen aus **derselben** Locale-Datei, die der Server liest - eine zweite Abschrift der Uebersetzung waere eine zweite Wahrheit und bräche bei jeder Korrektur am Wortlaut, ohne dass am Verhalten etwas falsch waere. Die einzige woertliche Erwartung ist der englische Default, denn genau der ist die Aussage.

Gegengeprobt: der Rueckbau auf den festen englischen Titel macht vier der fuenf Tests rot (der Englisch-Default bleibt korrekt gruen). Vollsuite gruen: 203 Suiten, 0 Fehlschlaege.

---

Beruehrt `server/routes/budget/loans.js` wie #860, aber an anderer Stelle. Der CHANGELOG-Eintrag kollidiert mit dem von #860 unter `[Unreleased]` - sag Bescheid, wenn ich einen der beiden rebasen soll.
