### PR TITLE
fix(ui): eine knopfzeile bricht um, statt ihre knoepfe zu quetschen (#872)

### DIFF
--- a/public/styles/birthdays.css
+++ b/public/styles/birthdays.css
@@ -592,6 +592,9 @@
   display: flex;
   align-items: center;
   justify-content: flex-end;
+  /* Umbruch statt Quetschen - Begruendung an `.modal-panel__footer`
+   * (layout.css, #872). */
+  flex-wrap: wrap;
   gap: var(--space-3);
   margin-top: var(--space-4);
 }

--- a/public/styles/budget.css
+++ b/public/styles/budget.css
@@ -1568,6 +1568,9 @@
 
 .budget-inline-modal__footer {
   justify-content: flex-end;
+  /* Umbruch statt Ueberlauf - Begruendung an `.modal-panel__footer`
+   * (layout.css, #872). */
+  flex-wrap: wrap;
 }
 
 /* --------------------------------------------------------

--- a/public/styles/contacts.css
+++ b/public/styles/contacts.css
@@ -517,8 +517,12 @@ html:has(.contacts-page.is-selecting) {
   margin-top: var(--space-4);
 }
 
+/* Eine Aktionsgruppe IN der Fusszeile ist selbst eine Knopfzeile und braucht
+ * dieselbe Erlaubnis (#872): fuer die Fusszeile ist sie EIN Flex-Item, also
+ * unteilbar - ohne eigenen Umbruch laeuft sie als Ganzes ueber. */
 .contact-modal__footer-actions {
   display: flex;
+  flex-wrap: wrap;
   gap: var(--space-3);
 }
 

--- a/public/styles/contacts.css
+++ b/public/styles/contacts.css
@@ -670,6 +670,9 @@ html:has(.contacts-page.is-selecting) {
   display: flex;
   align-items: center;
   justify-content: flex-end;
+  /* Umbruch statt Quetschen - Begruendung an `.modal-panel__footer`
+   * (layout.css, #872). */
+  flex-wrap: wrap;
   gap: var(--space-3);
   margin-top: var(--space-4);
 }

--- a/public/styles/dashboard.css
+++ b/public/styles/dashboard.css
@@ -2018,6 +2018,9 @@ svg.weather-forecast__icon {
   gap: var(--space-3);
   width: 100%;
   justify-content: flex-end;
+  /* Umbruch statt Quetschen - Begruendung an `.modal-panel__footer`
+   * (layout.css, #872). */
+  flex-wrap: wrap;
   margin-top: var(--space-2);
 }
 

--- a/public/styles/document-attach.css
+++ b/public/styles/document-attach.css
@@ -194,6 +194,9 @@ a.doc-attach__chip-name:focus-visible {
 
 .doc-attach-picker__footer {
   justify-content: flex-end;
+  /* Umbruch statt Ueberlauf - Begruendung an `.modal-panel__footer`
+   * (layout.css, #872). */
+  flex-wrap: wrap;
 }
 
 .doc-attach-picker__list {

--- a/public/styles/health.css
+++ b/public/styles/health.css
@@ -2052,7 +2052,9 @@ button.cycle-cal__day:not(:disabled):hover { background: var(--color-surface-2);
 /* display erst wenn sichtbar - sonst überschreibt der Flex das UA-[hidden]. */
 .cycle-bulk__confirm:not([hidden]) { display: flex; }
 .cycle-bulk__question { color: var(--color-text-primary); }
-.cycle-bulk__actions { display: flex; justify-content: flex-end; gap: var(--space-2); }
+/* Umbruch statt Quetschen - Begruendung an `.modal-panel__footer`
+ * (layout.css, #872). */
+.cycle-bulk__actions { display: flex; flex-wrap: wrap; justify-content: flex-end; gap: var(--space-2); }
 
 @media (max-width: 640px) {
   .cycle-hero { flex-direction: column; }

--- a/public/styles/inventory.css
+++ b/public/styles/inventory.css
@@ -464,6 +464,9 @@
 .inventory-booking-picker__role-footer {
   display: flex;
   justify-content: flex-end;
+  /* Umbruch statt Quetschen - Begruendung an `.modal-panel__footer`
+   * (layout.css, #872). */
+  flex-wrap: wrap;
   gap: var(--space-2);
 }
 

--- a/public/styles/layout.css
+++ b/public/styles/layout.css
@@ -3980,7 +3980,7 @@ p.field-hint--warn[hidden] {
   gap: var(--space-2);
 }
 
-.modal-actions > .btn {
+.modal-actions .btn {
   white-space: normal;
 }
 
@@ -4039,8 +4039,19 @@ p.field-hint--warn[hidden] {
   border-top: 1px solid var(--color-border-subtle);
 }
 
-.modal-panel__footer > .btn {
+/* JEDER Knopf in der Fusszeile, nicht nur das direkte Kind: mehrere Module
+ * legen Abbrechen/Speichern in eine eigene Flex-Gruppe (Kalender, Budget-Plaene,
+ * Kontakte), und deren Knoepfe traegen dasselbe `nowrap`. */
+.modal-panel__footer .btn {
   white-space: normal;
+}
+
+/* Und die Gruppe selbst darf umbrechen. Fuer die Fusszeile ist sie EIN
+ * Flex-Item und damit unteilbar - ohne diese Zeile laeuft sie als Ganzes ueber
+ * den Rand, und der Umbruch der Fusszeile hilft nichts mehr. `flex-wrap` an
+ * einem Nicht-Flex-Kind ist folgenlos, deshalb reicht der schlichte Selektor. */
+.modal-panel__footer > div {
+  flex-wrap: wrap;
 }
 
 /* Fußzeile INNERHALB des scrollenden Bodys (kein direktes Panel-Kind): dort

--- a/public/styles/layout.css
+++ b/public/styles/layout.css
@@ -3971,8 +3971,8 @@ p.field-hint--warn[hidden] {
 }
 
 /* Dieselbe Not, dieselbe Antwort wie bei `.modal-panel__footer` weiter unten
- * (#872): eine Knopfzeile im Modal-Rumpf quetscht ihre Knoepfe sonst genauso
- * unter die Inhaltsbreite. Die Begruendung steht dort, damit sie EINMAL steht. */
+ * (#872): eine Knopfzeile im Modal-Rumpf laeuft sonst genauso ueber ihren
+ * Container hinaus. Die Begruendung steht dort, damit sie EINMAL steht. */
 .modal-actions {
   display: flex;
   justify-content: flex-end;
@@ -4002,14 +4002,21 @@ p.field-hint--warn[hidden] {
   align-items: stretch;
 }
 
-/* EINE FUSSZEILE QUETSCHT KEINEN KNOPF - SIE BRICHT UM (#872).
+/* EINE FUSSZEILE LAEUFT NICHT UEBER - SIE BRICHT UM (#872).
  *
- * `.btn` traegt `white-space: nowrap` und keinen Schrumpfschutz. Ohne
- * `flex-wrap` drueckte die Zeile die Knoepfe deshalb unter ihre Inhaltsbreite,
- * und weil `.btn` seinen Inhalt zentriert, lief der Text auf BEIDEN Seiten aus
- * dem Knopf: aus „Löschen" wurde sichtbar „öschen". Auf einem Telefon reichten
- * dafuer schon die drei Aktionen der Aufgaben-Detailansicht (Löschen, Starten,
- * Aufgabe archivieren).
+ * WAS GENAU PASSIERTE, gemessen an der Aufgaben-Detailansicht auf 390px
+ * Telefonbreite: die drei Aktionen (Löschen · Starten · Aufgabe archivieren)
+ * brauchen zusammen rund 440px, die Fusszeile hat 364. Gequetscht werden die
+ * Knoepfe dabei NICHT - ein Flex-Item traegt `min-width: auto` und schrumpft
+ * deshalb nicht unter seine Inhaltsbreite. Stattdessen waechst die ZEILE ueber
+ * den Container hinaus, und weil sie rechtsbuendig ausgerichtet ist, tut sie
+ * das nach LINKS. Das Panel traegt `overflow: clip`, also faellt dort ab, was
+ * heraussteht: der Löschen-Knopf sass bei x = -11, das Panel beginnt bei
+ * x = 12 - dreiundzwanzig Pixel fehlten, und aus „Löschen" wurde sichtbar
+ * „öschen".
+ *
+ * Ein abgeschnittener Knopf sagt nicht, dass er abgeschnitten ist. Es gibt
+ * keine Ellipse, keinen Scrollbalken - nur ein Wort, das falsch anfaengt.
  *
  * DER UMBRUCH IST DIE ANTWORT UND KEINE UEBERLAUFLEISTE. Ein „…"-Menue wie in
  * SAP Fiori (Vorschlag des Melders) verschoebe die Grenze nur: es misst in
@@ -4017,10 +4024,11 @@ p.field-hint--warn[hidden] {
  * Rest doch wieder einen Umbruch. Der Umbruch traegt jede Sprache ohne
  * Messung, und im Sheet ist die Hoehe da.
  *
- * DER ZWEITE TEIL GEHOERT DAZU: bricht die ZEILE, kann ein einzelner Knopf
- * immer noch breiter sein als das Panel (lange Locale, 200 % Zoom). Dann muss
- * sein TEXT umbrechen duerfen - sonst steht der mittig abgeschnittene Knopf
- * wieder da, nur seltener. */
+ * DER ZWEITE TEIL GEHOERT DAZU: bricht die ZEILE, kann ein EINZELNER Knopf
+ * immer noch breiter sein als das Panel (lange Locale, 200 % Zoom). Dann hat
+ * die Zeile nichts mehr umzubrechen, und der Ueberlauf ist zurueck - also muss
+ * der Knopf INNEN umbrechen duerfen. Das nimmt das `white-space: nowrap` von
+ * `.btn` fuer genau diesen Ort zurueck. */
 .modal-panel__footer {
   display: flex;
   align-items: center;

--- a/public/styles/layout.css
+++ b/public/styles/layout.css
@@ -3970,10 +3970,18 @@ p.field-hint--warn[hidden] {
   .form-advanced__chevron { transition: none; }
 }
 
+/* Dieselbe Not, dieselbe Antwort wie bei `.modal-panel__footer` weiter unten
+ * (#872): eine Knopfzeile im Modal-Rumpf quetscht ihre Knoepfe sonst genauso
+ * unter die Inhaltsbreite. Die Begruendung steht dort, damit sie EINMAL steht. */
 .modal-actions {
   display: flex;
   justify-content: flex-end;
+  flex-wrap: wrap;
   gap: var(--space-2);
+}
+
+.modal-actions > .btn {
+  white-space: normal;
 }
 
 /* Einleitender Hinweis-Text über gestapelten Modal-Aktionen (z. B. Scope-Wahl). */
@@ -3994,13 +4002,37 @@ p.field-hint--warn[hidden] {
   align-items: stretch;
 }
 
+/* EINE FUSSZEILE QUETSCHT KEINEN KNOPF - SIE BRICHT UM (#872).
+ *
+ * `.btn` traegt `white-space: nowrap` und keinen Schrumpfschutz. Ohne
+ * `flex-wrap` drueckte die Zeile die Knoepfe deshalb unter ihre Inhaltsbreite,
+ * und weil `.btn` seinen Inhalt zentriert, lief der Text auf BEIDEN Seiten aus
+ * dem Knopf: aus „Löschen" wurde sichtbar „öschen". Auf einem Telefon reichten
+ * dafuer schon die drei Aktionen der Aufgaben-Detailansicht (Löschen, Starten,
+ * Aufgabe archivieren).
+ *
+ * DER UMBRUCH IST DIE ANTWORT UND KEINE UEBERLAUFLEISTE. Ein „…"-Menue wie in
+ * SAP Fiori (Vorschlag des Melders) verschoebe die Grenze nur: es misst in
+ * Pixeln, was in 20 Locales unterschiedlich lang ist, und braeuchte fuer den
+ * Rest doch wieder einen Umbruch. Der Umbruch traegt jede Sprache ohne
+ * Messung, und im Sheet ist die Hoehe da.
+ *
+ * DER ZWEITE TEIL GEHOERT DAZU: bricht die ZEILE, kann ein einzelner Knopf
+ * immer noch breiter sein als das Panel (lange Locale, 200 % Zoom). Dann muss
+ * sein TEXT umbrechen duerfen - sonst steht der mittig abgeschnittene Knopf
+ * wieder da, nur seltener. */
 .modal-panel__footer {
   display: flex;
   align-items: center;
   justify-content: flex-end;
+  flex-wrap: wrap;
   gap: var(--space-3);
   padding: var(--space-3) var(--space-4);
   border-top: 1px solid var(--color-border-subtle);
+}
+
+.modal-panel__footer > .btn {
+  white-space: normal;
 }
 
 /* Fußzeile INNERHALB des scrollenden Bodys (kein direktes Panel-Kind): dort

--- a/public/styles/rewards.css
+++ b/public/styles/rewards.css
@@ -167,7 +167,9 @@
  * nehmen, solange er läuft. */
 .rw-standing__points strong.rw-countup--active { color: var(--color-accent); }
 .rw-standing__progress { display: flex; flex-direction: column; gap: var(--space-2); min-width: 0; }
-.rw-standing__actions { display: flex; justify-content: flex-end; }
+/* Umbruch statt Quetschen - Begruendung an `.modal-panel__footer`
+ * (layout.css, #872). */
+.rw-standing__actions { display: flex; flex-wrap: wrap; justify-content: flex-end; }
 
 /* --------------------------------------------------------
    Eltern-Ersteinrichtung

--- a/public/styles/settings.css
+++ b/public/styles/settings.css
@@ -3030,6 +3030,10 @@
   display: flex;
   align-items: center;
   justify-content: flex-end;
+  /* Umbruch statt Quetschen - Begruendung an `.modal-panel__footer`
+   * (layout.css, #872). Die Schmalregel weiter unten setzt ihn nicht mehr,
+   * sie gibt der Statuszeile dort nur noch ihre eigene Zeile. */
+  flex-wrap: wrap;
   gap: var(--space-3);
   margin-top: var(--space-5);
   padding: var(--space-3) 0;
@@ -3123,10 +3127,10 @@
     text-align: center;
   }
 
-  /* Zwei Buttons plus Statuszeile passen bei 390px nicht nebeneinander; ohne
-     Umbruch schob der Status unter die Aktionsleiste. */
-  .perm-actions { flex-wrap: wrap; }
-
+  /* Zwei Buttons plus Statuszeile passen bei 390px nicht nebeneinander. Die
+     ERLAUBNIS zum Umbruch steht seit #872 in der Basisregel und gilt in jeder
+     Breite; hier bleibt nur der GRUND: die Statuszeile nimmt sich eine eigene
+     Zeile, statt sich zwischen die Knoepfe zu draengen. */
   .perm-actions__status {
     flex-basis: 100%;
     margin-right: 0;

--- a/public/styles/subscriptions.css
+++ b/public/styles/subscriptions.css
@@ -932,8 +932,13 @@
     justify-self: start;
   }
 
+  /* KEIN Umbruch, anders als bei den Fusszeilen (#872): das hier sind zwei
+   * Icon-Knoepfe ohne Text - sie koennen nicht zu lang werden, und ein
+   * Umbruch machte aus der letzten Rasterspalte zwei Zeilen. Die Ansage steht
+   * ausdruecklich da, damit sie als Entscheidung lesbar ist. */
   .subscriptions-toolbar__actions {
     display: flex;
+    flex-wrap: nowrap;
     gap: var(--space-2);
     grid-column: 3 / -1;
     justify-content: flex-end;

--- a/test/test-frontend-audit.js
+++ b/test/test-frontend-audit.js
@@ -13705,15 +13705,34 @@ test('jede rechtsbuendige Knopfzeile sagt, ob sie umbricht (#872)', () => {
   const offenders = [];
   let seenRows = 0;
 
+  /* JE SELEKTOR GESAMMELT, NICHT JE REGEL - so, wie die Kaskade es sieht.
+   *
+   * Die erste Fassung urteilte ueber die EINZELNE Regel und war damit blind
+   * fuer jede Zeile, deren Deklarationen verteilt stehen: `display: flex` aus
+   * einer geteilten Kopf-/Fusszeilen-Regel, `justify-content` dreissig Zeilen
+   * spaeter aus einer eigenen. Genau so gebaut sind
+   * `.budget-inline-modal__footer` und `.doc-attach-picker__footer` - zwei
+   * echte Verstoesse, die der Guard nicht sah. Gefunden hat sie die Review,
+   * nicht er. */
+  const declarations = new Map();
   for (const file of readdirSync(styleDir).filter((f) => f.endsWith('.css'))) {
     for (const { selector, body, at } of eachRule(read(`../public/styles/${file}`))) {
-      if (!/(footer|actions)\b/.test(selector)) continue;
-      if (!/display\s*:\s*(inline-)?flex/.test(body)) continue;
-      if (!/justify-content\s*:\s*(flex-)?end/.test(body)) continue;
-      seenRows += 1;
-      if (/flex-wrap\s*:/.test(body) || /\bflex-flow\s*:/.test(body)) continue;
-      offenders.push(`${file}${at.length ? ` [${at.join(' ')}]` : ''}: ${selector}`);
+      // Gruppenselektoren aufspalten: `.a, .b { display: flex }` gibt beiden
+      // dieselbe Deklaration, und nur einzeln laesst sich das zusammenlegen.
+      for (const one of selector.split(',').map((x) => x.trim()).filter(Boolean)) {
+        const key = `${file}${at.length ? ` [${at.join(' ')}]` : ''}: ${one}`;
+        declarations.set(key, (declarations.get(key) ?? '') + body);
+      }
     }
+  }
+
+  for (const [key, body] of declarations) {
+    if (!/(footer|actions)\b/.test(key)) continue;
+    if (!/display\s*:\s*(inline-)?flex/.test(body)) continue;
+    if (!/justify-content\s*:\s*(flex-)?end/.test(body)) continue;
+    seenRows += 1;
+    if (/flex-wrap\s*:/.test(body) || /\bflex-flow\s*:/.test(body)) continue;
+    offenders.push(key);
   }
 
   // Ohne diese Zusicherung waere der Guard gruen, sobald der Scanner die
@@ -13741,7 +13760,15 @@ test('jede rechtsbuendige Knopfzeile sagt, ob sie umbricht (#872)', () => {
  */
 test('in den Modal-Knopfzeilen darf der Knopftext umbrechen (#872)', () => {
   const css = read('../public/styles/layout.css');
-  for (const selector of ['.modal-panel__footer > .btn', '.modal-actions > .btn']) {
+
+  /* Und die verschachtelte Aktionsgruppe bricht selbst um. Fuer die Fusszeile
+   * ist sie EIN Flex-Item; ohne eigenen Umbruch laeuft sie als Ganzes ueber
+   * den Rand, und der Umbruch der Fusszeile hilft nichts mehr. Gebaut ist das
+   * so im Kalender, in den Budget-Plaenen und in den Kontakten. */
+  const gruppe = [...eachRule(css)].find((r) => r.selector.trim() === '.modal-panel__footer > div');
+  assert.ok(gruppe, '.modal-panel__footer > div fehlt - eine Aktionsgruppe laeuft wieder als Ganzes ueber');
+  assert.match(gruppe.body, /flex-wrap\s*:\s*wrap/);
+  for (const selector of ['.modal-panel__footer .btn', '.modal-actions .btn']) {
     const rule = [...eachRule(css)].find((r) => r.selector.trim() === selector);
     assert.ok(rule, `${selector} fehlt - ein einzelner zu breiter Knopf wird wieder abgeschnitten.`);
     assert.match(rule.body, /white-space\s*:\s*normal/,

--- a/test/test-frontend-audit.js
+++ b/test/test-frontend-audit.js
@@ -13673,3 +13673,76 @@ test('ein Teilschritt lässt sich korrigieren und entfernen, nicht nur abhaken (
   assert.ok(block, '.subtask-item__action fehlt');
   assert.match(block[1], /min-height:\s*var\(--target-base\)/);
 });
+
+/**
+ * EINE KNOPFZEILE SAGT, OB SIE UMBRICHT (#872).
+ *
+ * Der gemeldete Fehler war nicht kosmetisch: `.btn` traegt `white-space:
+ * nowrap` und keinen Schrumpfschutz, also drueckte eine Flex-Zeile ohne
+ * `flex-wrap` ihre Knoepfe unter die Inhaltsbreite. Weil `.btn` seinen Inhalt
+ * ZENTRIERT, lief der Text danach auf beiden Seiten aus dem Knopf - aus
+ * „Löschen" wurde sichtbar „öschen", ohne Ellipse, ohne Hinweis, dass etwas
+ * fehlt. Es traf die Aufgaben-Detailansicht auf einem Telefon; getroffen
+ * haette es jede Fusszeile mit drei Knoepfen in einer laengeren Locale.
+ *
+ * DIE REGEL VERLANGT EINE ENTSCHEIDUNG, KEINEN BESTIMMTEN WERT. Wo ein
+ * Umbruch falsch waere (zwei Icon-Knoepfe in einer Rasterspalte), steht
+ * `flex-wrap: nowrap` ausdruecklich da. Das unterscheidet eine getroffene
+ * Entscheidung von einem Versaeumnis - und nur Letzteres ist der Bug.
+ *
+ * ALS REGEL UND NICHT ALS ALLOWLIST: er sucht die FORM (rechtsbuendige
+ * Flex-Zeile, deren Name sie als Fuss- oder Aktionszeile ausweist), nicht die
+ * neun Selektoren, die es heute gibt. Beim ersten Lauf fand er in genau
+ * dieser Form acht weitere Zeilen mit demselben Mangel; eine Liste haette nur
+ * die eine gemeldete Stelle gedeckt.
+ *
+ * Guard-Ebene: Form (aus dem Stylesheet gelesen).
+ */
+test('jede rechtsbuendige Knopfzeile sagt, ob sie umbricht (#872)', () => {
+  const styleDir = new URL('../public/styles/', import.meta.url);
+  const offenders = [];
+  let seenRows = 0;
+
+  for (const file of readdirSync(styleDir).filter((f) => f.endsWith('.css'))) {
+    for (const { selector, body, at } of eachRule(read(`../public/styles/${file}`))) {
+      if (!/(footer|actions)\b/.test(selector)) continue;
+      if (!/display\s*:\s*(inline-)?flex/.test(body)) continue;
+      if (!/justify-content\s*:\s*(flex-)?end/.test(body)) continue;
+      seenRows += 1;
+      if (/flex-wrap\s*:/.test(body) || /\bflex-flow\s*:/.test(body)) continue;
+      offenders.push(`${file}${at.length ? ` [${at.join(' ')}]` : ''}: ${selector}`);
+    }
+  }
+
+  // Ohne diese Zusicherung waere der Guard gruen, sobald der Scanner die
+  // Stylesheets nicht mehr faende - eine leere Liste ist keine Zusicherung.
+  assert.ok(seenRows >= 9,
+    `Nur ${seenRows} rechtsbuendige Knopfzeilen gefunden - der Scanner findet `
+    + 'public/styles/ nicht mehr, statt nichts zu beanstanden.');
+
+  assert.deepEqual(offenders.sort(), [],
+    'Diese Knopfzeile sagt nicht, was bei Platzmangel passieren soll. Ohne '
+    + '`flex-wrap` quetscht sie ihre Knoepfe unter die Inhaltsbreite, und weil '
+    + '`.btn` zentriert und nicht umbricht, wird der Text beidseitig '
+    + 'abgeschnitten (#872). Setze `flex-wrap: wrap` - oder `nowrap` mit einer '
+    + `Begruendung, wenn der Umbruch hier falsch waere.\n${offenders.join('\n')}`);
+});
+
+/**
+ * Der Umbruch der ZEILE reicht nicht, wenn EIN Knopf allein zu breit ist.
+ *
+ * Genau dann kann die Zeile nicht mehr umbrechen, und der abgeschnittene Text
+ * aus #872 stuende wieder da - seltener, aber unveraendert falsch. Deshalb
+ * geben die beiden kanonischen Modal-Knopfzeilen ihren Knoepfen das Recht,
+ * INNEN umzubrechen, und nehmen damit das `white-space: nowrap` von `.btn`
+ * fuer diesen einen Ort zurueck.
+ */
+test('in den Modal-Knopfzeilen darf der Knopftext umbrechen (#872)', () => {
+  const css = read('../public/styles/layout.css');
+  for (const selector of ['.modal-panel__footer > .btn', '.modal-actions > .btn']) {
+    const rule = [...eachRule(css)].find((r) => r.selector.trim() === selector);
+    assert.ok(rule, `${selector} fehlt - ein einzelner zu breiter Knopf wird wieder abgeschnitten.`);
+    assert.match(rule.body, /white-space\s*:\s*normal/,
+      `${selector} nimmt das nowrap von .btn nicht zurueck.`);
+  }
+});

--- a/test/test-frontend-audit.js
+++ b/test/test-frontend-audit.js
@@ -13677,13 +13677,15 @@ test('ein Teilschritt lässt sich korrigieren und entfernen, nicht nur abhaken (
 /**
  * EINE KNOPFZEILE SAGT, OB SIE UMBRICHT (#872).
  *
- * Der gemeldete Fehler war nicht kosmetisch: `.btn` traegt `white-space:
- * nowrap` und keinen Schrumpfschutz, also drueckte eine Flex-Zeile ohne
- * `flex-wrap` ihre Knoepfe unter die Inhaltsbreite. Weil `.btn` seinen Inhalt
- * ZENTRIERT, lief der Text danach auf beiden Seiten aus dem Knopf - aus
- * „Löschen" wurde sichtbar „öschen", ohne Ellipse, ohne Hinweis, dass etwas
- * fehlt. Es traf die Aufgaben-Detailansicht auf einem Telefon; getroffen
- * haette es jede Fusszeile mit drei Knoepfen in einer laengeren Locale.
+ * Der gemeldete Fehler war nicht kosmetisch, und er entsteht nicht durch
+ * Quetschen: ein Flex-Item traegt `min-width: auto` und schrumpft nicht unter
+ * seine Inhaltsbreite. Stattdessen waechst die ZEILE ueber den Container
+ * hinaus - rechtsbuendig also nach LINKS -, und das Panel schneidet mit
+ * `overflow: clip` ab, was heraussteht. Gemessen an der Aufgaben-Detailansicht
+ * auf 390px: der Löschen-Knopf sass bei x = -11, das Panel beginnt bei x = 12,
+ * aus „Löschen" wurde sichtbar „öschen". Ohne Ellipse, ohne Scrollbalken -
+ * nur ein Wort, das falsch anfaengt. Getroffen haette es jede Fusszeile mit
+ * drei Knoepfen in einer laengeren Locale.
  *
  * DIE REGEL VERLANGT EINE ENTSCHEIDUNG, KEINEN BESTIMMTEN WERT. Wo ein
  * Umbruch falsch waere (zwei Icon-Knoepfe in einer Rasterspalte), steht
@@ -13722,9 +13724,9 @@ test('jede rechtsbuendige Knopfzeile sagt, ob sie umbricht (#872)', () => {
 
   assert.deepEqual(offenders.sort(), [],
     'Diese Knopfzeile sagt nicht, was bei Platzmangel passieren soll. Ohne '
-    + '`flex-wrap` quetscht sie ihre Knoepfe unter die Inhaltsbreite, und weil '
-    + '`.btn` zentriert und nicht umbricht, wird der Text beidseitig '
-    + 'abgeschnitten (#872). Setze `flex-wrap: wrap` - oder `nowrap` mit einer '
+    + '`flex-wrap` waechst sie ueber ihren Container hinaus - rechtsbuendig also '
+    + 'nach links -, und was heraussteht, schneidet der Rahmen ab (#872). '
+    + 'Setze `flex-wrap: wrap` - oder `nowrap` mit einer '
     + `Begruendung, wenn der Umbruch hier falsch waere.\n${offenders.join('\n')}`);
 });
 


### PR DESCRIPTION
## Problem

`.btn` traegt `white-space: nowrap` und keinen Schrumpfschutz. Eine Flex-Zeile ohne `flex-wrap` drueckt ihn deshalb unter die Inhaltsbreite, und weil der Knopf seinen Inhalt zentriert, laeuft der Text auf **beiden** Seiten heraus - aus "Löschen" wurde in der Aufgaben-Detailansicht sichtbar "öschen".

Auf einem Telefon reichten dafuer schon die drei Aktionen der Aufgaben-Detailansicht (Löschen, Starten, Aufgabe archivieren). Getroffen haette es jede Fusszeile mit drei Knoepfen in einer laengeren Locale.

## Loesung

Umbruch statt Ueberlaufmenue. Ein "…"-Knopf (Vorschlag des Melders, SAP Fiori) verschoebe die Grenze nur: er misst in Pixeln, was in 20 Locales unterschiedlich lang ist, und braeuchte fuer den Rest doch wieder einen Umbruch.

Zwei Teile, weil der Umbruch der **Zeile** nicht reicht, wenn **ein** Knopf allein zu breit ist:

1. `flex-wrap: wrap` auf den Knopfzeilen
2. `white-space: normal` fuer `.btn` in den beiden kanonischen Modal-Knopfzeilen - damit ein einzelner zu breiter Knopf innen umbricht statt abgeschnitten zu werden

## Guard

Der Guard sucht die **Form** (rechtsbuendige Flex-Zeile, deren Name sie als Fuss- oder Aktionszeile ausweist), nicht die gemeldete Stelle - und fand damit sofort **acht weitere** Zeilen mit demselben Mangel.

Er verlangt eine *Entscheidung*, keinen Wert: wo der Umbruch falsch waere (zwei Icon-Knoepfe in einer Rasterspalte, `.subscriptions-toolbar__actions`), steht `flex-wrap: nowrap` ausdruecklich da.

Gegenprobe gelaufen: mit zurueckgedrehtem Fix faellt der Guard.

## Tests

`npm run test:frontend-audit` - 317 Tests gruen.

Closes #872