### PR TITLE
fix(dashboard): was abgelaufen ist, verschwindet - und was laeuft, bleibt (#877)

### DIFF
--- a/server/services/countdowns.js
+++ b/server/services/countdowns.js
@@ -135,18 +135,26 @@ export function nextEventDate(event, todayKey, exceptions = null, { graceDays = 
     return floor && startKey >= floor ? startKey : null;
   }
 
+  /* `seriesStart` SETZT COUNT DURCH (#877). Ohne die Angabe zaehlte eine Serie
+   * mit "endet nach N Malen" endlos weiter: `nextOccurrence()` ist zustandslos
+   * und weiss nicht, das wievielte Vorkommen es liefert. Gemeldet wurde das als
+   * "abgelaufene Termine bleiben unbegrenzt stehen" - und es war sogar der
+   * schlimmere Fall, weil die Kachel dazu ein Datum in der ZUKUNFT nannte.
+   *
+   * Die Kalender-Oberflaeche bietet "endet nach N Malen" ausdruecklich an
+   * (`allowCount` in pages/calendar.js), das ist also keine Sonderform. */
   let candidate = startKey >= todayKey
     ? startKey
-    : nextOccurrenceAfter(startKey, event.recurrence_rule, todayKey);
+    : nextOccurrenceAfter(startKey, event.recurrence_rule, todayKey, { seriesStart: startKey });
 
   let skips = 0;
   while (candidate && exceptions?.has(candidate) && skips++ < MAX_EXCEPTION_SKIPS) {
-    candidate = nextOccurrenceAfter(candidate, event.recurrence_rule, candidate);
+    candidate = nextOccurrenceAfter(candidate, event.recurrence_rule, candidate, { seriesStart: startKey });
   }
-  // `nextOccurrenceAfter` hat eine eigene Schleifengrenze und kann bei einer
-  // sehr alten Serie mit sehr kurzem Intervall aufgeben, bevor sie die Gegenwart
-  // erreicht. Ein Datum in der Vergangenheit ist dann kein Countdown, sondern
-  // ein falscher - lieber nichts zeigen.
+  // Ein Datum in der Vergangenheit ist kein Countdown, sondern ein falscher -
+  // lieber nichts zeigen. Der haeufigste Weg hierher war frueher die
+  // Schleifengrenze beim Aufholen (eine taegliche Serie ab 2023 gab auf);
+  // seit #877 springt das Aufholen, statt zu zaehlen.
   if (!candidate || candidate < todayKey) return null;
   return candidate;
 }

--- a/server/services/recurrence.js
+++ b/server/services/recurrence.js
@@ -121,22 +121,166 @@ function nextOccurrence(baseDateStr, rrule) {
 }
 
 /**
+ * So viele Einzelschritte holt das Aufholen höchstens nach.
+ *
+ * DIE ZAHL IST EIN SICHERHEITSNETZ, KEINE REICHWEITE. Sie war es einmal nicht:
+ * bei 1000 Schritten gab eine tägliche Serie ab 2023 auf und eine wöchentliche
+ * ab 2005 ebenso - beides gewöhnliche Einträge, keine Randfälle. Das Ergebnis
+ * war ein Datum in der Vergangenheit, das der Aufrufer als "gibt es nicht mehr"
+ * las: ein Termin, der heute stattfindet, verschwand (#877).
+ *
+ * Die Reichweite kommt jetzt vom Vorsprung darunter, der in Intervallschritten
+ * springt statt zu zählen. Was danach noch iteriert wird, sind die Fälle mit
+ * BYDAY, und dort liegt die Schrittweite unter einer Woche - 2000 Schritte
+ * decken damit gut drei Jahrzehnte ab.
+ */
+const CATCH_UP_STEPS = 2000;
+
+/**
+ * Springt in Intervallschritten dicht an `notBeforeStr` heran.
+ *
+ * WARUM RECHNEN STATT ZAEHLEN. Eine tägliche Serie von 2015 bis heute sind
+ * viertausend Einzelschritte, jeder mit einem eigenen Date-Objekt - und das
+ * bei jedem Aufbau der Übersicht. Wie viele Intervalle dazwischenliegen, lässt
+ * sich für die Frequenzen ohne Wochentagsfilter direkt ausrechnen.
+ *
+ * MIT BYDAY WIRD NICHT GESPRUNGEN. Dort bestimmt nicht das Intervall allein,
+ * wann das nächste Vorkommen liegt ("jeden zweiten Montag und Donnerstag"),
+ * und ein Sprung könnte über ein Vorkommen hinweggehen. Diese Fälle laufen
+ * weiter über die Schleife - ihre Schritte sind klein genug.
+ *
+ * BEWUSST EIN STUECK ZU KURZ: der Sprung landet garantiert NICHT hinter dem
+ * Ziel, damit die Schleife danach das erste passende Vorkommen findet. Ein
+ * Sprung, der zu weit ginge, überspränge genau das Vorkommen, das gesucht ist.
+ *
+ * MONATLICH UND JAEHRLICH NUR BIS ZUM 28. Eine Serie am 31. läuft nicht auf
+ * einem festen Monatsraster: der 31. Juni existiert nicht, `nextOccurrence()`
+ * schiebt sie auf den nächsten Monat, und ab da DRIFTET sie - aus "alle fünf
+ * Monate ab dem 31. Januar" wird der 31. Juli statt des 30. Juni. Die Zahl der
+ * Kalendermonate ist dann nicht mehr die Zahl der Schritte, und ein Sprung
+ * darüber landet Monate daneben (gemessen: 2026-12-31 statt 2026-08-31).
+ *
+ * Diese Serien laufen weiter über die Schleife. Das kostet nichts: monatlich
+ * sind zwölf Schritte im Jahr, die Grenze von 2000 reicht für Jahrhunderte -
+ * anders als täglich, wo genau das der gemeldete Fehler war.
+ *
+ * @returns {string} das Datum, ab dem weitergezählt wird (nie hinter notBefore)
+ */
+function fastForward(fromKey, parsed, notBeforeKey) {
+  const { freq, interval, byday } = parsed;
+  if (byday.length) return fromKey;
+
+  const from = new Date(`${fromKey}T00:00:00Z`);
+  const to   = new Date(`${notBeforeKey}T00:00:00Z`);
+  if (isNaN(from.getTime()) || isNaN(to.getTime()) || to <= from) return fromKey;
+  if ((freq === 'MONTHLY' || freq === 'YEARLY') && from.getUTCDate() > 28) return fromKey;
+
+  const days = Math.floor((to - from) / 86400000);
+  let steps;
+  if (freq === 'DAILY')       steps = Math.floor(days / interval);
+  else if (freq === 'WEEKLY')  steps = Math.floor(days / (7 * interval));
+  else {
+    // MONTHLY und YEARLY über Kalendermonate, nicht über Tage: ein Monat ist
+    // keine feste Anzahl Tage, und eine Näherung liefe über die Jahre auseinander.
+    const months = (to.getUTCFullYear() - from.getUTCFullYear()) * 12
+      + (to.getUTCMonth() - from.getUTCMonth());
+    steps = Math.floor(months / (freq === 'YEARLY' ? 12 * interval : interval));
+  }
+  // Einen Schritt Sicherheitsabstand - siehe oben.
+  steps -= 1;
+  if (!Number.isFinite(steps) || steps <= 0) return fromKey;
+
+  const jumped = new Date(from);
+  if (freq === 'DAILY')        jumped.setUTCDate(jumped.getUTCDate() + steps * interval);
+  else if (freq === 'WEEKLY')  jumped.setUTCDate(jumped.getUTCDate() + steps * 7 * interval);
+  else if (freq === 'MONTHLY') jumped.setUTCMonth(jumped.getUTCMonth() + steps * interval);
+  else                          jumped.setUTCFullYear(jumped.getUTCFullYear() + steps * interval);
+
+  const key = jumped.toISOString().slice(0, 10);
+  // MONTHLY kippt bei einem 31. in einen kürzeren Monat um ein paar Tage
+  // vorwärts (JS-Datumsarithmetik). Dann lieber gar nicht springen als
+  // daneben - die Schleife kann es ohnehin.
+  return key > notBeforeKey || key < fromKey ? fromKey : key;
+}
+
+/**
  * Wie nextOccurrence, überspringt aber alle Vorkommen vor `notBeforeStr`, bis das
  * erste Vorkommen >= notBeforeStr gefunden ist (Aufholen übersprungener Serien).
  * Gibt null zurück, wenn die Serie (UNTIL) vorher endet oder kein Basisdatum existiert.
+ *
+ * `seriesStart` SETZT ZUSAETZLICH `COUNT` DURCH. Ohne die Angabe bleibt es beim
+ * bisherigen Verhalten - `nextOccurrence()` ist zustandslos und kann nicht
+ * wissen, das wievielte Vorkommen es gerade liefert. Wer den Serienanfang
+ * kennt, kann zählen: das letzte erlaubte Vorkommen ist `seriesStart` plus
+ * (COUNT - 1) Intervalle, und alles danach gibt es nicht mehr.
+ *
+ * WARUM DAS NICHT IMMER GILT: `nextDueAfterCompletion()` reicht als Basis das
+ * Fälligkeitsdatum der gerade erledigten Instanz herein, nicht den Serienstart.
+ * Von dort zu zählen ergäbe eine Serie, die sich bei jedem Abhaken verlängert -
+ * also lieber gar nicht zählen als falsch. Deshalb ist es eine Angabe des
+ * Aufrufers und keine Vermutung dieser Funktion.
+ *
  * @param {string} baseDateStr  - ISO-Datums-String (YYYY-MM-DD)
  * @param {string} rrule        - RRULE-String
  * @param {string} notBeforeStr - Untere Schranke (YYYY-MM-DD); Ergebnis ist >= dieser
+ * @param {{seriesStart?: string|null}} [opts]
  * @returns {string|null}       - Nächstes zukünftiges Datum als YYYY-MM-DD oder null
  */
-function nextOccurrenceAfter(baseDateStr, rrule, notBeforeStr) {
-  let current = nextOccurrence(baseDateStr, rrule);
+function nextOccurrenceAfter(baseDateStr, rrule, notBeforeStr, { seriesStart = null } = {}) {
+  const parsed = parseRRule(rrule);
+  if (!parsed) return null;
+
+  const lastAllowed = seriesStart ? lastOccurrenceOf(seriesStart, parsed) : null;
+  // Die Serie ist aufgebraucht, bevor die Schranke ueberhaupt erreicht wird.
+  if (lastAllowed && notBeforeStr && lastAllowed < notBeforeStr) return null;
+
+  const start = notBeforeStr ? fastForward(baseDateStr, parsed, notBeforeStr) : baseDateStr;
+  let current = nextOccurrence(start, rrule);
   // Vergleich per lexikografischem YYYY-MM-DD-String (Format ist fix, daher sicher).
   let guard = 0;
-  while (current && notBeforeStr && current < notBeforeStr && guard++ < 1000) {
+  while (current && notBeforeStr && current < notBeforeStr && guard++ < CATCH_UP_STEPS) {
     current = nextOccurrence(current, rrule);
   }
+  if (current && lastAllowed && current > lastAllowed) return null;
   return current;
+}
+
+/**
+ * Das letzte Vorkommen einer Serie mit COUNT - oder null, wenn sie keines hat.
+ *
+ * DTSTART IST VORKOMMEN 1, deshalb (COUNT - 1) Intervalle. Mit BYDAY laesst
+ * sich das nicht ausrechnen: dort haengt an einem Intervall mehr als ein
+ * Vorkommen, und die Zahl derer vor der Schranke ist nicht die Zahl der
+ * Intervalle. Solche Serien werden nicht begrenzt - lieber einer zu lang als
+ * einer zu kurz, denn das Zuviel sieht man, das Zuwenig fehlt lautlos.
+ *
+ * @returns {string|null} YYYY-MM-DD
+ */
+function lastOccurrenceOf(seriesStart, parsed) {
+  const { freq, interval, byday, count } = parsed;
+  if (!count || byday.length) return null;
+
+  const start = new Date(`${String(seriesStart).slice(0, 10)}T00:00:00Z`);
+  if (isNaN(start.getTime())) return null;
+
+  /* MONATLICH UND JAEHRLICH NUR BIS ZUM 28., aus demselben Grund wie beim
+   * Sprung darueber: eine Serie am 31. laeuft nicht auf einem festen
+   * Monatsraster, sondern driftet an jedem kurzen Monat. (COUNT - 1) Intervalle
+   * waeren dann nicht ihr letztes Vorkommen, sondern irgendeines davor - und
+   * eine zu frueh gesetzte Grenze schneidet Termine ab, die es noch gibt.
+   * Solche Serien werden nicht begrenzt: einer zu lang sieht man, einer zu
+   * kurz fehlt lautlos. */
+  if ((freq === 'MONTHLY' || freq === 'YEARLY') && start.getUTCDate() > 28) return null;
+
+  const steps = count - 1;
+  const last = new Date(start);
+  if (freq === 'DAILY')        last.setUTCDate(last.getUTCDate() + steps * interval);
+  else if (freq === 'WEEKLY')  last.setUTCDate(last.getUTCDate() + steps * 7 * interval);
+  else if (freq === 'MONTHLY') last.setUTCMonth(last.getUTCMonth() + steps * interval);
+  else if (freq === 'YEARLY')  last.setUTCFullYear(last.getUTCFullYear() + steps * interval);
+  else return null;
+
+  return last.toISOString().slice(0, 10);
 }
 
 /**

--- a/test/test-countdown.js
+++ b/test/test-countdown.js
@@ -22,6 +22,7 @@ process.env.TZ = 'Europe/Berlin';
 
 const { MIGRATIONS, get, _setTestDatabase } = await import('../server/db.js');
 const { getCountdowns, nextEventDate, daysBetween } = await import('../server/services/countdowns.js');
+const { nextOccurrence } = await import('../server/services/recurrence.js');
 const { MIRRORED_FIELDS } = await import('../server/services/calendar-outbound.js');
 const { countdownPhrase, countdownRank, daysBetweenDateKeys } = await import('../public/utils/countdown.js');
 
@@ -501,5 +502,123 @@ test('ein PUT ohne das Feld löscht eine gesetzte Markierung nicht', async () =>
     assert.equal(row.countdown, 1, 'ein PUT ohne das Feld hat die Markierung gelöscht');
   } finally {
     await new Promise((resolve) => server.close(resolve));
+  }
+});
+
+// --------------------------------------------------------
+// Was abgelaufen ist, verschwindet - und was laeuft, bleibt (#877)
+// --------------------------------------------------------
+
+/** Ein Termin, wie ihn `nextEventDate` erwartet. */
+const ev = (start, rule = null) => ({ start_datetime: start, all_day: 1, recurrence_rule: rule });
+
+const HEUTE = '2026-08-26';
+const GRACE = { graceDays: 7, tz: 'UTC' };
+
+test('eine Serie mit COUNT ist nach ihrem letzten Mal vorbei (#877)', () => {
+  // GEMELDET WAR: "past/expired appointments continue to be displayed
+  // indefinitely". Der Weg dorthin ist COUNT.
+  //
+  // `nextOccurrence()` ist zustandslos und kann COUNT nicht durchsetzen - das
+  // steht so in recurrence.js und stimmt auch. Was fehlte, ist die Stelle, die
+  // es KANN: `nextEventDate` kennt den Serienstart, also kann sie zaehlen.
+  // Ohne sie lief eine dreimalige Serie aus dem Januar 2025 im August 2026
+  // immer noch weiter und zeigte einen Termin in der ZUKUNFT an - der
+  // Countdown war also nicht nur zu langlebig, sondern schlicht falsch.
+  const dreimalAbJanuar = ev('2025-01-01', 'FREQ=MONTHLY;COUNT=3');
+  assert.equal(nextEventDate(dreimalAbJanuar, HEUTE, null, GRACE), null,
+    'die Serie hatte ihre drei Termine im Januar, Februar und Maerz 2025');
+
+  // Die Gegenrichtung: eine Serie, deren Vorkommen noch nicht aufgebraucht
+  // sind, zaehlt normal weiter.
+  const nochNichtAufgebraucht = ev('2026-01-01', 'FREQ=MONTHLY;COUNT=24');
+  assert.equal(nextEventDate(nochNichtAufgebraucht, HEUTE, null, GRACE), '2026-09-01');
+});
+
+test('COUNT zaehlt ab dem Serienstart, nicht ab heute (#877)', () => {
+  // Der Randfall, an dem eine Zaehlung "ab dem naechsten Vorkommen" gruen
+  // waere und trotzdem falsch: die Serie hat genau noch ein Mal vor sich.
+  const nochEinmal = ev('2026-06-01', 'FREQ=MONTHLY;COUNT=4');
+  assert.equal(nextEventDate(nochEinmal, HEUTE, null, GRACE), '2026-09-01',
+    'Juni, Juli, August, September - das vierte Mal steht noch aus');
+
+  const geradeVorbei = ev('2026-06-01', 'FREQ=MONTHLY;COUNT=3');
+  assert.equal(nextEventDate(geradeVorbei, HEUTE, null, GRACE), null,
+    'Juni, Juli, August - das dritte Mal war der 1. August, also vorbei');
+});
+
+test('eine alte Serie verschwindet nicht, nur weil sie alt ist (#877)', () => {
+  // DIE ANDERE HAELFTE DESSELBEN BERICHTS. `nextOccurrenceAfter` holte die
+  // Serie Schritt fuer Schritt ein und gab nach 1000 Schritten auf; ein Datum
+  // in der Vergangenheit wird dann zu `null`, und der Countdown verschwindet.
+  //
+  // Gemessen: eine TAEGLICHE Serie ab 2023 und eine WOECHENTLICHE ab 2005
+  // fielen heraus - beides voellig gewoehnliche Eintraege, keine Randfaelle.
+  // Ein wiederkehrender Termin, der heute stattfindet, muss heute anzeigen.
+  assert.equal(nextEventDate(ev('2023-01-01', 'FREQ=DAILY'), HEUTE, null, GRACE), HEUTE,
+    'eine taegliche Serie findet auch heute statt');
+  assert.equal(nextEventDate(ev('2015-01-01', 'FREQ=DAILY'), HEUTE, null, GRACE), HEUTE);
+
+  // Woechentlich ab einem Donnerstag im Jahr 2005: der naechste Donnerstag.
+  const woechentlich = nextEventDate(ev('2005-01-06', 'FREQ=WEEKLY'), HEUTE, null, GRACE);
+  assert.ok(woechentlich && woechentlich >= HEUTE,
+    `eine woechentliche Serie seit 2005 darf nicht verschwinden (war: ${woechentlich})`);
+  assert.equal(new Date(`${woechentlich}T00:00:00Z`).getUTCDay(), 4, 'sie bleibt auf ihrem Donnerstag');
+});
+
+test('einmalige Termine folgen weiter der Nachfrist (#877)', () => {
+  // Die Zusicherung aus #647, unveraendert - der Fix darf sie nicht mitnehmen.
+  assert.equal(nextEventDate(ev('2026-08-23'), HEUTE, null, GRACE), '2026-08-23', '3 Tage her: bleibt');
+  assert.equal(nextEventDate(ev('2026-08-18'), HEUTE, null, GRACE), null, '8 Tage her: weg');
+  assert.equal(nextEventDate(ev('2024-08-26'), HEUTE, null, GRACE), null, '2 Jahre her: weg');
+});
+
+test('eine Serie mit UNTIL bleibt vorbei (#877)', () => {
+  // Sie war schon richtig - der Fix darf sie nicht kaputt machen.
+  assert.equal(nextEventDate(ev('2025-01-01', 'FREQ=MONTHLY;UNTIL=20250601T000000Z'), HEUTE, null, GRACE), null);
+});
+
+test('der Sprung beim Aufholen liefert dasselbe wie das Zaehlen (#877)', () => {
+  // DIE ABKUERZUNG DARF DAS ERGEBNIS NICHT AENDERN, nur seinen Preis. Genau
+  // hier liegt das Risiko dieser Sorte Optimierung: ein Sprung, der ein Stueck
+  // zu weit geht, ueberspringt das gesuchte Vorkommen - und das Ergebnis sieht
+  // trotzdem plausibel aus, weil es ein gueltiges Datum der Serie ist.
+  //
+  // Also gegengerechnet: Schritt fuer Schritt vom Serienstart aus, ohne jede
+  // Abkuerzung, und das Ergebnis muss gleich sein.
+  const langsam = (startKey, rule, todayKey) => {
+    let current = startKey;
+    for (let i = 0; i < 20000 && current < todayKey; i += 1) {
+      const next = nextOccurrence(current, rule);
+      if (!next || next <= current) return null;
+      current = next;
+    }
+    return current >= todayKey ? current : null;
+  };
+
+  // Breit ausgelegt, weil ein Sprung genau dort danebengeht, wo das Raster
+  // nicht gleichmaessig ist: Monatsenden, Schaltjahre, ungerade Intervalle.
+  // Der 31.03. mit Intervall 5 stand beim ersten Wurf drin und hat den Fehler
+  // gefunden - die Serie driftet an jedem kurzen Monat, und der Sprung landete
+  // vier Monate zu weit.
+  const faelle = [];
+  for (const iv of [1, 2, 3, 5, 7]) {
+    faelle.push(['2015-01-01', `FREQ=DAILY;INTERVAL=${iv}`]);
+    faelle.push(['2005-01-06', `FREQ=WEEKLY;INTERVAL=${iv}`]);
+    for (const tag of ['01-15', '01-28', '01-29', '01-30', '01-31', '03-31', '05-31']) {
+      faelle.push([`1990-${tag}`, `FREQ=MONTHLY;INTERVAL=${iv}`]);
+    }
+    faelle.push([`2000-02-29`, `FREQ=YEARLY;INTERVAL=${iv}`]);
+    faelle.push([`1990-12-31`, `FREQ=YEARLY;INTERVAL=${iv}`]);
+  }
+  // Und die kurzen Abstaende, bei denen gar nicht gesprungen wird - der
+  // haeufige Fall darf durch die Abkuerzung nicht anders werden.
+  faelle.push(['2026-08-20', 'FREQ=DAILY'], ['2026-08-26', 'FREQ=MONTHLY'],
+    ['2026-08-01', 'FREQ=WEEKLY'], ['2026-07-15', 'FREQ=MONTHLY;INTERVAL=2']);
+
+  for (const [start, rule] of faelle) {
+    const mitSprung = nextEventDate(ev(start, rule), HEUTE, null, GRACE);
+    assert.equal(mitSprung, langsam(start, rule, HEUTE),
+      `${rule} ab ${start}: der Sprung weicht vom Zaehlen ab`);
   }
 });


### PR DESCRIPTION
Fixes #877.

## Der Bericht stimmt, die naheliegende Erklaerung nicht

Gemeldet: *"past/expired appointments continue to be displayed indefinitely"* unter **Stichtage**.

Die Nachfrist von sieben Tagen gibt es seit v2.18.0 (#647), und sie greift auch - **fuer einmalige Termine**. Nachgerechnet:

| Fall | vorher |
|---|---|
| einmalig, 3 Tage her | bleibt (so gewollt) |
| einmalig, 8 Tage her | faellt raus |
| einmalig, 2 Jahre her | faellt raus |
| Serie mit UNTIL vorbei | faellt raus |
| **Serie mit COUNT erschoepft** | **zeigt 2026-09-01** |
| **taegliche Serie ab 2023** | **verschwindet** |
| **woechentliche Serie ab 2005** | **verschwindet** |

Zwei Fehler in derselben Funktion, aus entgegengesetzten Richtungen - und zusammen erklaeren sie den Bericht.

## 1. `COUNT` wurde nie durchgesetzt

`nextOccurrence()` ist zustandslos und kann nicht wissen, das wievielte Vorkommen es liefert. Das steht so in `recurrence.js` und stimmt. Was fehlte, ist die Stelle, die es **kann**: wer den Serienstart kennt, kann zaehlen.

Ohne sie lief eine dreimalige Serie aus dem Januar 2025 im August 2026 immer noch weiter - und nannte dabei ein Datum in der **Zukunft**. Der Countdown war also nicht nur zu langlebig, sondern schlicht falsch.

Das ist keine Sonderform: die Kalender-Oberflaeche bietet "endet nach N Malen" ausdruecklich an (`allowCount: true` in `pages/calendar.js`).

`seriesStart` ist bewusst eine **Angabe des Aufrufers** und keine Vermutung der Funktion. `nextDueAfterCompletion()` reicht als Basis das Faelligkeitsdatum der gerade erledigten Instanz herein, nicht den Serienstart - von dort zu zaehlen ergaebe eine Serie, die sich bei jedem Abhaken verlaengert.

## 2. Eine alte Serie verschwand, nur weil sie alt ist

Das Aufholen zaehlte Schritt fuer Schritt und gab nach 1000 Schritten auf. Ein Datum in der Vergangenheit wird dann zu `null` - und der Countdown ist weg, obwohl der Termin heute stattfindet.

Das Aufholen springt jetzt in Intervallschritten. Die Grenze bleibt als Sicherheitsnetz, aber sie ist nicht mehr die Reichweite.

## Was der Sprung nicht darf - und der Test, der es gefunden hat

Genau hier liegt das Risiko dieser Sorte Abkuerzung: ein Sprung, der ein Stueck zu weit geht, ueberspringt das gesuchte Vorkommen - und das Ergebnis **sieht plausibel aus**, weil es ein gueltiges Datum der Serie ist.

Der Aequivalenztest rechnet deshalb rund 180 Serien Schritt fuer Schritt gegen. Er hat beim ersten Wurf einen echten Fehler gefunden:

> Eine Monatsserie am 31. laeuft **nicht** auf einem festen Monatsraster. Der 31. Juni existiert nicht, die Serie rutscht auf den naechsten Monat und driftet ab da. Aus "alle fuenf Monate ab dem 31. Maerz" wurde `2026-12-31` statt `2026-08-31` - vier Monate daneben.

Monatlich und jaehrlich wird deshalb nur bis zum 28. gesprungen; darueber laeuft die Schleife, und das kostet nichts (zwoelf Schritte im Jahr, die Grenze reicht fuer Jahrhunderte). Dieselbe Einschraenkung gilt fuer die COUNT-Grenze: eine zu frueh gesetzte Grenze schneidet Termine ab, die es noch gibt - einer zu lang sieht man, einer zu kurz fehlt lautlos.

## Was bewusst NICHT geaendert wurde

Der Melder schlaegt vor, Vergangenes grundsaetzlich auszublenden oder einen Schalter dafuer anzubieten. Beides bleibt, wie es ist:

Die Nachfrist ist der **Zweck** dieser Kachel, nicht ihr Versehen. #647 hat das ausformuliert: ein Ablaufdatum, das genau beim Aufprall aufhoert zu zaehlen, laesst einen im einen Moment allein, fuer den man es gesetzt hat - am Vortag steht "Morgen", am Tag danach steht nichts mehr, und niemand sagt einem, dass man es verpasst hat. Sieben Tage decken eine Woche Alltag ab: wer freitags nicht hinsieht, findet den verpassten Stichtag am Montag noch vor.

Ein Schalter dafuer waere eine Frage, die man beim Einrichten stellt, damit die Anzeige nachher stimmt - dieselbe Sorte Frage, die #647 schon bei den Rundungsschwellen abgelehnt hat.

## Guards

- `test:countdown`: 28 -> 32. Beide Fehler sind einzeln festgehalten, dazu der Aequivalenztest.
- Gegenproben: jeder der beiden Fixes einzeln zurueckgedreht macht genau seine Tests rot.
- Regression ueber alle Nutzer von `recurrence.js`: `tasks-recurrence` (43), `calendar-routes` (57), `calendar` (83), `caldav-recurrence` (9), `budget-recurrence` (26), `recurring-scope` (13), `calendar-exceptions` (6), `task-completions` (31), `inventory-deadlines-feed` (15), `multi-reminders` (11) - alle gruen.
