### PR TITLE
fix(budget): die uebersicht haelt ihre transaktionsliste erreichbar (#904)

### DIFF
--- a/public/styles/budget.css
+++ b/public/styles/budget.css
@@ -305,16 +305,19 @@
 
 /* Der Budget-Tab hält seine eigene Scroll-Region: Zusammenfassung und
  * Kategoriebalken bleiben stehen, nur die Transaktionsliste scrollt - solange
- * der feste Teil in den Viewport passt. `overflow-y: auto` statt `hidden`,
- * denn der feste Teil wächst mit den Kategorien: mit `hidden` war die Liste
- * auf einem kurzen Desktop-Viewport unerreichbar abgeschnitten (#904). Im
- * Normalfall läuft nichts über und das Panel scrollt nicht; erst wenn die
- * Untergrenze von .budget-list-section das Panel überlaufen lässt, scrollen
- * Zusammenfassung und Balken mit. Der Abstand kommt aus .budget-summary-bar. */
+ * der feste Teil in den Viewport passt. Die Scroll-Achse kommt aus der
+ * Basisregel (.budget-tab-panel, overflow-y: auto) und wird hier bewusst
+ * NICHT mehr überschrieben: das frühere `overflow: hidden` schnitt die Liste
+ * auf kurzen Desktop-Viewports unerreichbar ab (#904). Im Normalfall läuft
+ * nichts über und das Panel scrollt nicht; erst wenn die Untergrenze von
+ * .budget-list-section das Panel überlaufen lässt, scrollen Zusammenfassung
+ * und Balken mit. Mit dem Shorthand entfiel auch `overflow-x: hidden` - die
+ * x-Achse steht damit auf `auto`, gemessen ohne horizontalen Überlauf
+ * (scrollWidth == clientWidth bei 641/900/1512px Breite). Der Abstand kommt
+ * aus .budget-summary-bar. */
 .budget-tab-panel--budget {
   display: flex;
   flex-direction: column;
-  overflow-y: auto;
   -webkit-overflow-scrolling: touch;
   padding-block-start: 0;
 }
@@ -1194,9 +1197,12 @@
    * auf Kopfzeilenhöhe, und das Panel (damals `overflow: hidden`) ließ sie
    * unerreichbar (#904). 280px = Kopfzeile (60px) + drei Buchungszeilen (64px)
    * + eine angeschnittene vierte, die das interne Scrollen sichtbar macht.
+   * Das `min(…, 100%)` kappt die Untergrenze am Panel-Viewport: auf einer
+   * Kompakthöhe (Panel < 280px) erzwänge der harte Wert sonst einen Überlauf,
+   * bei dem selbst am Scroll-Ende die Kopfzeile angeschnitten bliebe.
    * Unterhalb von 640px setzt der Mobil-Reflow sie zurück - dort scrollt das
    * Panel als Ganzes und die Sektion wächst mit ihrem Inhalt. */
-  min-height: 280px;
+  min-height: min(280px, 100%);
   /* Das Lesemaß steht an der SEKTION, nicht an `.budget-list` darunter, und
    * zwar aus zwei Gründen. Erstens fluchten so Kopf und Liste an derselben
    * Kante - läge es an der Liste, stünde die Überschrift „Transaktionen" über
@@ -1282,28 +1288,37 @@
   border-top: 1px solid var(--color-border-subtle);
 }
 
+/* Seit #904 kann auch das Budget-Panel selbst scrollen (Untergrenze der
+ * Transaktionssektion laesst es ueberlaufen) - es gehoert deshalb wie
+ * --loans in die Gruppe der duennen Modul-Scrollbars, sonst stuende auf
+ * Plattformen mit klassischen Scrollbalken ein System-Balken direkt
+ * neben dem 10px-Akzentbalken der Liste. */
 .budget-list,
 .budget-loans__list,
-.budget-tab-panel--loans {
+.budget-tab-panel--loans,
+.budget-tab-panel--budget {
   scrollbar-width: thin;
   scrollbar-color: var(--module-accent) transparent;
 }
 
 .budget-list::-webkit-scrollbar,
 .budget-loans__list::-webkit-scrollbar,
-.budget-tab-panel--loans::-webkit-scrollbar {
+.budget-tab-panel--loans::-webkit-scrollbar,
+.budget-tab-panel--budget::-webkit-scrollbar {
   width: 10px;
 }
 
 .budget-list::-webkit-scrollbar-track,
 .budget-loans__list::-webkit-scrollbar-track,
-.budget-tab-panel--loans::-webkit-scrollbar-track {
+.budget-tab-panel--loans::-webkit-scrollbar-track,
+.budget-tab-panel--budget::-webkit-scrollbar-track {
   background: transparent;
 }
 
 .budget-list::-webkit-scrollbar-thumb,
 .budget-loans__list::-webkit-scrollbar-thumb,
-.budget-tab-panel--loans::-webkit-scrollbar-thumb {
+.budget-tab-panel--loans::-webkit-scrollbar-thumb,
+.budget-tab-panel--budget::-webkit-scrollbar-thumb {
   background: color-mix(in srgb, var(--module-accent) var(--tint-hint), transparent);
   border: 3px solid transparent;
   border-radius: var(--radius-full);

--- a/public/styles/budget.css
+++ b/public/styles/budget.css
@@ -304,12 +304,18 @@
 }
 
 /* Der Budget-Tab hält seine eigene Scroll-Region: Zusammenfassung und
- * Kategoriebalken bleiben stehen, nur die Transaktionsliste scrollt. Das Panel
- * selbst scrollt deshalb nicht, und sein Abstand kommt aus .budget-summary-bar. */
+ * Kategoriebalken bleiben stehen, nur die Transaktionsliste scrollt - solange
+ * der feste Teil in den Viewport passt. `overflow-y: auto` statt `hidden`,
+ * denn der feste Teil wächst mit den Kategorien: mit `hidden` war die Liste
+ * auf einem kurzen Desktop-Viewport unerreichbar abgeschnitten (#904). Im
+ * Normalfall läuft nichts über und das Panel scrollt nicht; erst wenn die
+ * Untergrenze von .budget-list-section das Panel überlaufen lässt, scrollen
+ * Zusammenfassung und Balken mit. Der Abstand kommt aus .budget-summary-bar. */
 .budget-tab-panel--budget {
   display: flex;
   flex-direction: column;
-  overflow: hidden;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
   padding-block-start: 0;
 }
 
@@ -1183,7 +1189,14 @@
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  min-height: 0;
+  /* Untergrenze statt `min-height: 0`: als flex:1-Kind neben dem inhaltshohen
+   * Kategorie-Chart kollabierte die Sektion auf kurzen Desktop-Viewports bis
+   * auf Kopfzeilenhöhe, und das Panel (damals `overflow: hidden`) ließ sie
+   * unerreichbar (#904). 280px = Kopfzeile (60px) + drei Buchungszeilen (64px)
+   * + eine angeschnittene vierte, die das interne Scrollen sichtbar macht.
+   * Unterhalb von 640px setzt der Mobil-Reflow sie zurück - dort scrollt das
+   * Panel als Ganzes und die Sektion wächst mit ihrem Inhalt. */
+  min-height: 280px;
   /* Das Lesemaß steht an der SEKTION, nicht an `.budget-list` darunter, und
    * zwar aus zwei Gründen. Erstens fluchten so Kopf und Liste an derselben
    * Kante - läge es an der Liste, stünde die Überschrift „Transaktionen" über
@@ -1412,11 +1425,11 @@
    * Der Eltern-Container begrenzt die Breite nicht, daher viewport-relativ. */
   .budget-tabs { max-width: calc(100vw - var(--space-8)); }
 
-  .budget-tab-panel--budget {
-    overflow-y: auto;
-    -webkit-overflow-scrolling: touch;
-  }
-
+  /* `overflow-y: auto` + Momentum stehen seit #904 an der Basisregel des
+   * Panels - hier bleibt nur der Reflow: Sektion und Liste geben ihre eigene
+   * Scroll-Achse ab und wachsen mit ihrem Inhalt, das Panel scrollt als
+   * Ganzes. `min-height: 0` nimmt der Sektion die 280px-Untergrenze der
+   * Desktop-Fassung wieder ab - hier ist sie kein Scrollfenster mehr. */
   .budget-tab-panel--budget .budget-list-section,
   .budget-tab-panel--budget .budget-list {
     flex: 0 0 auto;

--- a/public/styles/layout.css
+++ b/public/styles/layout.css
@@ -327,9 +327,10 @@
  * `:not(:has(.page-scrollport))` an BEIDEN Selektoren, und das ist keine
  * Symmetrie um ihrer selbst willen. Am Default-Port beantwortet es „bringt die
  * Seite ihren eigenen mit?". An der Rolle beantwortet es dieselbe Frage eine
- * Ebene tiefer: das Budget schaltet seinen Scrollport bei 640px um (darüber
- * scrollt `.budget-list` im Panel, darunter das Panel selbst), beide tragen die
- * Rolle, und der Nachlauf gehört jeweils dem inneren. Ohne den Ausschluss
+ * Ebene tiefer: im Budget tragen Panel und `.budget-list` BEIDE die Rolle -
+ * unter 640px scrollt nur das Panel, darüber die Liste (und seit #904 bei
+ * Überlauf zusätzlich das Panel) -, und der Nachlauf gehört in jeder dieser
+ * Konstellationen dem inneren Träger. Ohne den Ausschluss
  * polsterte das Panel die Liste, die es enthält, aus dem sichtbaren Bereich -
  * derselbe Fehler wie oben, nur eine Ebene tiefer.
  *

--- a/test/test-budget-ui.js
+++ b/test/test-budget-ui.js
@@ -926,12 +926,18 @@ test('die Transaktionsliste bleibt auf kurzen Desktop-Viewports erreichbar (#904
     if (at.length) continue; // der Mobil-Reflow (≤640px) scrollt das Panel als Ganzes
     if (selector.trim() === '.budget-tab-panel--budget') {
       panelSeen = true;
-      assert.doesNotMatch(
-        body, /overflow(?:-y)?\s*:\s*hidden/,
-        '.budget-tab-panel--budget clippt wieder: wächst der feste Teil über den '
-        + 'Viewport, ist die Transaktionsliste unerreichbar (#904) - das Panel '
-        + 'braucht overflow-y: auto als Ausweichweg',
-      );
+      // `clip` kappt wie `hidden`, nur ohne Scrollport - und die Block-Achse
+      // lässt sich auch als Langform oder als zweiter Shorthand-Wert setzen.
+      // Der Grund für die Zusicherung ist das Abschneiden, nicht die eine
+      // Schreibweise dafür (dieselbe Regel wie in test-frontend-audit.js).
+      for (const [, prop, value] of body.matchAll(/(?:^|;)\s*(overflow(?:-y|-block)?)\s*:\s*([^;]+)/g)) {
+        assert.ok(
+          !/\b(?:hidden|clip)\b/.test(value),
+          `.budget-tab-panel--budget clippt wieder (${prop}: ${value.trim()}): wächst `
+          + 'der feste Teil über den Viewport, ist die Transaktionsliste '
+          + 'unerreichbar (#904) - das Panel braucht overflow-y: auto als Ausweichweg',
+        );
+      }
     }
     if (selector.trim() === '.budget-list-section') {
       sectionSeen = true;

--- a/test/test-budget-ui.js
+++ b/test/test-budget-ui.js
@@ -920,11 +920,29 @@ test('die Transaktionsliste bleibt auf kurzen Desktop-Viewports erreichbar (#904
   // das Panel nicht scrollte, führte kein Weg zu ihr (#904, gemessen: Sektion
   // 32px hoch, Liste ab y=648 bei 620px Viewport). Beide Hälften einzeln
   // gepinnt: jede allein genügt, um den Defekt wiederzubeleben.
+  // Vier Fluchtwege aus dem Review, jeder mit Gegenprobe belegt:
+  // 1. Ausgenommen ist NUR der benannte Mobil-Reflow (max-width: 640px), nicht
+  //    jeder At-Block - #904 ist ein Kurz-Viewport-Defekt, eine max-height-
+  //    Query wäre der wahrscheinlichste Rückweg gewesen und blieb unsichtbar.
+  // 2. Geprüft wird jede Regel, deren SUBJEKT (letzter Compound) das Element
+  //    trifft - `.budget-page .budget-tab-panel--budget` clippt genauso, war
+  //    aber am exakten Selektorvergleich vorbei.
+  // 3. Bei min-height zählt die LETZTE Deklaration der Regel (Kaskade
+  //    innerhalb des Blocks; die Falle aus dem css-rules.js-Kopf).
+  // 4. Die Untergrenze muss eine nutzbare px-Länge tragen: die Sektion clippt
+  //    (`overflow: hidden`), ihr automatisches Minimum ist damit 0 - ein
+  //    `min-height: auto` oder `1px` kollabiert exakt wie das alte `0`,
+  //    bestand aber den reinen Nicht-Null-Test.
+  const subjectIs = (selector, cls) => selector.split(',').some((einzel) => {
+    const compounds = einzel.trim().split(/[\s>+~]+/).filter(Boolean);
+    return compounds.length > 0 && compounds[compounds.length - 1].includes(cls);
+  });
+
   let panelSeen = false;
-  let sectionSeen = false;
+  let floorSeen = false;
   for (const { selector, body, at } of eachRule(budgetCss)) {
-    if (at.length) continue; // der Mobil-Reflow (≤640px) scrollt das Panel als Ganzes
-    if (selector.trim() === '.budget-tab-panel--budget') {
+    if (at.some((a) => /max-width:\s*640px/.test(a))) continue;
+    if (subjectIs(selector, '.budget-tab-panel--budget')) {
       panelSeen = true;
       // `clip` kappt wie `hidden`, nur ohne Scrollport - und die Block-Achse
       // lässt sich auch als Langform oder als zweiter Shorthand-Wert setzen.
@@ -933,26 +951,33 @@ test('die Transaktionsliste bleibt auf kurzen Desktop-Viewports erreichbar (#904
       for (const [, prop, value] of body.matchAll(/(?:^|;)\s*(overflow(?:-y|-block)?)\s*:\s*([^;]+)/g)) {
         assert.ok(
           !/\b(?:hidden|clip)\b/.test(value),
-          `.budget-tab-panel--budget clippt wieder (${prop}: ${value.trim()}): wächst `
+          `"${selector.trim()}" clippt das Budget-Panel (${prop}: ${value.trim()}): wächst `
           + 'der feste Teil über den Viewport, ist die Transaktionsliste '
-          + 'unerreichbar (#904) - das Panel braucht overflow-y: auto als Ausweichweg',
+          + 'unerreichbar (#904) - die Scroll-Achse der Basisregel muss offen bleiben',
         );
       }
     }
-    if (selector.trim() === '.budget-list-section') {
-      sectionSeen = true;
-      const min = body.match(/min-height\s*:\s*([^;]+)/);
-      assert.ok(min, '.budget-list-section braucht eine nutzbare min-height-Untergrenze (#904)');
-      assert.doesNotMatch(
-        min[1], /^\s*0(?:px)?\s*$/,
-        '.budget-list-section darf nicht wieder auf 0 kollabieren: als flex:1-Kind '
-        + 'neben dem inhaltshohen Kategorie-Chart schrumpft sie sonst auf '
-        + 'Kopfzeilenhöhe (#904)',
+    if (subjectIs(selector, '.budget-list-section')) {
+      const decls = [...body.matchAll(/min-height\s*:\s*([^;]+)/g)];
+      if (decls.length === 0) continue;
+      const value = decls[decls.length - 1][1].trim();
+      const px = value.match(/(\d+(?:\.\d+)?)px/);
+      assert.ok(
+        px && Number(px[1]) >= 200,
+        `"${selector.trim()}" setzt min-height: ${value} - die Sektion braucht eine `
+        + 'nutzbare px-Untergrenze (>= 200px, ggf. per min() ans Panel gekappt): '
+        + 'auto, 0 oder Kleinstwerte kollabieren sie neben dem inhaltshohen '
+        + 'Kategorie-Chart wieder auf Kopfzeilenhöhe (#904)',
       );
+      floorSeen = true;
     }
   }
   assert.ok(panelSeen, '.budget-tab-panel--budget fehlt in budget.css');
-  assert.ok(sectionSeen, '.budget-list-section fehlt in budget.css');
+  assert.ok(
+    floorSeen,
+    '.budget-list-section deklariert ausserhalb des Mobil-Reflows keine '
+    + 'min-height-Untergrenze mehr (#904)',
+  );
 });
 
 test('Trendpfeile sind Icons, keine Textglyphen', () => {

--- a/test/test-budget-ui.js
+++ b/test/test-budget-ui.js
@@ -10,6 +10,7 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync, readdirSync } from 'node:fs';
 import { withoutHtmlComments } from './source-text.js';
+import { eachRule } from './css-rules.js';
 
 const read = (path) => readFileSync(new URL(path, import.meta.url), 'utf8').replace(/\r/g, '');
 
@@ -908,6 +909,44 @@ test('Panel-Fläche und Kopfleiste sind geteilt, nicht pro Tab gebaut', () => {
       `${rule[1]} setzt Scroll-Achse oder Padding selbst - beides gehört .budget-tab-panel`,
     );
   }
+});
+
+test('die Transaktionsliste bleibt auf kurzen Desktop-Viewports erreichbar (#904)', () => {
+  // Der feste Teil des Budget-Tabs (Zusammenfassung + Kategorie-Chart) wächst
+  // mit den Kategorien. Zwei Regeln zusammen hielten die Liste gefangen: das
+  // Panel clippte mit `overflow: hidden`, und die Sektion durfte per
+  // `min-height: 0` bis auf Kopfzeilenhöhe kollabieren - bei neun Kategorien
+  // auf 1512x747 lag die Liste vollständig unterhalb des Viewports, und weil
+  // das Panel nicht scrollte, führte kein Weg zu ihr (#904, gemessen: Sektion
+  // 32px hoch, Liste ab y=648 bei 620px Viewport). Beide Hälften einzeln
+  // gepinnt: jede allein genügt, um den Defekt wiederzubeleben.
+  let panelSeen = false;
+  let sectionSeen = false;
+  for (const { selector, body, at } of eachRule(budgetCss)) {
+    if (at.length) continue; // der Mobil-Reflow (≤640px) scrollt das Panel als Ganzes
+    if (selector.trim() === '.budget-tab-panel--budget') {
+      panelSeen = true;
+      assert.doesNotMatch(
+        body, /overflow(?:-y)?\s*:\s*hidden/,
+        '.budget-tab-panel--budget clippt wieder: wächst der feste Teil über den '
+        + 'Viewport, ist die Transaktionsliste unerreichbar (#904) - das Panel '
+        + 'braucht overflow-y: auto als Ausweichweg',
+      );
+    }
+    if (selector.trim() === '.budget-list-section') {
+      sectionSeen = true;
+      const min = body.match(/min-height\s*:\s*([^;]+)/);
+      assert.ok(min, '.budget-list-section braucht eine nutzbare min-height-Untergrenze (#904)');
+      assert.doesNotMatch(
+        min[1], /^\s*0(?:px)?\s*$/,
+        '.budget-list-section darf nicht wieder auf 0 kollabieren: als flex:1-Kind '
+        + 'neben dem inhaltshohen Kategorie-Chart schrumpft sie sonst auf '
+        + 'Kopfzeilenhöhe (#904)',
+      );
+    }
+  }
+  assert.ok(panelSeen, '.budget-tab-panel--budget fehlt in budget.css');
+  assert.ok(sectionSeen, '.budget-list-section fehlt in budget.css');
 });
 
 test('Trendpfeile sind Icons, keine Textglyphen', () => {


### PR DESCRIPTION
Closes #904

## Der Fehler

Der feste Teil des Budget-Tabs (Zusammenfassung + Kategorie-Chart) wächst mit den Kategorien. Auf kurzen Desktop-Viewports kollabierte die Transaktionssektion (`flex: 1` + `min-height: 0`) bis auf Kopfzeilenhöhe, und weil das Panel `overflow: hidden` trug, führte kein Scrollweg zu ihr. Reproduziert mit den Demo-Daten (9 Kategorien): bei 1512x747 war die Liste auf 105px gequetscht, bei 620px Viewporthöhe lag sie mit y=648 vollständig ausserhalb - Sektion 32px, Panel `scrollHeight == clientHeight`. Deckt sich mit der Messung im Issue.

## Der Fix

Zwei Hälften, jede für sich notwendig - keine allein genügt:

- **`.budget-list-section` bekommt eine Untergrenze von 280px** statt `min-height: 0`: Kopfzeile (60px) + drei Buchungszeilen (64px) + eine angeschnittene vierte, die das interne Scrollen sichtbar macht. Ohne die Untergrenze kollabiert die Sektion, das Panel läuft nie über, und `overflow-y: auto` hätte nichts zu scrollen.
- **`.budget-tab-panel--budget` scrollt mit `overflow-y: auto`**, sobald die Untergrenze das Panel überlaufen lässt. Passt alles in den Viewport, läuft nichts über und nichts scrollt - das bewusste Desktop-Design (feste Zusammenfassung, nur die Liste scrollt) bleibt im Normalfall buchstäblich unverändert. Der Vorschlag aus dem Issue (ein einziger Panel-Scrollport) hätte dieses Design auch dort aufgegeben, wo es funktioniert.

Der Mobil-Reflow (≤640px) nimmt der Sektion die Untergrenze wieder ab (dort ist sie kein Scrollfenster, sondern wächst mit ihrem Inhalt) und verliert seinen jetzt redundanten `overflow`-Block an die Basisregel. Die `page-scrollport`-Rollen im Markup sind unangetastet; `:not(:has(.page-scrollport))` gibt den Shell-Nachlauf weiterhin dem inneren Scroller.

## Gemessen (Live-Instanz, Demo-Seed, SW abgemeldet)

| Viewport | vorher | nachher |
|---|---|---|
| 1512x747 | Liste 105px, Panel scrollt nicht | Sektion 280px, Panel scrollt (796/675) |
| 1512x620 | Sektion 32px, Liste ab y=648 unerreichbar | Sektion 280px voll im Bild nach Panel-Scroll |
| 1512x1100 | Sektion 512px, Panel scrollt nicht | identisch - Normalfall unverändert |
| 375x812 (mobil) | Panel scrollt als Ganzes, Sektion inhaltshoch | identisch |

## Guard

`test:budget-ui` pinnt beide Hälften einzeln (Basisebene via `eachRule`, der Mobil-Block bleibt ausgenommen): das Panel darf nicht wieder clippen, die Sektion nicht wieder auf 0 kollabieren. Gegenprobe für beide Hälften einzeln an der exakten Stelle eingebaut - beide machen rot.

`test:budget-ui` 66 pass, `test:frontend-audit` 328 pass.