### PR TITLE
fix(health): abhaengige Datensaetze erben das Schreibrecht des Elternteils (#884)

### DIFF
--- a/server/routes/health/helpers.js
+++ b/server/routes/health/helpers.js
@@ -116,6 +116,26 @@ export function writableClause(alias, viewer) {
 }
 
 /**
+ * Lädt einen abhängigen Datensatz, wenn `viewer` dessen Eltern-Zeile ändern
+ * darf; sonst null.
+ *
+ * Zeitpläne und Dosis-Einträge hängen am Medikament, Analyte am Befund: sie
+ * haben keine eigene `user_id`, ihr Scoping ist immer das des Elternteils. Wer
+ * das von Hand als `m.user_id = ?` schreibt, schneidet die Betreuung (#584)
+ * still wieder weg - genau das war #884: anlegen ging, wegräumen nicht. Die
+ * Regel steht deshalb hier und nicht in jeder Route erneut.
+ *
+ * @param {string} sql         - SELECT … JOIN … WHERE <kind>.id = ?  (ohne Scope)
+ * @param {string} parentAlias - Alias der Eltern-Tabelle mit `user_id`
+ * @param {number} id          - ID des abhängigen Datensatzes
+ * @param {number} viewer      - eingeloggter Nutzer
+ */
+export function writableChild(sql, parentAlias, id, viewer) {
+  const w = writableClause(parentAlias, viewer);
+  return db.get().prepare(`${sql} AND ${w.sql}`).get(id, ...w.params) ?? null;
+}
+
+/**
  * Eigentümer eines zu schreibenden Datensatzes aus dem Request.
  * Ohne `user_id` im Body bleibt es der eingeloggte Nutzer - die Route verhält
  * sich für alle Bestandsaufrufe also unverändert.

--- a/server/routes/health/labs.js
+++ b/server/routes/health/labs.js
@@ -10,7 +10,7 @@ import * as v from '../../middleware/validate.js';
 import {
   log, VISIBILITIES, MAX_UNIT,
   viewerId, careAwareClause, applyUpdate, badRequest, deriveFlag, attachResults,
-  resolveOwner, writableClause,
+  resolveOwner, writableClause, writableChild,
 } from './helpers.js';
 
 const router = express.Router();
@@ -222,11 +222,11 @@ router.delete('/results/:id', (req, res) => {
     const id = parseInt(req.params.id, 10);
     if (!id) return res.status(400).json({ error: 'Ungültige ID.', code: 400 });
 
-    const existing = db.get().prepare(`
+    const existing = writableChild(`
       SELECT res.id FROM health_lab_results res
       JOIN health_lab_reports r ON r.id = res.report_id
-      WHERE res.id = ? AND r.user_id = ?
-    `).get(id, viewer);
+      WHERE res.id = ?
+    `, 'r', id, viewer);
     if (!existing) return res.status(404).json({ error: 'Analyt nicht gefunden.', code: 404 });
 
     db.get().prepare('DELETE FROM health_lab_results WHERE id = ?').run(id);

--- a/server/routes/health/medications.js
+++ b/server/routes/health/medications.js
@@ -11,7 +11,7 @@ import * as v from '../../middleware/validate.js';
 import {
   log, VISIBILITIES, LOG_STATUS, MAX_UNIT,
   viewerId, careAwareClause, toBit, applyUpdate, badRequest,
-  resolveOwner, writableClause,
+  resolveOwner, writableClause, writableChild,
 } from './helpers.js';
 
 const router = express.Router();
@@ -256,11 +256,11 @@ router.patch('/schedules/:id', (req, res) => {
     const id = parseInt(req.params.id, 10);
     if (!id) return res.status(400).json({ error: 'Ungültige ID.', code: 400 });
 
-    const existing = db.get().prepare(`
+    const existing = writableChild(`
       SELECT s.* FROM medication_schedules s
       JOIN medications m ON m.id = s.medication_id
-      WHERE s.id = ? AND m.user_id = ?
-    `).get(id, viewer);
+      WHERE s.id = ?
+    `, 'm', id, viewer);
     if (!existing) return res.status(404).json({ error: 'Einnahmeplan nicht gefunden.', code: 404 });
 
     const b = req.body || {};
@@ -299,11 +299,11 @@ router.delete('/schedules/:id', (req, res) => {
     const id = parseInt(req.params.id, 10);
     if (!id) return res.status(400).json({ error: 'Ungültige ID.', code: 400 });
 
-    const existing = db.get().prepare(`
+    const existing = writableChild(`
       SELECT s.id FROM medication_schedules s
       JOIN medications m ON m.id = s.medication_id
-      WHERE s.id = ? AND m.user_id = ?
-    `).get(id, viewer);
+      WHERE s.id = ?
+    `, 'm', id, viewer);
     if (!existing) return res.status(404).json({ error: 'Einnahmeplan nicht gefunden.', code: 404 });
 
     db.get().prepare('DELETE FROM medication_schedules WHERE id = ?').run(id);
@@ -418,17 +418,20 @@ function updateLogStatus(req, res, newStatus) {
 /**
  * Der Log-Eintrag samt Besitzer, oder null.
  *
- * Bewusst über `m.user_id = viewer` und nicht über die Sichtbarkeit: ein
- * Dosis-Eintrag ist eine Aufzeichnung über den eigenen Körper. Wer ein
+ * Bewusst über das Schreibrecht am Medikament und nicht über die Sichtbarkeit:
+ * ein Dosis-Eintrag ist eine Aufzeichnung über den eigenen Körper. Wer ein
  * Medikament sehen darf, darf deshalb noch lange nicht in seinem Protokoll
- * korrigieren - dieselbe Grenze, die take/skip seit jeher ziehen.
+ * korrigieren - dieselbe Grenze, die take/skip seit jeher ziehen. Die Betreuung
+ * (#584) liegt innerhalb dieser Grenze: sie ist ausdrücklich erteilt, und ohne
+ * sie könnte ein Elternteil die Dosis, die es selbst eingetragen hat, nicht
+ * abhaken (#884).
  */
 function ownLogRow(id, viewer) {
-  return db.get().prepare(`
+  return writableChild(`
     SELECT l.*, m.user_id AS owner_id FROM medication_logs l
     JOIN medications m ON m.id = l.medication_id
-    WHERE l.id = ? AND m.user_id = ?
-  `).get(id, viewer) ?? null;
+    WHERE l.id = ?
+  `, 'm', id, viewer);
 }
 
 // --------------------------------------------------------

--- a/test/test-health-api.js
+++ b/test/test-health-api.js
@@ -1190,6 +1190,85 @@ test('Betreuung: eine leere Liste entzieht sie wieder', async () => {
   assert.equal(res.status, 403, 'nach dem Entzug ist der Weg sofort zu');
 });
 
+// Die Meldung aus #884: angelegt werden konnte beides, weggeraeumt nichts. Ein
+// Zeitplan und ein Dosis-Eintrag haben keine eigene `user_id` - sie haengen am
+// Medikament und muessen dessen Scoping erben, Betreuung eingeschlossen. Der
+// Alltagsfall ist die betreuende Person, die den Plan des Kindes wieder
+// loeschen oder dessen Dosis abhaken will.
+test('Betreuung: Zeitplan der betreuten Person laesst sich aendern und loeschen (#884)', async () => {
+  asAdmin();
+  await call('PUT', `/caregivers/${userC}`, { caregiver_ids: [userA] });
+
+  asA();
+  const med = await call('POST', '/medications', { name: 'Vitamin D', user_id: userC });
+  assert.equal(med.body.data.user_id, userC);
+
+  const sched = await call('POST', `/medications/${med.body.data.id}/schedules`, {
+    time_of_day: '07:00', dose_qty: 1,
+  });
+  assert.equal(sched.status, 201, 'anlegen ging schon vorher');
+  const schedId = sched.body.data.id;
+
+  const patched = await call('PATCH', `/schedules/${schedId}`, { dose_qty: 2 });
+  assert.equal(patched.status, 200);
+  assert.equal(patched.body.data.dose_qty, 2);
+
+  asB();
+  assert.equal((await call('DELETE', `/schedules/${schedId}`)).status, 404,
+    'ohne Betreuung bleibt der Plan unerreichbar');
+
+  asA();
+  assert.equal((await call('DELETE', `/schedules/${schedId}`)).status, 204);
+});
+
+// Warum die Meldung „zufaellig" klang: solange der Betreuer die Dosis selbst
+// anlegt, laeuft sie ueber das Medikament und geht. Sobald der Scheduler den
+// Eintrag vorab erzeugt hat, tippt die Oberflaeche auf /logs/:id/take - und nur
+// dieser Weg war zu. Derselbe Knopf, mal so, mal so.
+test('Betreuung: eine vorab erzeugte Dosis der betreuten Person ist abhakbar (#884)', async () => {
+  asA();
+  const med = await call('POST', '/medications', { name: 'Eisen', user_id: userC });
+  const medId = med.body.data.id;
+  const sched = await call('POST', `/medications/${medId}/schedules`, { time_of_day: '08:00' });
+
+  // So legt der Scheduler ihn an: pending, mit schedule_id, ohne Zutun des Betreuers.
+  const logId = db.prepare(`INSERT INTO medication_logs (medication_id, schedule_id, scheduled_at, status)
+    VALUES (?, ?, '2026-08-05T08:00', 'pending')`).run(medId, sched.body.data.id).lastInsertRowid;
+
+  asB();
+  assert.equal((await call('POST', `/logs/${logId}/take`, {})).status, 404,
+    'ohne Betreuung bleibt fremdes Protokoll zu');
+
+  asA();
+  const taken = await call('POST', `/logs/${logId}/take`, {});
+  assert.equal(taken.status, 200);
+  assert.equal(taken.body.data.status, 'taken');
+
+  const back = await call('PATCH', `/logs/${logId}`, { status: 'pending' });
+  assert.equal(back.status, 200);
+  assert.equal(back.body.data.status, 'pending');
+  assert.equal(back.body.data.taken_at, null);
+
+  const skipped = await call('POST', `/logs/${logId}/skip`, {});
+  assert.equal(skipped.status, 200);
+});
+
+// Dieselbe Luecke, nur nie gemeldet: ein Analyt haengt am Befund wie der
+// Zeitplan am Medikament. Anlegen ging, loeschen nicht.
+test('Betreuung: Analyt der betreuten Person laesst sich wieder loeschen (#884)', async () => {
+  asA();
+  const lab = await call('POST', '/labs', { report_date: '2026-08-05', user_id: userC });
+  assert.equal(lab.body.data.user_id, userC);
+  const resu = await call('POST', `/labs/${lab.body.data.id}/results`, { analyte: 'Ferritin', value_num: 40 });
+  assert.equal(resu.status, 201);
+
+  asB();
+  assert.equal((await call('DELETE', `/results/${resu.body.data.id}`)).status, 404);
+
+  asA();
+  assert.equal((await call('DELETE', `/results/${resu.body.data.id}`)).status, 204);
+});
+
 test('Betreuung: niemand wird sein eigener Betreuer, Unbekannte werden abgelehnt', async () => {
   asAdmin();
   const self = await call('PUT', `/caregivers/${userC}`, { caregiver_ids: [userC, userA] });

--- a/test/test-health-structure.js
+++ b/test/test-health-structure.js
@@ -7,6 +7,13 @@
  * (keine verlorene/doppelte Route). Fängt ab, dass ein Cluster-Router still nicht
  * gemountet wird oder eine Route beim Umbau verloren geht/umbenannt wird.
  *
+ * Dazu ein Scope-Guard (#884): ein abhängiger Datensatz - Zeitplan, Dosis-
+ * Eintrag, Analyt - darf sein Schreibrecht nur über `writableChild()` aus
+ * helpers.js beziehen. Ein handgeschriebenes `m.user_id = ?` sieht daneben
+ * harmlos aus und schneidet die Betreuung (#584) still weg: anlegen ging,
+ * wegräumen nicht. Der Guard ist deshalb eine Regel und keine Liste bekannter
+ * Stellen - eine neue Route mit demselben Griff fällt sofort auf.
+ *
  * Der Verhaltensbeweis liegt in den funktionalen Suiten (test:health-api,
  * test:health-vitals, test:health-meds, test:health-labs, test:health-activity,
  * test:health-cycle, test:health-overview, test:health-nav,
@@ -14,6 +21,9 @@
  */
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import healthRouter from '../server/routes/health.js';
 
@@ -127,4 +137,40 @@ test('die Cluster-Router zusammen ergeben genau die Orchestrator-Routen (keine v
 
 test('Default-Export ist ein montierbarer Router', () => {
   assert.equal(typeof healthRouter, 'function', 'default export ist kein Router');
+});
+
+// --------------------------------------------------------
+// Scope-Guard (#884)
+// --------------------------------------------------------
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const ROUTE_DIR = path.join(HERE, '..', 'server', 'routes', 'health');
+
+// helpers.js ist die eine Stelle, an der die Klausel gebaut werden DARF -
+// dort steht sie in Template-Strings und ist genau der Helfer, den alle
+// anderen benutzen sollen.
+const SCOPE_OWNER = 'helpers.js';
+
+// Ein Alias vor `user_id` heisst: die Spalte gehoert einer gejointen
+// Eltern-Tabelle. Unqualifiziertes `user_id = ?` ist davon nicht betroffen -
+// das ist die eigene Spalte, etwa im bewusst rein persoenlichen cycle.js.
+const RAW_PARENT_SCOPE = /\b[a-z][a-z0-9_]*\.user_id\s*=\s*\?/;
+
+test('kein handgeschriebenes <alias>.user_id = ? ausserhalb von helpers.js (#884)', () => {
+  const offenders = [];
+  for (const file of fs.readdirSync(ROUTE_DIR).filter((f) => f.endsWith('.js') && f !== SCOPE_OWNER)) {
+    const lines = fs.readFileSync(path.join(ROUTE_DIR, file), 'utf8').split('\n');
+    lines.forEach((line, i) => {
+      if (RAW_PARENT_SCOPE.test(line)) offenders.push(`${file}:${i + 1}: ${line.trim()}`);
+    });
+  }
+  assert.deepEqual(offenders, [],
+    'Scoping ueber einen Eltern-Alias gehoert in writableChild()/writableClause(), sonst faellt die Betreuung (#584) still weg');
+});
+
+// Gegenprobe zur Regel selbst: ohne sie waere der Guard gruen, weil das Muster
+// nie zutrifft - nicht, weil die Routen sauber sind.
+test('der Scope-Guard erkennt das Muster, das er verbietet', () => {
+  assert.ok(RAW_PARENT_SCOPE.test('WHERE s.id = ? AND m.user_id = ?'), 'Verstoss wird nicht erkannt');
+  assert.ok(!RAW_PARENT_SCOPE.test("SELECT * FROM cycle_settings WHERE user_id = ?"), 'eigene Spalte faelschlich beanstandet');
 });


### PR DESCRIPTION
Behebt #884 - beide gemeldeten Probleme, sie haben dieselbe Ursache.

## Was passiert ist

Ein Zeitplan, ein Dosis-Eintrag und ein Analyt haben keine eigene `user_id`: ihr Scoping haengt am Medikament bzw. am Befund. An vier Stellen stand dort ein handgeschriebenes `m.user_id = ?` statt des Helfers, und das schneidet die Betreuung (#584) still weg. Die betreuende Person konnte fuer das Kind anlegen, aber nicht mehr wegraeumen.

`server/routes/health/medications.js` sagt im Kopf ausdruecklich zu, dass "Plaene und Einnahmeprotokolle ihr Scoping von hier erben". Die Zusage hielt an vier Stellen nicht.

**Warum die Meldung "zufaellig" klang:** solange der Betreuer die Dosis selbst anhakt, laeuft sie ueber `POST /medications/:id/logs` - die Route nutzt den Helfer und geht. Sobald der Scheduler den Eintrag vorab erzeugt hat, tippt die Oberflaeche auf `/logs/:id/take`, und nur dieser Weg war zu. Derselbe Knopf, mal so, mal so. Genau das beschreibt die Meldung.

## Aenderung

`writableChild()` in `server/routes/health/helpers.js` haelt die Regel jetzt an einer Stelle: ein abhaengiger Datensatz erbt das Schreibrecht seines Elternteils.

Umgestellt: `PATCH /schedules/:id`, `DELETE /schedules/:id`, `ownLogRow()` (traegt take/skip/PATCH/DELETE auf Dosis-Eintraegen) und `DELETE /results/:id` in `labs.js` - der Analyt hatte dieselbe Luecke, nur nie gemeldet.

Nicht angefasst: `cycle.js`. Der Zyklus ist bewusst rein persoenlich, und der bestehende Test dazu bleibt gruen.

## Guard

`test-health-structure.js` verbietet das Muster jetzt als Regel und nicht als Liste bekannter Stellen: kein `<alias>.user_id = ?` ausserhalb von `helpers.js`. Unqualifiziertes `user_id = ?` bleibt erlaubt - das ist die eigene Spalte.

## Tests

- Drei neue Faelle in `test:health-api`, alle drei **vor** dem Fix rot
- Der Guard ist gegengeprobt: mit einem injizierten `AND m.user_id = ?` faellt er
- `npm test` vollstaendig gruen