### PR TITLE
fix(calendar): align week headers with hourly columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Week-view day headings align with the hourly calendar columns.** The header and all-day row
+  now share the hourly grid's gutter width.
+
 ## [2.51.0] - 2026-08-28
 
 ### Added

--- a/public/pages/calendar.js
+++ b/public/pages/calendar.js
@@ -1990,7 +1990,7 @@ function renderWeekView(container) {
   container.insertAdjacentHTML('beforeend', `
     <div class="week-view">
       <div class="week-view__header" id="week-header"
-           style="display:grid;grid-template-columns:var(--space-12) repeat(${colCount},1fr);">
+           style="display:grid;grid-template-columns:var(--cal-gutter-width) repeat(${colCount},1fr);">
         <div class="week-view__time-gutter"></div>
         ${days.map((d) => {
           const dt = new Date(d + 'T00:00:00');
@@ -2001,7 +2001,7 @@ function renderWeekView(container) {
         }).join('')}
       </div>
       <!-- Ganztägige Ereignisse -->
-      <div class="allday-row" style="display:grid;grid-template-columns:var(--space-12) repeat(${colCount},1fr);">
+      <div class="allday-row" style="display:grid;grid-template-columns:var(--cal-gutter-width) repeat(${colCount},1fr);">
         <div class="calendar-all-day-label">${t('calendar.allDayShort')}</div>
         ${days.map((d, i) => `
           <div class="allday-cell">

--- a/test/test-calendar.js
+++ b/test/test-calendar.js
@@ -575,6 +575,27 @@ test('clickedTime: eine Spalte ohne messbare Höhe legt nichts Falsches an', () 
  * Regex: das alte Muster war dreimal blind und jedes Mal war der Guard grün. */
 const calendarCss = readFileSync(new URL('../public/styles/calendar.css', import.meta.url), 'utf8');
 
+test('Wochenraster: Kopf, Ganztagszeile und Stunden verwenden dieselbe Zeitspaltenbreite', () => {
+  const src = readFileSync(new URL('../public/pages/calendar.js', import.meta.url), 'utf8');
+  const renderWeekView = src.slice(
+    src.indexOf('function renderWeekView'),
+    src.indexOf('function renderDayView'),
+  );
+  const gutterColumns = renderWeekView.match(
+    /grid-template-columns:var\(--cal-gutter-width\) repeat\(\$\{colCount\},1fr\)/g,
+  ) ?? [];
+  const timeGutter = [...eachRule(calendarCss)]
+    .find((rule) => rule.selector.trim() === '.week-view__times');
+
+  assert(gutterColumns.length === 2,
+    'Kopf und Ganztagszeile müssen --cal-gutter-width verwenden; die Stundenleiste darunter '
+    + 'verwendet dasselbe Token und sonst laufen die Tagesgrenzen auseinander');
+  assert(timeGutter && /width:\s*var\(--cal-gutter-width\)/.test(timeGutter.body),
+    'die Stundenleiste muss ihre Breite aus --cal-gutter-width beziehen');
+  assert(!renderWeekView.includes('grid-template-columns:var(--space-12)'),
+    'die Wochenansicht darf nicht auf die alte 48px-Sprosse zurückfallen');
+});
+
 function zIndexOf(selector) {
   for (const rule of eachRule(calendarCss)) {
     if (!rule.selector.split(',').map((s) => s.trim()).includes(selector)) continue;


### PR DESCRIPTION
## Summary

Align the week-view header and all-day row with the hourly calendar columns by using the shared calendar gutter width.

Adds a regression test to keep all three rows aligned.

## Tests

- `npm test`