### PR TITLE
feat(receipts): add standalone receipt-tracking backend service

### DIFF
--- a/services/receipt-tracker/.env.example
+++ b/services/receipt-tracker/.env.example
@@ -1,0 +1,21 @@
+# Where the real Yuvomi instance lives, reached over the internal network —
+# used only to verify the incoming session cookie against GET /api/v1/auth/me.
+YUVOMI_INTERNAL_URL=http://localhost:3000
+
+# Public origin the browser actually uses (checked against the Origin header
+# on state-changing requests, alongside the CSRF double-submit cookie).
+PUBLIC_ORIGIN=http://localhost:8090
+
+# Port this service listens on. The dev proxy (or your real reverse proxy in
+# production) forwards /api/extensions/receipt-tracker/* here.
+PORT=4100
+
+# Where the SQLite file and uploaded receipt images live.
+DATA_DIR=./data
+
+# Vision-provider API keys are NOT set here — they're entered once by an
+# admin from the module's Settings tab and stored server-side in the DB
+# (see src/db.js `settings` table). These env vars are only a fallback for
+# local testing without going through the UI.
+GEMINI_API_KEY=
+ANTHROPIC_API_KEY=

--- a/services/receipt-tracker/dev-proxy.js
+++ b/services/receipt-tracker/dev-proxy.js
@@ -1,0 +1,35 @@
+/**
+ * Local-only stand-in for the reverse proxy (nginx/Caddy) that fronts both
+ * Yuvomi and this service in production. Forwards
+ * /api/extensions/receipt-tracker/* to this service and everything else to
+ * Yuvomi core, so the browser sees one origin and the session cookie
+ * carries over — exactly the setup MODULES.md describes.
+ *
+ * Not part of the module or the service itself; only used for
+ * `npm run dev-proxy` while developing locally. In production this becomes
+ * one `location /api/extensions/receipt-tracker/ { proxy_pass ...; }` block
+ * in nginx.conf, alongside Yuvomi's own.
+ */
+import express from 'express';
+import { createProxyMiddleware } from 'http-proxy-middleware';
+
+const YUVOMI_URL = process.env.YUVOMI_INTERNAL_URL || 'http://localhost:3000';
+const SERVICE_URL = `http://localhost:${process.env.PORT || 4100}`;
+const PROXY_PORT = process.env.DEV_PROXY_PORT || 8090;
+
+const app = express();
+
+app.use(
+  '/api/extensions/receipt-tracker',
+  createProxyMiddleware({
+    target: SERVICE_URL,
+    changeOrigin: true,
+    pathRewrite: { '^/api/extensions/receipt-tracker': '' },
+  })
+);
+
+app.use(createProxyMiddleware({ target: YUVOMI_URL, changeOrigin: true, ws: true }));
+
+app.listen(PROXY_PORT, () => {
+  console.log(`[dev-proxy] http://localhost:${PROXY_PORT} -> Yuvomi @ ${YUVOMI_URL}, service @ ${SERVICE_URL}`);
+});

--- a/services/receipt-tracker/package-lock.json
+++ b/services/receipt-tracker/package-lock.json
@@ -1,0 +1,1568 @@
+{
+  "name": "receipt-tracker-service",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "receipt-tracker-service",
+      "version": "0.1.0",
+      "dependencies": {
+        "better-sqlite3": "^11.3.0",
+        "cookie-parser": "^1.4.6",
+        "dotenv": "^16.4.5",
+        "express": "^4.21.2",
+        "http-proxy-middleware": "^3.0.3",
+        "multer": "^2.0.0"
+      }
+    },
+    "node_modules/@types/http-proxy": {
+      "version": "1.17.17",
+      "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.17.tgz",
+      "integrity": "sha512-ED6LB+Z1AVylNTu7hdzuBqOgMnvG/ld6wGCG8wFnAzKX5uyW2K3WD52v0gnLCTK/VLpXtKckgWuyScYK6cSPaw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "26.4.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.4.0.tgz",
+      "integrity": "sha512-faiGnoIrLH/V8cibOMEAZ8pMw6oXqSukl29ra4mN8GdaB2ZewzeaLj+INpV5N+Z1eKWzY+IzaIZH2EIR6YZRNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/append-field": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
+      "license": "MIT"
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/better-sqlite3": {
+      "version": "11.10.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-11.10.0.tgz",
+      "integrity": "sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.6",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.6.tgz",
+      "integrity": "sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.15.1",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
+    },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "engines": [
+        "node >= 6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
+      "integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.5",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.15.1",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "~2.0.2",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/http-proxy": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
+      "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^4.0.0",
+        "follow-redirects": "^1.0.0",
+        "requires-port": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/http-proxy-middleware": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-3.0.7.tgz",
+      "integrity": "sha512-iwbQltVlx8bCrqePUM8C+hllHvdawVhQJaLrj1X7qllkvFQdXFsr16pW/mo9+JDVjN+QO2XUx9jd8SmoFkE5qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-proxy": "^1.17.15",
+        "debug": "^4.3.6",
+        "http-proxy": "^1.18.1",
+        "is-glob": "^4.0.3",
+        "is-plain-object": "^5.0.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": "^14.18.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/http-proxy-middleware/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/http-proxy-middleware/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-plain-object": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.1.0.tgz",
+      "integrity": "sha512-bUi/yjmtKYcRVUtWRGr0UA6xEFh2I6zWUwMrUXB3s7bmYCaZ8a+0ZsTRkrawh/mzlSD1Y0Ph8bp/U+TvBpWDNw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/multer": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.3.0.tgz",
+      "integrity": "sha512-cjNbm3sttszgZeGfJR124D+jFEfkXCVAsoPBmFn9X7UxmDSFHWqE2CoEj0vrmSpuAFnqWR1Szcm9QTsiHr60Xw==",
+      "license": "MIT",
+      "dependencies": {
+        "append-field": "^1.0.0",
+        "busboy": "^1.6.0",
+        "concat-stream": "^2.0.0",
+        "type-is": "^1.6.18"
+      },
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-abi": {
+      "version": "3.96.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.96.0.tgz",
+      "integrity": "sha512-rebQ/lz7i0EkoLzUVSrKRzA69zMkwLp95kKMWoMDkkM00Suxz0D7zEQPwRml5fQum24mj7bPvmlgLAmu2JCiYg==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "license": "MIT"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "license": "MIT"
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/send": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.5.tgz",
+      "integrity": "sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    }
+  }
+}

--- a/services/receipt-tracker/package.json
+++ b/services/receipt-tracker/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "receipt-tracker-service",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Backend service for the Yuvomi Receipts module — vision-model extraction, receipt/item storage, search and spend analysis. Runs beside Yuvomi, never touches yuvomi.db.",
+  "scripts": {
+    "start": "node --import dotenv/config src/index.js",
+    "dev": "node --import dotenv/config --watch src/index.js",
+    "dev-proxy": "node --import dotenv/config dev-proxy.js"
+  },
+  "dependencies": {
+    "better-sqlite3": "^11.3.0",
+    "cookie-parser": "^1.4.6",
+    "dotenv": "^16.4.5",
+    "express": "^4.21.2",
+    "http-proxy-middleware": "^3.0.3",
+    "multer": "^2.0.0"
+  }
+}

--- a/services/receipt-tracker/src/auth.js
+++ b/services/receipt-tracker/src/auth.js
@@ -1,0 +1,63 @@
+/**
+ * Identity for every request comes from Yuvomi itself, never from the
+ * request body — the browser half of a module is not a trusted caller.
+ * We forward the incoming Yuvomi session cookie to the real
+ * GET /api/v1/auth/me over the internal URL and trust only that response
+ * for user id / role. Cached briefly per cookie value so we don't burn
+ * Yuvomi's 300 req/min/IP budget on every call (MODULES.md).
+ */
+
+const YUVOMI_INTERNAL_URL = process.env.YUVOMI_INTERNAL_URL || 'http://localhost:3000';
+const CACHE_TTL_MS = 5000;
+
+const cache = new Map(); // cookieHeader -> { at, user }
+
+async function resolveUser(cookieHeader) {
+  if (!cookieHeader) return null;
+
+  const cached = cache.get(cookieHeader);
+  if (cached && Date.now() - cached.at < CACHE_TTL_MS) {
+    return cached.user;
+  }
+
+  let user = null;
+  try {
+    const res = await fetch(`${YUVOMI_INTERNAL_URL}/api/v1/auth/me`, {
+      headers: { cookie: cookieHeader },
+    });
+    if (res.ok) {
+      const body = await res.json();
+      user = body.user || null;
+    }
+  } catch {
+    // Yuvomi unreachable — treat as unauthenticated rather than throwing,
+    // so the failure mode is a clean 401, not a crash.
+    user = null;
+  }
+
+  cache.set(cookieHeader, { at: Date.now(), user });
+  return user;
+}
+
+/** Express middleware: attaches req.yuvomiUser or rejects with 401. */
+export async function requireYuvomiSession(req, res, next) {
+  const user = await resolveUser(req.headers.cookie);
+  if (!user) {
+    return res.status(401).json({ error: 'Not authenticated with Yuvomi.', code: 401 });
+  }
+  req.yuvomiUser = user;
+  next();
+}
+
+/** Express middleware: requireYuvomiSession, plus role === 'admin'. */
+export async function requireYuvomiAdmin(req, res, next) {
+  const user = await resolveUser(req.headers.cookie);
+  if (!user) {
+    return res.status(401).json({ error: 'Not authenticated with Yuvomi.', code: 401 });
+  }
+  if (user.role !== 'admin') {
+    return res.status(403).json({ error: 'Admin access required.', code: 403 });
+  }
+  req.yuvomiUser = user;
+  next();
+}

--- a/services/receipt-tracker/src/csrf.js
+++ b/services/receipt-tracker/src/csrf.js
@@ -1,0 +1,41 @@
+/**
+ * Double-submit CSRF cookie, independent of Yuvomi's own CSRF token
+ * (MODULES.md: "Yuvomi's CSRF token protects Yuvomi's endpoints, not a
+ * module's"). Also requires Origin to match the public host.
+ */
+import crypto from 'node:crypto';
+
+const COOKIE_NAME = 'receipt-tracker-csrf';
+const HEADER_NAME = 'x-receipt-tracker-csrf';
+const PUBLIC_ORIGIN = process.env.PUBLIC_ORIGIN || '';
+
+export function issueCsrfCookie(req, res) {
+  let token = req.cookies?.[COOKIE_NAME];
+  if (!token) {
+    token = crypto.randomBytes(24).toString('hex');
+    res.cookie(COOKIE_NAME, token, {
+      httpOnly: false,
+      sameSite: 'lax',
+      secure: process.env.SESSION_SECURE === 'true',
+      maxAge: 1000 * 60 * 60 * 24 * 7,
+    });
+  }
+  return token;
+}
+
+export function requireCsrf(req, res, next) {
+  if (['GET', 'HEAD', 'OPTIONS'].includes(req.method)) return next();
+
+  if (PUBLIC_ORIGIN && req.headers.origin && req.headers.origin !== PUBLIC_ORIGIN) {
+    return res.status(403).json({ error: 'Origin mismatch.', code: 403 });
+  }
+
+  const cookieToken = req.cookies?.[COOKIE_NAME];
+  const headerToken = req.headers[HEADER_NAME];
+  if (!cookieToken || !headerToken || cookieToken !== headerToken) {
+    return res.status(403).json({ error: 'Invalid CSRF token.', code: 403 });
+  }
+  next();
+}
+
+export { COOKIE_NAME, HEADER_NAME };

--- a/services/receipt-tracker/src/db.js
+++ b/services/receipt-tracker/src/db.js
@@ -1,0 +1,97 @@
+/**
+ * Own SQLite store for the Receipts module.
+ *
+ * This is intentionally separate from yuvomi.db — per MODULES.md, a module
+ * with a backend service keeps its own state in its own database and reads/
+ * writes Yuvomi's data only through /api/v1. Nothing here is Yuvomi core.
+ */
+import Database from 'better-sqlite3';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const DATA_DIR = process.env.DATA_DIR || './data';
+fs.mkdirSync(DATA_DIR, { recursive: true });
+fs.mkdirSync(path.join(DATA_DIR, 'images'), { recursive: true });
+
+const db = new Database(path.join(DATA_DIR, 'receipt-tracker.db'));
+db.pragma('journal_mode = WAL');
+db.pragma('foreign_keys = ON');
+
+db.exec(`
+  CREATE TABLE IF NOT EXISTS settings (
+    key   TEXT PRIMARY KEY,
+    value TEXT
+  );
+
+  CREATE TABLE IF NOT EXISTS receipts (
+    id                INTEGER PRIMARY KEY AUTOINCREMENT,
+    created_by        INTEGER NOT NULL,   -- Yuvomi user id (from /api/v1/auth/me), not a foreign key: yuvomi.db is not ours to join against
+    merchant          TEXT    NOT NULL,
+    purchase_date     TEXT    NOT NULL,   -- YYYY-MM-DD
+    tax               REAL    NOT NULL DEFAULT 0,
+    tip               REAL    NOT NULL DEFAULT 0,
+    total             REAL    NOT NULL,
+    image_path        TEXT,
+    provider          TEXT,
+    model             TEXT,
+    created_at        TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    updated_at        TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+  );
+
+  CREATE TABLE IF NOT EXISTS receipt_items (
+    id                INTEGER PRIMARY KEY AUTOINCREMENT,
+    receipt_id        INTEGER NOT NULL REFERENCES receipts(id) ON DELETE CASCADE,
+    raw_name          TEXT    NOT NULL,   -- exactly what the vision model read off the receipt
+    canonical_label   TEXT,               -- optional normalized name assigned on review, e.g. "Milk" for 6 different OCR spellings
+    description       TEXT,
+    quantity          REAL    NOT NULL DEFAULT 1,
+    unit_price        REAL,
+    total_price       REAL    NOT NULL,
+    category          TEXT    NOT NULL DEFAULT 'Other'
+  );
+
+  CREATE INDEX IF NOT EXISTS idx_receipts_date      ON receipts(purchase_date);
+  CREATE INDEX IF NOT EXISTS idx_receipts_merchant   ON receipts(merchant);
+  CREATE INDEX IF NOT EXISTS idx_receipts_created_by ON receipts(created_by);
+  CREATE INDEX IF NOT EXISTS idx_items_receipt       ON receipt_items(receipt_id);
+  CREATE INDEX IF NOT EXISTS idx_items_category      ON receipt_items(category);
+  CREATE INDEX IF NOT EXISTS idx_items_canonical     ON receipt_items(canonical_label);
+  CREATE INDEX IF NOT EXISTS idx_items_raw_name      ON receipt_items(raw_name);
+
+  -- Maps a raw merchant string (as it appears on receipts.merchant) to a
+  -- shared brand/group name, e.g. "ShopRite of Bayonne" and "ShopRite of
+  -- Metro Plaza" both -> "ShopRite". A merchant with no row here is its own
+  -- group (falls back to the raw name wherever this is joined). Editable
+  -- from the Tracking page; also written in bulk by the AI reclassify pass.
+  CREATE TABLE IF NOT EXISTS merchant_groups (
+    merchant   TEXT PRIMARY KEY,
+    group_name TEXT NOT NULL
+  );
+`);
+
+// Seed the category list the vision prompt itself classifies into (see
+// providers/schema.js) — matches what the household's real export (2026
+// spending sheet) actually used, plus Entertainment which the prompt
+// supports but their data never happened to need yet. Free text, not an
+// enum — a household can add more from the review form.
+const DEFAULT_CATEGORIES = ['Grocery', 'Dining', 'Utilities', 'Entertainment', 'Supplies', 'Shopping', 'Other'];
+const seedCategories = db.prepare(`INSERT OR IGNORE INTO settings (key, value) VALUES ('categories', ?)`);
+seedCategories.run(JSON.stringify(DEFAULT_CATEGORIES));
+
+export function get() {
+  return db;
+}
+
+export function getSetting(key) {
+  const row = db.prepare('SELECT value FROM settings WHERE key = ?').get(key);
+  return row ? row.value : null;
+}
+
+export function setSetting(key, value) {
+  db.prepare(`
+    INSERT INTO settings (key, value) VALUES (?, ?)
+    ON CONFLICT(key) DO UPDATE SET value = excluded.value
+  `).run(key, value);
+}
+
+export default db;

--- a/services/receipt-tracker/src/index.js
+++ b/services/receipt-tracker/src/index.js
@@ -1,0 +1,49 @@
+import express from 'express';
+import cookieParser from 'cookie-parser';
+import { issueCsrfCookie } from './csrf.js';
+import { requireYuvomiSession } from './auth.js';
+import settingsRouter from './routes/settings.js';
+import scanRouter from './routes/scan.js';
+import receiptsRouter from './routes/receipts.js';
+import statsRouter from './routes/stats.js';
+import merchantGroupsRouter from './routes/merchant-groups.js';
+import reclassifyRouter from './routes/reclassify.js';
+import exportRouter from './routes/export.js';
+
+const app = express();
+const PORT = process.env.PORT || 4100;
+
+app.use(cookieParser());
+app.use(express.json({ limit: '1mb' }));
+
+// Every response under this router gets a CSRF cookie issued/renewed so the
+// client always has a fresh double-submit token to echo back.
+app.use((req, res, next) => {
+  issueCsrfCookie(req, res);
+  next();
+});
+
+app.get('/health', (_req, res) => res.json({ ok: true }));
+
+// A cheap endpoint the client hits once on load to confirm session + get
+// the user's role for UI purposes only — the server independently
+// re-checks role on every write, this is just so the Settings tab can hide
+// itself for non-admins.
+app.get('/whoami', requireYuvomiSession, (req, res) => res.json({ data: req.yuvomiUser }));
+
+app.use('/settings', settingsRouter);
+app.use('/scan', scanRouter);
+app.use('/receipts', receiptsRouter);
+app.use('/stats', statsRouter);
+app.use('/merchant-groups', merchantGroupsRouter);
+app.use('/reclassify', reclassifyRouter);
+app.use('/export.csv', exportRouter);
+
+app.use((err, _req, res, _next) => {
+  console.error(err);
+  res.status(500).json({ error: 'Internal error.', code: 500 });
+});
+
+app.listen(PORT, () => {
+  console.log(`[receipt-tracker-service] listening on :${PORT}`);
+});

--- a/services/receipt-tracker/src/providers/claude.js
+++ b/services/receipt-tracker/src/providers/claude.js
@@ -1,0 +1,123 @@
+import {
+  RECEIPT_PROMPT,
+  normalizeExtraction,
+  buildItemBatchPrompt,
+  buildMerchantGroupPrompt,
+  normalizeItemBatch,
+  normalizeMerchantGroups,
+} from './schema.js';
+
+export const DEFAULT_MODEL = 'claude-sonnet-5';
+
+/** Live list of models this API key can actually use. */
+export async function listModels({ apiKey }) {
+  if (!apiKey) throw new Error('No Anthropic API key to list models with.');
+
+  const res = await fetch('https://api.anthropic.com/v1/models?limit=100', {
+    headers: { 'x-api-key': apiKey, 'anthropic-version': '2023-06-01' },
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`Claude model list failed (${res.status}): ${text.slice(0, 300)}`);
+  }
+
+  const body = await res.json();
+  return (body.data || []).map((m) => ({ id: m.id, label: m.display_name || m.id }));
+}
+
+function extractJson(text) {
+  try {
+    return JSON.parse(text);
+  } catch {
+    const match = text.match(/\{[\s\S]*\}/);
+    if (!match) throw new Error('Could not find JSON in Claude response.');
+    return JSON.parse(match[0]);
+  }
+}
+
+export async function extract({ apiKey, model, base64, mimeType }) {
+  if (!apiKey) throw new Error('No Anthropic API key configured.');
+
+  // Claude's Messages API takes PDFs as a "document" content block, distinct
+  // from the "image" block used for photos — same request shape otherwise.
+  const isPdf = mimeType === 'application/pdf';
+  const fileBlock = {
+    type: isPdf ? 'document' : 'image',
+    source: { type: 'base64', media_type: mimeType, data: base64 },
+  };
+
+  const res = await fetch('https://api.anthropic.com/v1/messages', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'x-api-key': apiKey,
+      'anthropic-version': '2023-06-01',
+    },
+    body: JSON.stringify({
+      model: model || DEFAULT_MODEL,
+      max_tokens: 4096,
+      messages: [
+        {
+          role: 'user',
+          content: [fileBlock, { type: 'text', text: RECEIPT_PROMPT }],
+        },
+      ],
+    }),
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`Claude request failed (${res.status}): ${text.slice(0, 300)}`);
+  }
+
+  const body = await res.json();
+  const text = body?.content?.find((b) => b.type === 'text')?.text;
+  if (!text) throw new Error('Empty response from Claude.');
+
+  return normalizeExtraction(extractJson(text));
+}
+
+async function generateJson({ apiKey, model, prompt, maxTokens }) {
+  const res = await fetch('https://api.anthropic.com/v1/messages', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'x-api-key': apiKey,
+      'anthropic-version': '2023-06-01',
+    },
+    body: JSON.stringify({
+      model: model || DEFAULT_MODEL,
+      max_tokens: maxTokens,
+      messages: [{ role: 'user', content: prompt }],
+    }),
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`Claude request failed (${res.status}): ${text.slice(0, 300)}`);
+  }
+
+  const body = await res.json();
+  if (body?.stop_reason === 'max_tokens') {
+    throw new Error('Response was cut off (hit max_tokens).');
+  }
+  const text = body?.content?.find((b) => b.type === 'text')?.text;
+  if (!text) throw new Error('Empty response from Claude.');
+  return extractJson(text);
+}
+
+/** One batch of items — see schema.js buildItemBatchPrompt. Batched by the
+ * caller (reclassify.js) rather than sent all at once: hundreds of items
+ * in one response reliably overflows or times out. */
+export async function classifyItems({ apiKey, model, items, existingLabels }) {
+  if (!apiKey) throw new Error('No Anthropic API key configured.');
+  const raw = await generateJson({ apiKey, model, prompt: buildItemBatchPrompt({ items, existingLabels }), maxTokens: 4096 });
+  return normalizeItemBatch(raw);
+}
+
+/** All merchants in one call — a few dozen at most, fits comfortably. */
+export async function classifyMerchants({ apiKey, model, merchants }) {
+  if (!apiKey) throw new Error('No Anthropic API key configured.');
+  const raw = await generateJson({ apiKey, model, prompt: buildMerchantGroupPrompt({ merchants }), maxTokens: 4096 });
+  return normalizeMerchantGroups(raw);
+}

--- a/services/receipt-tracker/src/providers/gemini.js
+++ b/services/receipt-tracker/src/providers/gemini.js
@@ -1,0 +1,124 @@
+import {
+  RECEIPT_PROMPT,
+  GEMINI_RESPONSE_SCHEMA,
+  normalizeExtraction,
+  buildItemBatchPrompt,
+  buildMerchantGroupPrompt,
+  ITEM_BATCH_RESPONSE_SCHEMA,
+  MERCHANT_GROUP_RESPONSE_SCHEMA,
+  normalizeItemBatch,
+  normalizeMerchantGroups,
+} from './schema.js';
+
+export const DEFAULT_MODEL = 'gemini-3.5-flash';
+
+/** Live list of models this API key can actually use for image/PDF extraction. */
+export async function listModels({ apiKey }) {
+  if (!apiKey) throw new Error('No Gemini API key to list models with.');
+
+  const res = await fetch(`https://generativelanguage.googleapis.com/v1beta/models?key=${apiKey}&pageSize=200`);
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`Gemini model list failed (${res.status}): ${text.slice(0, 300)}`);
+  }
+
+  const body = await res.json();
+  return (body.models || [])
+    // generateContent is the call we make; vision/PDF input isn't broken out
+    // in this list, so a model that can't take images will surface that at
+    // scan time with a clear error rather than being silently excluded here.
+    .filter((m) => (m.supportedGenerationMethods || []).includes('generateContent'))
+    .map((m) => ({
+      id: m.name.replace(/^models\//, ''),
+      label: m.displayName || m.name.replace(/^models\//, ''),
+    }));
+}
+
+export async function extract({ apiKey, model, base64, mimeType }) {
+  if (!apiKey) throw new Error('No Gemini API key configured.');
+  const url = `https://generativelanguage.googleapis.com/v1beta/models/${model || DEFAULT_MODEL}:generateContent?key=${apiKey}`;
+
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      contents: [
+        {
+          parts: [
+            { inline_data: { mime_type: mimeType, data: base64 } },
+            { text: RECEIPT_PROMPT },
+          ],
+        },
+      ],
+      generationConfig: {
+        responseMimeType: 'application/json',
+        responseSchema: GEMINI_RESPONSE_SCHEMA,
+      },
+    }),
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`Gemini request failed (${res.status}): ${text.slice(0, 300)}`);
+  }
+
+  const body = await res.json();
+  const text = body?.candidates?.[0]?.content?.parts?.[0]?.text;
+  if (!text) throw new Error('Empty response from Gemini.');
+
+  return normalizeExtraction(JSON.parse(text));
+}
+
+async function generateJson({ apiKey, model, prompt, responseSchema, maxOutputTokens }) {
+  const url = `https://generativelanguage.googleapis.com/v1beta/models/${model || DEFAULT_MODEL}:generateContent?key=${apiKey}`;
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      contents: [{ parts: [{ text: prompt }] }],
+      generationConfig: { responseMimeType: 'application/json', responseSchema, maxOutputTokens },
+    }),
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`Gemini request failed (${res.status}): ${text.slice(0, 300)}`);
+  }
+
+  const body = await res.json();
+  const candidate = body?.candidates?.[0];
+  const text = candidate?.content?.parts?.[0]?.text;
+  if (!text) {
+    const reason = candidate?.finishReason ? ` (finishReason: ${candidate.finishReason})` : '';
+    throw new Error(`Empty response from Gemini${reason}.`);
+  }
+  return JSON.parse(text);
+}
+
+/** One batch of items — see schema.js buildItemBatchPrompt. Batched by the
+ * caller (reclassify.js) rather than sent all at once: hundreds of items
+ * in one response reliably overflows or times out. */
+export async function classifyItems({ apiKey, model, items, existingLabels }) {
+  if (!apiKey) throw new Error('No Gemini API key configured.');
+  const raw = await generateJson({
+    apiKey,
+    model,
+    prompt: buildItemBatchPrompt({ items, existingLabels }),
+    responseSchema: ITEM_BATCH_RESPONSE_SCHEMA,
+    maxOutputTokens: 8192,
+  });
+  return normalizeItemBatch(raw);
+}
+
+/** All merchants in one call — a few dozen at most, fits comfortably. */
+export async function classifyMerchants({ apiKey, model, merchants }) {
+  if (!apiKey) throw new Error('No Gemini API key configured.');
+  const raw = await generateJson({
+    apiKey,
+    model,
+    prompt: buildMerchantGroupPrompt({ merchants }),
+    responseSchema: MERCHANT_GROUP_RESPONSE_SCHEMA,
+    maxOutputTokens: 4096,
+  });
+  return normalizeMerchantGroups(raw);
+}

--- a/services/receipt-tracker/src/providers/index.js
+++ b/services/receipt-tracker/src/providers/index.js
@@ -1,0 +1,63 @@
+import * as gemini from './gemini.js';
+import * as claude from './claude.js';
+
+/**
+ * Registry of selectable vision providers for receipt extraction. Adding a
+ * new provider is: implement extract({apiKey, model, base64, mimeType}) ->
+ * normalized ReceiptData and listModels({apiKey}) -> [{id, label}], then
+ * list it here. `models` is only a fallback shown before the live list has
+ * loaded (or if listing fails) — Settings fetches the real list per key.
+ */
+export const PROVIDERS = {
+  gemini: {
+    label: 'Google Gemini',
+    defaultModel: gemini.DEFAULT_MODEL,
+    models: ['gemini-3.5-flash', 'gemini-pro-latest', 'gemini-3.5-flash-lite'],
+    extract: gemini.extract,
+    listModels: gemini.listModels,
+    classifyItems: gemini.classifyItems,
+    classifyMerchants: gemini.classifyMerchants,
+  },
+  claude: {
+    label: 'Anthropic Claude',
+    defaultModel: claude.DEFAULT_MODEL,
+    models: ['claude-sonnet-5', 'claude-opus-5', 'claude-fable-5'],
+    extract: claude.extract,
+    listModels: claude.listModels,
+    classifyItems: claude.classifyItems,
+    classifyMerchants: claude.classifyMerchants,
+  },
+};
+
+export function providerCatalog() {
+  return Object.fromEntries(
+    Object.entries(PROVIDERS).map(([key, p]) => [
+      key,
+      { label: p.label, defaultModel: p.defaultModel, models: p.models },
+    ])
+  );
+}
+
+export async function runExtraction({ provider, model, apiKey, base64, mimeType }) {
+  const entry = PROVIDERS[provider];
+  if (!entry) throw new Error(`Unknown provider "${provider}".`);
+  return entry.extract({ apiKey, model, base64, mimeType });
+}
+
+export async function runListModels({ provider, apiKey }) {
+  const entry = PROVIDERS[provider];
+  if (!entry) throw new Error(`Unknown provider "${provider}".`);
+  return entry.listModels({ apiKey });
+}
+
+export async function runClassifyItems({ provider, model, apiKey, items, existingLabels }) {
+  const entry = PROVIDERS[provider];
+  if (!entry) throw new Error(`Unknown provider "${provider}".`);
+  return entry.classifyItems({ apiKey, model, items, existingLabels });
+}
+
+export async function runClassifyMerchants({ provider, model, apiKey, merchants }) {
+  const entry = PROVIDERS[provider];
+  if (!entry) throw new Error(`Unknown provider "${provider}".`);
+  return entry.classifyMerchants({ apiKey, model, merchants });
+}

--- a/services/receipt-tracker/src/providers/schema.js
+++ b/services/receipt-tracker/src/providers/schema.js
@@ -1,0 +1,232 @@
+/**
+ * Shared shape every vision provider must return. This closely follows the
+ * prompt/schema in the original receipt-tracker app's server.ts, which is
+ * what actually produced the household's clean historical CSV — notably:
+ * `item` is a clean human-readable name (the model's job, it's good at
+ * this), `description` is the raw printed line for reference, and the
+ * root is an ARRAY of receipts so one photo/PDF containing more than one
+ * physical receipt comes back as separate entries instead of one merged
+ * mess. Discounts/coupons get their own negative-price entry rather than
+ * being netted into the item above them (also matches the historical data).
+ */
+export const DEPARTMENT_CATEGORIES = [
+  'Produce', 'Meat & Seafood', 'Dairy & Deli', 'Bakery', 'Snacks', 'Beverages',
+  'Alcohol', 'Pantry', 'Prepared Foods', 'Grocery', 'Household', 'Supplies',
+  'Health & Beauty', 'Baby', 'Apparel', 'Sporting Goods', 'Shopping', 'Dining',
+  'Utilities', 'Other',
+];
+
+export const RECEIPT_PROMPT = `You are reading one or more retail or restaurant receipts (a photo or a scanned/exported PDF). It may contain a single receipt, or multiple separate receipts (side-by-side, stacked, or on separate pages) — recognize ALL distinct physical receipts present and extract each one separately.
+
+For each receipt:
+- merchant: the clean, recognizable store or merchant name.
+- date: the purchase date in YYYY-MM-DD. Default to today (${new Date().toISOString().slice(0, 10)}) if genuinely unreadable.
+- items: one entry per printed line, including discounts/coupons/instant-savings — those get their own entry with a negative total_price, immediately after the item they apply to (do not net them into that item's price). If a discount line has no product name printed (just a code/number), name it descriptively using the item it discounts, e.g. "Chicken Melt Discount".
+  - item: a clean, concise, human-readable product name. Expand abbreviations using your own knowledge of how receipts print them (e.g. "B/S ATL SALM" -> "Boneless Skinless Atlantic Salmon", "HVY CREAM QT" -> "Heavy Cream, Quart"). This is the name a person would recognize, not a transcription.
+  - description: the exact line text as printed on the receipt, unmodified — kept for reference against the original.
+  - canonical_label: a short general product-type label for grouping this item with similar purchases over time, e.g. "Turkey Breast", "King Salmon", "Laundry Detergent", "Vegetable" for a specific onion/pepper/etc when nothing more specific fits. Leave empty only if the item name is already that generic.
+  - quantity: may be fractional (e.g. weighed produce). Default to 1 if not shown.
+  - unit_price / total_price: the numbers printed on the receipt (before tax).
+  - category: the grocery/store department this item belongs to. Prefer one of: ${DEPARTMENT_CATEGORIES.join(', ')} — but if an item clearly belongs to a department not in this list, use the correct department name rather than forcing it into "Other".
+- tax, tip, total: the receipt-level values (tip is 0 if not applicable, e.g. a grocery store).
+
+Respond with ONLY valid JSON, no markdown fences, matching exactly:
+{
+  "receipts": [
+    {
+      "merchant": string,
+      "date": "YYYY-MM-DD",
+      "tax": number,
+      "tip": number,
+      "total": number,
+      "items": [
+        { "item": string, "description": string, "canonical_label": string, "quantity": number, "unit_price": number, "total_price": number, "category": string }
+      ]
+    }
+  ]
+}
+If there is only one receipt, return a "receipts" array with exactly one element.`;
+
+// Gemini's responseSchema (a restricted JSON-Schema subset).
+export const GEMINI_RESPONSE_SCHEMA = {
+  type: 'object',
+  properties: {
+    receipts: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          merchant: { type: 'string' },
+          date: { type: 'string' },
+          tax: { type: 'number' },
+          tip: { type: 'number' },
+          total: { type: 'number' },
+          items: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                item: { type: 'string' },
+                description: { type: 'string' },
+                canonical_label: { type: 'string' },
+                quantity: { type: 'number' },
+                unit_price: { type: 'number' },
+                total_price: { type: 'number' },
+                category: { type: 'string' },
+              },
+              required: ['item', 'quantity', 'total_price', 'category'],
+            },
+          },
+        },
+        required: ['merchant', 'date', 'total', 'items'],
+      },
+    },
+  },
+  required: ['receipts'],
+};
+
+/**
+ * Text-only reclassification pass over every distinct item name and
+ * merchant already in the database — run after prompt changes so
+ * historical/imported data (which predates the improved prompt, or came
+ * from a CSV with its own inconsistent labels) gets the same quality bar
+ * as a fresh scan.
+ *
+ * Split into two calls rather than one:
+ * - Merchants (typically a few dozen) fit comfortably in one call.
+ * - Items can run into the hundreds, which in practice overflows a
+ *   single response (truncated JSON) on some models and is slow on
+ *   others. Items are processed in batches instead — each batch is told
+ *   which canonical_labels earlier batches already chose and asked to
+ *   reuse one rather than invent a near-duplicate, so consistency is
+ *   carried forward across batches instead of requiring one giant call.
+ */
+export function buildItemBatchPrompt({ items, existingLabels }) {
+  // JSON.stringify (not manual "${x}" quoting) so an item name containing a
+  // literal quote or backslash (e.g. `Keebler 9" Crust`) round-trips as
+  // valid JSON both here and, by example, in the model's own output.
+  const itemLines = items
+    .map((it) => `- ${JSON.stringify(it.raw_name)} (current category: ${it.category || 'none'}, current label: ${it.canonical_label || 'none'})`)
+    .join('\n');
+  const existingLabelsBlock = existingLabels?.length
+    ? `\nLabels already chosen for other items in this same cleanup pass — reuse one of these for the same real product instead of inventing a near-duplicate (e.g. don't add "Chicken" if "Chicken Breast" is already here and fits):\n${existingLabels.map((l) => `- ${JSON.stringify(l)}`).join('\n')}\n`
+    : '';
+
+  return `You are cleaning up a household's grocery/shopping spend-tracking database so its "most bought items" report is accurate instead of fragmented.
+
+For every item below, assign:
+- canonical_label: a short, general product-type name for grouping repeat purchases of the same real-world product over time (e.g. "Whole Milk", "Chicken Breast", "Paper Towels", "Bananas").
+- category: the store department, from exactly this list: ${DEPARTMENT_CATEGORIES.join(', ')}. Fix any item that's clearly miscategorized.
+${existingLabelsBlock}
+Items (${items.length} in this batch):
+${itemLines}
+
+Respond with ONLY valid JSON, no markdown fences, matching exactly:
+{ "items": [ { "raw_name": string, "canonical_label": string, "category": string } ] }
+Include every item listed above, exactly once each, with raw_name matching the input string exactly. Never write "none"/"n/a" as a label — if truly nothing more specific fits, repeat the item's own clean name.`;
+}
+
+export function buildMerchantGroupPrompt({ merchants }) {
+  const merchantLines = merchants.map((m) => `- ${JSON.stringify(m)}`).join('\n');
+  return `Group these merchants from a household's spend-tracking database by real-world business — merchants that are the same business at different physical locations should share one group_name (e.g. "ShopRite of Bayonne" and "ShopRite of Metro Plaza" both -> "ShopRite"). Leave genuinely distinct merchants as their own group (group_name equal to the merchant name). Use your judgement on borderline cases like a gas station vs. the main store of the same brand.
+
+Merchants (${merchants.length} total):
+${merchantLines}
+
+Respond with ONLY valid JSON, no markdown fences, matching exactly:
+{ "merchantGroups": [ { "merchant": string, "group_name": string } ] }
+Include every merchant listed above, exactly once each, with merchant matching the input string exactly.`;
+}
+
+export const ITEM_BATCH_RESPONSE_SCHEMA = {
+  type: 'object',
+  properties: {
+    items: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          raw_name: { type: 'string' },
+          canonical_label: { type: 'string' },
+          category: { type: 'string' },
+        },
+        required: ['raw_name', 'canonical_label', 'category'],
+      },
+    },
+  },
+  required: ['items'],
+};
+
+export const MERCHANT_GROUP_RESPONSE_SCHEMA = {
+  type: 'object',
+  properties: {
+    merchantGroups: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          merchant: { type: 'string' },
+          group_name: { type: 'string' },
+        },
+        required: ['merchant', 'group_name'],
+      },
+    },
+  },
+  required: ['merchantGroups'],
+};
+
+// Models sometimes write the word "none"/"n/a"/etc instead of actually
+// leaving a field empty, despite instructions — treat those as empty too.
+const EMPTY_LABEL_RE = /^(none|n\/a|na|null|empty|unknown|-)$/i;
+function cleanLabel(value) {
+  const s = String(value || '').trim();
+  return s && !EMPTY_LABEL_RE.test(s) ? s : null;
+}
+
+export function normalizeItemBatch(raw) {
+  if (!raw || typeof raw !== 'object') throw new Error('Model did not return an object.');
+  const items = Array.isArray(raw.items) ? raw.items : [];
+  return items.map((it) => ({
+    raw_name: String(it.raw_name || '').trim(),
+    canonical_label: cleanLabel(it.canonical_label),
+    category: String(it.category || 'Other').trim() || 'Other',
+  })).filter((it) => it.raw_name);
+}
+
+export function normalizeMerchantGroups(raw) {
+  if (!raw || typeof raw !== 'object') throw new Error('Model did not return an object.');
+  const merchantGroups = Array.isArray(raw.merchantGroups) ? raw.merchantGroups : [];
+  return merchantGroups.map((m) => ({
+    merchant: String(m.merchant || '').trim(),
+    group_name: String(m.group_name || '').trim(),
+  })).filter((m) => m.merchant && m.group_name);
+}
+
+/** Loose validation + normalization of whatever a provider returned. Always
+ * returns an array of receipts, even when the provider (or an older prompt
+ * response) gave back a single flat receipt object. */
+export function normalizeExtraction(raw) {
+  if (!raw || typeof raw !== 'object') throw new Error('Model did not return an object.');
+  const rawReceipts = Array.isArray(raw.receipts) ? raw.receipts : Array.isArray(raw.items) ? [raw] : [];
+  if (!rawReceipts.length) throw new Error('Model did not return any receipts.');
+
+  return rawReceipts.map((r) => {
+    const items = Array.isArray(r.items) ? r.items : [];
+    return {
+      merchant: String(r.merchant || '').trim() || 'Unknown merchant',
+      date: String(r.date || '').trim(),
+      tax: Number(r.tax) || 0,
+      tip: Number(r.tip) || 0,
+      total: Number(r.total) || 0,
+      items: items.map((it) => ({
+        item: String(it.item || '').trim(),
+        description: it.description ? String(it.description).trim() : null,
+        canonical_label: it.canonical_label ? String(it.canonical_label).trim() : null,
+        quantity: Number(it.quantity) || 1,
+        unit_price: it.unit_price != null ? Number(it.unit_price) : null,
+        total_price: Number(it.total_price) || 0,
+        category: String(it.category || 'Other').trim() || 'Other',
+      })),
+    };
+  });
+}

--- a/services/receipt-tracker/src/routes/export.js
+++ b/services/receipt-tracker/src/routes/export.js
@@ -1,0 +1,46 @@
+/**
+ * CSV export — every item across every receipt, flattened. Opens directly
+ * in Excel/Sheets; no separate .xlsx writer needed for that.
+ */
+import express from 'express';
+import * as db from '../db.js';
+import { requireYuvomiSession } from '../auth.js';
+
+const router = express.Router();
+
+function csvField(value) {
+  const s = value == null ? '' : String(value);
+  return /[",\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
+}
+
+router.get('/', requireYuvomiSession, (_req, res) => {
+  const rows = db
+    .get()
+    .prepare(`
+      SELECT r.purchase_date, r.merchant, r.tax AS receipt_tax, r.tip AS receipt_tip, r.total AS receipt_total,
+             i.raw_name, i.canonical_label, i.category, i.quantity, i.unit_price, i.total_price
+      FROM receipt_items i JOIN receipts r ON r.id = i.receipt_id
+      ORDER BY r.purchase_date, r.id, i.id
+    `)
+    .all();
+
+  const header = [
+    'Date', 'Merchant', 'Item', 'Group As', 'Category', 'Quantity', 'Unit Price', 'Item Total',
+    'Receipt Tax', 'Receipt Tip', 'Receipt Total',
+  ];
+  const lines = [header.join(',')];
+  for (const r of rows) {
+    lines.push(
+      [
+        r.purchase_date, r.merchant, r.raw_name, r.canonical_label || '', r.category,
+        r.quantity, r.unit_price ?? '', r.total_price, r.receipt_tax, r.receipt_tip, r.receipt_total,
+      ].map(csvField).join(',')
+    );
+  }
+
+  res.setHeader('Content-Type', 'text/csv; charset=utf-8');
+  res.setHeader('Content-Disposition', `attachment; filename="receipts-${new Date().toISOString().slice(0, 10)}.csv"`);
+  res.send(lines.join('\n'));
+});
+
+export default router;

--- a/services/receipt-tracker/src/routes/merchant-groups.js
+++ b/services/receipt-tracker/src/routes/merchant-groups.js
@@ -1,0 +1,44 @@
+/**
+ * Merchant grouping — e.g. "ShopRite of Bayonne" and "ShopRite of Metro
+ * Plaza" both roll up under "ShopRite" for the Tracking page, while
+ * receipts.merchant keeps the specific location. A merchant with no row
+ * here is its own group (falls back to its raw name wherever this is
+ * joined — see stats.js).
+ */
+import express from 'express';
+import * as db from '../db.js';
+import { requireYuvomiSession } from '../auth.js';
+import { requireCsrf } from '../csrf.js';
+
+const router = express.Router();
+
+router.get('/', requireYuvomiSession, (_req, res) => {
+  const merchants = db.get().prepare('SELECT DISTINCT merchant FROM receipts ORDER BY merchant').all().map((r) => r.merchant);
+  const groups = db.get().prepare('SELECT merchant, group_name FROM merchant_groups').all();
+  const groupByMerchant = Object.fromEntries(groups.map((g) => [g.merchant, g.group_name]));
+
+  res.json({
+    data: merchants.map((merchant) => ({ merchant, group_name: groupByMerchant[merchant] || merchant })),
+  });
+});
+
+router.put('/:merchant', requireYuvomiSession, requireCsrf, (req, res) => {
+  const merchant = req.params.merchant;
+  const groupName = String(req.body?.group_name || '').trim();
+
+  if (!groupName || groupName === merchant) {
+    // Same as its own name (or cleared) — no row needed, falls back naturally.
+    db.get().prepare('DELETE FROM merchant_groups WHERE merchant = ?').run(merchant);
+  } else {
+    db.get()
+      .prepare(`
+        INSERT INTO merchant_groups (merchant, group_name) VALUES (?, ?)
+        ON CONFLICT(merchant) DO UPDATE SET group_name = excluded.group_name
+      `)
+      .run(merchant, groupName);
+  }
+
+  res.json({ data: { merchant, group_name: groupName || merchant } });
+});
+
+export default router;

--- a/services/receipt-tracker/src/routes/receipts.js
+++ b/services/receipt-tracker/src/routes/receipts.js
@@ -1,0 +1,290 @@
+import express from 'express';
+import fs from 'node:fs';
+import path from 'node:path';
+import * as db from '../db.js';
+import { requireYuvomiSession } from '../auth.js';
+import { requireCsrf } from '../csrf.js';
+
+const router = express.Router();
+
+const DATA_DIR = process.env.DATA_DIR || './data';
+const STAGED_DIR = path.join(DATA_DIR, 'images', 'staged');
+const RECEIPTS_DIR = path.join(DATA_DIR, 'images', 'receipts');
+fs.mkdirSync(RECEIPTS_DIR, { recursive: true });
+
+function withItems(receipt) {
+  const items = db
+    .get()
+    .prepare('SELECT * FROM receipt_items WHERE receipt_id = ? ORDER BY id')
+    .all(receipt.id);
+  return { ...receipt, items };
+}
+
+function ensureCategory(category) {
+  const categories = JSON.parse(db.getSetting('categories') || '[]');
+  if (!categories.includes(category)) {
+    categories.push(category);
+    db.setSetting('categories', JSON.stringify(categories));
+  }
+}
+
+// POST / — persist a reviewed/edited receipt + its line items.
+router.post('/', requireYuvomiSession, requireCsrf, (req, res) => {
+  const { merchant, date, tax, tip, total, items, stagedImageId, provider, model } = req.body || {};
+
+  if (!merchant || !date || !Array.isArray(items) || items.length === 0) {
+    return res.status(400).json({ error: 'merchant, date and at least one item are required.', code: 400 });
+  }
+
+  // A single scanned photo/PDF can hold several distinct receipts (see
+  // providers/schema.js) — they all carry the same stagedImageId. The
+  // first save here moves the staged file into place; every later save
+  // for the same scan just points at that same now-final file instead of
+  // trying to move it again (which would silently drop the image).
+  let imagePath = null;
+  if (stagedImageId) {
+    const stagedPath = path.join(STAGED_DIR, stagedImageId);
+    const finalPath = path.join(RECEIPTS_DIR, stagedImageId);
+    if (fs.existsSync(stagedPath)) {
+      fs.renameSync(stagedPath, finalPath);
+      imagePath = `receipts/${stagedImageId}`;
+    } else if (fs.existsSync(finalPath)) {
+      imagePath = `receipts/${stagedImageId}`;
+    }
+  }
+
+  const insertReceipt = db.get().prepare(`
+    INSERT INTO receipts (created_by, merchant, purchase_date, tax, tip, total, image_path, provider, model)
+    VALUES (@created_by, @merchant, @purchase_date, @tax, @tip, @total, @image_path, @provider, @model)
+  `);
+  const insertItem = db.get().prepare(`
+    INSERT INTO receipt_items (receipt_id, raw_name, canonical_label, description, quantity, unit_price, total_price, category)
+    VALUES (@receipt_id, @raw_name, @canonical_label, @description, @quantity, @unit_price, @total_price, @category)
+  `);
+
+  const receiptId = db.get().transaction(() => {
+    const info = insertReceipt.run({
+      created_by: req.yuvomiUser.id,
+      merchant: String(merchant).trim(),
+      purchase_date: String(date).trim(),
+      tax: Number(tax) || 0,
+      tip: Number(tip) || 0,
+      total: Number(total) || 0,
+      image_path: imagePath,
+      provider: provider || null,
+      model: model || null,
+    });
+    for (const it of items) {
+      const category = String(it.category || 'Other').trim() || 'Other';
+      ensureCategory(category);
+      insertItem.run({
+        receipt_id: info.lastInsertRowid,
+        raw_name: String(it.item || it.raw_name || '').trim(),
+        canonical_label: it.canonical_label ? String(it.canonical_label).trim() : null,
+        description: it.description ? String(it.description).trim() : null,
+        quantity: Number(it.quantity) || 1,
+        unit_price: it.unit_price != null ? Number(it.unit_price) : null,
+        total_price: Number(it.total_price) || 0,
+        category,
+      });
+    }
+    return info.lastInsertRowid;
+  })();
+
+  const receipt = db.get().prepare('SELECT * FROM receipts WHERE id = ?').get(receiptId);
+  res.status(201).json({ data: withItems(receipt) });
+});
+
+// GET / — search + filter + paginate.
+router.get('/', requireYuvomiSession, (req, res) => {
+  const { q, category, merchant, from, to, page = '1', pageSize = '25' } = req.query;
+
+  const where = [];
+  const params = {};
+  if (q) {
+    where.push(`(
+      r.merchant LIKE @q
+      OR r.id IN (SELECT receipt_id FROM receipt_items WHERE raw_name LIKE @q OR canonical_label LIKE @q)
+    )`);
+    params.q = `%${q}%`;
+  }
+  if (category) {
+    where.push('r.id IN (SELECT receipt_id FROM receipt_items WHERE category = @category)');
+    params.category = category;
+  }
+  if (merchant) {
+    where.push('r.merchant = @merchant');
+    params.merchant = merchant;
+  }
+  if (from) {
+    where.push('r.purchase_date >= @from');
+    params.from = from;
+  }
+  if (to) {
+    where.push('r.purchase_date <= @to');
+    params.to = to;
+  }
+
+  const whereSql = where.length ? `WHERE ${where.join(' AND ')}` : '';
+  const limit = Math.min(Number(pageSize) || 25, 100);
+  const offset = (Math.max(Number(page) || 1, 1) - 1) * limit;
+
+  const total = db.get().prepare(`SELECT COUNT(*) AS n FROM receipts r ${whereSql}`).get(params).n;
+  const rows = db
+    .get()
+    .prepare(`SELECT r.* FROM receipts r ${whereSql} ORDER BY r.purchase_date DESC, r.id DESC LIMIT @limit OFFSET @offset`)
+    .all({ ...params, limit, offset });
+
+  res.json({ data: rows.map(withItems), meta: { total, page: Number(page) || 1, pageSize: limit } });
+});
+
+router.get('/:id', requireYuvomiSession, (req, res) => {
+  const receipt = db.get().prepare('SELECT * FROM receipts WHERE id = ?').get(req.params.id);
+  if (!receipt) return res.status(404).json({ error: 'Not found.', code: 404 });
+  res.json({ data: withItems(receipt) });
+});
+
+router.put('/:id', requireYuvomiSession, requireCsrf, (req, res) => {
+  const existing = db.get().prepare('SELECT * FROM receipts WHERE id = ?').get(req.params.id);
+  if (!existing) return res.status(404).json({ error: 'Not found.', code: 404 });
+
+  const { merchant, date, tax, tip, total, items } = req.body || {};
+
+  db.get().transaction(() => {
+    db.get()
+      .prepare(`
+        UPDATE receipts
+        SET merchant = @merchant, purchase_date = @purchase_date, tax = @tax, tip = @tip, total = @total,
+            updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
+        WHERE id = @id
+      `)
+      .run({
+        id: existing.id,
+        merchant: String(merchant ?? existing.merchant).trim(),
+        purchase_date: String(date ?? existing.purchase_date).trim(),
+        tax: tax != null ? Number(tax) : existing.tax,
+        tip: tip != null ? Number(tip) : existing.tip,
+        total: total != null ? Number(total) : existing.total,
+      });
+
+    if (Array.isArray(items)) {
+      db.get().prepare('DELETE FROM receipt_items WHERE receipt_id = ?').run(existing.id);
+      const insertItem = db.get().prepare(`
+        INSERT INTO receipt_items (receipt_id, raw_name, canonical_label, description, quantity, unit_price, total_price, category)
+        VALUES (@receipt_id, @raw_name, @canonical_label, @description, @quantity, @unit_price, @total_price, @category)
+      `);
+      for (const it of items) {
+        const category = String(it.category || 'Other').trim() || 'Other';
+        ensureCategory(category);
+        insertItem.run({
+          receipt_id: existing.id,
+          raw_name: String(it.item || it.raw_name || '').trim(),
+          canonical_label: it.canonical_label ? String(it.canonical_label).trim() : null,
+          description: it.description ? String(it.description).trim() : null,
+          quantity: Number(it.quantity) || 1,
+          unit_price: it.unit_price != null ? Number(it.unit_price) : null,
+          total_price: Number(it.total_price) || 0,
+          category,
+        });
+      }
+    }
+  })();
+
+  const updated = db.get().prepare('SELECT * FROM receipts WHERE id = ?').get(existing.id);
+  res.json({ data: withItems(updated) });
+});
+
+router.delete('/:id', requireYuvomiSession, requireCsrf, (req, res) => {
+  const existing = db.get().prepare('SELECT * FROM receipts WHERE id = ?').get(req.params.id);
+  if (!existing) return res.status(404).json({ error: 'Not found.', code: 404 });
+
+  if (existing.image_path) {
+    const full = path.join(DATA_DIR, 'images', existing.image_path);
+    fs.rm(full, { force: true }, () => {});
+  }
+  db.get().prepare('DELETE FROM receipts WHERE id = ?').run(existing.id);
+  res.status(204).end();
+});
+
+// Item-level editing, independent of the whole-receipt PUT above — lets
+// History correct or drop a single line without resubmitting every other
+// item on the receipt.
+router.put('/:id/items/:itemId', requireYuvomiSession, requireCsrf, (req, res) => {
+  const item = db
+    .get()
+    .prepare('SELECT * FROM receipt_items WHERE id = ? AND receipt_id = ?')
+    .get(req.params.itemId, req.params.id);
+  if (!item) return res.status(404).json({ error: 'Item not found.', code: 404 });
+
+  const body = req.body || {};
+  const category = body.category != null ? String(body.category).trim() || 'Other' : item.category;
+  if (body.category != null) ensureCategory(category);
+
+  db.get()
+    .prepare(`
+      UPDATE receipt_items
+      SET raw_name = @raw_name, canonical_label = @canonical_label, description = @description,
+          quantity = @quantity, unit_price = @unit_price, total_price = @total_price, category = @category
+      WHERE id = @id
+    `)
+    .run({
+      id: item.id,
+      raw_name: body.item != null || body.raw_name != null ? String(body.item ?? body.raw_name).trim() : item.raw_name,
+      canonical_label: body.canonical_label !== undefined ? (body.canonical_label ? String(body.canonical_label).trim() : null) : item.canonical_label,
+      description: body.description !== undefined ? (body.description ? String(body.description).trim() : null) : item.description,
+      quantity: body.quantity != null ? Number(body.quantity) || 1 : item.quantity,
+      unit_price: body.unit_price !== undefined ? (body.unit_price != null ? Number(body.unit_price) : null) : item.unit_price,
+      total_price: body.total_price != null ? Number(body.total_price) || 0 : item.total_price,
+      category,
+    });
+
+  const receipt = db.get().prepare('SELECT * FROM receipts WHERE id = ?').get(req.params.id);
+  res.json({ data: withItems(receipt) });
+});
+
+router.post('/:id/items', requireYuvomiSession, requireCsrf, (req, res) => {
+  const receipt = db.get().prepare('SELECT id FROM receipts WHERE id = ?').get(req.params.id);
+  if (!receipt) return res.status(404).json({ error: 'Receipt not found.', code: 404 });
+
+  const it = req.body || {};
+  const category = String(it.category || 'Other').trim() || 'Other';
+  ensureCategory(category);
+
+  db.get()
+    .prepare(`
+      INSERT INTO receipt_items (receipt_id, raw_name, canonical_label, description, quantity, unit_price, total_price, category)
+      VALUES (@receipt_id, @raw_name, @canonical_label, @description, @quantity, @unit_price, @total_price, @category)
+    `)
+    .run({
+      receipt_id: req.params.id,
+      raw_name: String(it.item || it.raw_name || '').trim(),
+      canonical_label: it.canonical_label ? String(it.canonical_label).trim() : null,
+      description: it.description ? String(it.description).trim() : null,
+      quantity: Number(it.quantity) || 1,
+      unit_price: it.unit_price != null ? Number(it.unit_price) : null,
+      total_price: Number(it.total_price) || 0,
+      category,
+    });
+
+  res.status(201).json({ data: withItems(db.get().prepare('SELECT * FROM receipts WHERE id = ?').get(req.params.id)) });
+});
+
+router.delete('/:id/items/:itemId', requireYuvomiSession, requireCsrf, (req, res) => {
+  const item = db
+    .get()
+    .prepare('SELECT id FROM receipt_items WHERE id = ? AND receipt_id = ?')
+    .get(req.params.itemId, req.params.id);
+  if (!item) return res.status(404).json({ error: 'Item not found.', code: 404 });
+
+  db.get().prepare('DELETE FROM receipt_items WHERE id = ?').run(item.id);
+  const receipt = db.get().prepare('SELECT * FROM receipts WHERE id = ?').get(req.params.id);
+  res.json({ data: withItems(receipt) });
+});
+
+router.get('/:id/image', requireYuvomiSession, (req, res) => {
+  const receipt = db.get().prepare('SELECT image_path FROM receipts WHERE id = ?').get(req.params.id);
+  if (!receipt?.image_path) return res.status(404).json({ error: 'No image.', code: 404 });
+  res.sendFile(path.resolve(DATA_DIR, 'images', receipt.image_path));
+});
+
+export default router;

--- a/services/receipt-tracker/src/routes/reclassify.js
+++ b/services/receipt-tracker/src/routes/reclassify.js
@@ -1,0 +1,116 @@
+/**
+ * One-shot AI cleanup pass: re-labels every distinct item and re-groups
+ * every merchant already in the database using the current (improved)
+ * prompt, so historical/imported data catches up to whatever quality bar
+ * new scans get. Admin-only — costs real API calls and rewrites data.
+ *
+ * Items are processed in batches (not one giant call — see providers/
+ * schema.js for why) applied to the DB after each batch, so a failure
+ * partway through still keeps whatever progress was made instead of
+ * losing the whole pass.
+ */
+import express from 'express';
+import * as db from '../db.js';
+import { requireYuvomiAdmin } from '../auth.js';
+import { requireCsrf } from '../csrf.js';
+import { runClassifyItems, runClassifyMerchants } from '../providers/index.js';
+
+const router = express.Router();
+const ITEM_BATCH_SIZE = 60;
+
+router.post('/', requireYuvomiAdmin, requireCsrf, async (req, res) => {
+  const provider = db.getSetting('vision_provider') || 'gemini';
+  const model = req.body?.model || db.getSetting('vision_model') || null;
+  const apiKey = db.getSetting(`${provider}_api_key`) || process.env[`${provider.toUpperCase()}_API_KEY`] || null;
+  if (!apiKey) {
+    return res.status(409).json({ error: `No API key configured for ${provider}. Set one under Settings first.`, code: 409 });
+  }
+
+  const items = db
+    .get()
+    .prepare('SELECT raw_name, MIN(category) AS category, MIN(canonical_label) AS canonical_label FROM receipt_items GROUP BY raw_name')
+    .all();
+  const merchants = db.get().prepare('SELECT DISTINCT merchant FROM receipts ORDER BY merchant').all().map((r) => r.merchant);
+
+  if (!items.length) {
+    return res.status(400).json({ error: 'No items to reclassify yet.', code: 400 });
+  }
+
+  const updateItem = db.get().prepare('UPDATE receipt_items SET canonical_label = ?, category = ? WHERE raw_name = ?');
+  const upsertGroup = db.get().prepare(`
+    INSERT INTO merchant_groups (merchant, group_name) VALUES (?, ?)
+    ON CONFLICT(merchant) DO UPDATE SET group_name = excluded.group_name
+  `);
+  const clearGroup = db.get().prepare('DELETE FROM merchant_groups WHERE merchant = ?');
+
+  let merchantsGrouped = 0;
+  try {
+    const merchantGroups = await runClassifyMerchants({ provider, model, apiKey, merchants });
+    db.get().transaction(() => {
+      for (const m of merchantGroups) {
+        if (m.group_name === m.merchant) clearGroup.run(m.merchant);
+        else {
+          upsertGroup.run(m.merchant, m.group_name);
+          merchantsGrouped++;
+        }
+      }
+    })();
+  } catch (err) {
+    return res.status(502).json({ error: `Merchant grouping failed: ${err.message}`, code: 502 });
+  }
+
+  const existingLabels = new Set();
+  let itemsUpdated = 0;
+  let batchesDone = 0;
+  const totalBatches = Math.ceil(items.length / ITEM_BATCH_SIZE);
+
+  for (let i = 0; i < items.length; i += ITEM_BATCH_SIZE) {
+    const batch = items.slice(i, i + ITEM_BATCH_SIZE);
+    let result;
+    try {
+      // Malformed/truncated JSON from the model is common enough at this
+      // volume of structured-output calls to be worth one immediate retry
+      // before giving up and losing the rest of the run.
+      try {
+        result = await runClassifyItems({ provider, model, apiKey, items: batch, existingLabels: [...existingLabels] });
+      } catch {
+        result = await runClassifyItems({ provider, model, apiKey, items: batch, existingLabels: [...existingLabels] });
+      }
+    } catch (err) {
+      // Partial progress already committed to the DB from earlier batches —
+      // report what happened rather than losing it.
+      return res.status(502).json({
+        error: `Item batch ${batchesDone + 1}/${totalBatches} failed twice: ${err.message}. ${itemsUpdated} item rows were already updated before this failure.`,
+        code: 502,
+      });
+    }
+
+    db.get().transaction(() => {
+      for (const it of result) {
+        const info = updateItem.run(it.canonical_label, it.category, it.raw_name);
+        itemsUpdated += info.changes;
+        if (it.canonical_label) existingLabels.add(it.canonical_label);
+      }
+    })();
+    batchesDone++;
+  }
+
+  const distinctLabelsAfter = db
+    .get()
+    .prepare('SELECT COUNT(DISTINCT canonical_label) n FROM receipt_items WHERE canonical_label IS NOT NULL')
+    .get().n;
+  const categoriesUsed = db.get().prepare('SELECT DISTINCT category FROM receipt_items').all().map((r) => r.category);
+  db.setSetting('categories', JSON.stringify([...new Set(categoriesUsed)].sort()));
+
+  res.json({
+    data: {
+      distinctItemsSeen: items.length,
+      batchesRun: batchesDone,
+      itemRowsUpdated: itemsUpdated,
+      distinctLabelsAfter,
+      merchantsGrouped,
+    },
+  });
+});
+
+export default router;

--- a/services/receipt-tracker/src/routes/scan.js
+++ b/services/receipt-tracker/src/routes/scan.js
@@ -1,0 +1,77 @@
+/**
+ * POST /scan — runs the configured vision model over an uploaded receipt
+ * photo and returns a draft extraction. Nothing is written to the receipts
+ * table here: the client shows this in the review screen first, and only
+ * a subsequent POST /receipts (with the human-edited payload) persists it.
+ */
+import express from 'express';
+import multer from 'multer';
+import fs from 'node:fs';
+import path from 'node:path';
+import crypto from 'node:crypto';
+import * as db from '../db.js';
+import { requireYuvomiSession } from '../auth.js';
+import { requireCsrf } from '../csrf.js';
+import { runExtraction } from '../providers/index.js';
+
+const router = express.Router();
+const upload = multer({ limits: { fileSize: 20 * 1024 * 1024 } });
+
+const ALLOWED_MIME_TYPES = new Set([
+  'image/jpeg',
+  'image/png',
+  'image/webp',
+  'image/heic',
+  'image/heif',
+  'application/pdf',
+]);
+
+const DATA_DIR = process.env.DATA_DIR || './data';
+const STAGED_DIR = path.join(DATA_DIR, 'images', 'staged');
+fs.mkdirSync(STAGED_DIR, { recursive: true });
+
+router.post('/', requireYuvomiSession, requireCsrf, upload.single('image'), async (req, res) => {
+  if (!req.file) {
+    return res.status(400).json({ error: 'No file uploaded.', code: 400 });
+  }
+  if (!ALLOWED_MIME_TYPES.has(req.file.mimetype)) {
+    return res.status(415).json({
+      error: `Unsupported file type "${req.file.mimetype}". Upload a photo (JPEG/PNG/WebP/HEIC) or a PDF.`,
+      code: 415,
+    });
+  }
+
+  const provider = db.getSetting('vision_provider') || 'gemini';
+  const model = db.getSetting('vision_model') || null;
+  const apiKey =
+    db.getSetting(`${provider}_api_key`) || process.env[`${provider.toUpperCase()}_API_KEY`] || null;
+
+  if (!apiKey) {
+    return res.status(409).json({
+      error: `No API key configured for ${provider}. An admin needs to set one under Receipts → Settings.`,
+      code: 409,
+    });
+  }
+
+  // Stage the image now so a save right after doesn't need a second upload.
+  const stagedId = crypto.randomUUID();
+  const ext = (req.file.mimetype.split('/')[1] || 'jpg').replace('jpeg', 'jpg');
+  const stagedPath = path.join(STAGED_DIR, `${stagedId}.${ext}`);
+  fs.writeFileSync(stagedPath, req.file.buffer);
+
+  try {
+    const draft = await runExtraction({
+      provider,
+      model,
+      apiKey,
+      base64: req.file.buffer.toString('base64'),
+      mimeType: req.file.mimetype,
+    });
+
+    res.json({ data: { stagedImageId: `${stagedId}.${ext}`, provider, model, draft } });
+  } catch (err) {
+    res.status(502).json({ error: `Extraction failed: ${err.message}`, code: 502 });
+  }
+});
+
+export default router;

--- a/services/receipt-tracker/src/routes/settings.js
+++ b/services/receipt-tracker/src/routes/settings.js
@@ -1,0 +1,89 @@
+/**
+ * Household-wide vision-provider configuration. One admin sets this up
+ * once; every household member using the module gets it automatically —
+ * nobody else needs their own API key. Reads are open to any authenticated
+ * member (so the UI can show what's configured); writes are admin-only.
+ * The key value itself is never returned, only whether one is set.
+ */
+import express from 'express';
+import * as db from '../db.js';
+import { requireYuvomiSession, requireYuvomiAdmin } from '../auth.js';
+import { requireCsrf } from '../csrf.js';
+import { providerCatalog, PROVIDERS, runListModels } from '../providers/index.js';
+
+const router = express.Router();
+
+function keyFieldFor(provider) {
+  return `${provider}_api_key`;
+}
+
+router.get('/', requireYuvomiSession, (_req, res) => {
+  const provider = db.getSetting('vision_provider') || 'gemini';
+  const model = db.getSetting('vision_model') || PROVIDERS[provider]?.defaultModel || null;
+  const hasApiKey = Boolean(db.getSetting(keyFieldFor(provider)) || process.env[`${provider.toUpperCase()}_API_KEY`]);
+
+  res.json({
+    data: {
+      provider,
+      model,
+      hasApiKey,
+      providers: providerCatalog(),
+      categories: JSON.parse(db.getSetting('categories') || '[]'),
+    },
+  });
+});
+
+router.put('/', requireYuvomiAdmin, requireCsrf, (req, res) => {
+  const { provider, model, apiKey } = req.body || {};
+
+  if (!provider || !PROVIDERS[provider]) {
+    return res.status(400).json({ error: 'Unknown or missing provider.', code: 400 });
+  }
+
+  db.setSetting('vision_provider', provider);
+  db.setSetting('vision_model', model || PROVIDERS[provider].defaultModel);
+
+  // Only overwrite the stored key if one was actually sent — leaves it
+  // untouched when the admin is just switching the model, not rotating keys.
+  if (typeof apiKey === 'string' && apiKey.trim()) {
+    db.setSetting(keyFieldFor(provider), apiKey.trim());
+  }
+
+  res.json({
+    data: {
+      provider,
+      model: db.getSetting('vision_model'),
+      hasApiKey: Boolean(db.getSetting(keyFieldFor(provider))),
+    },
+  });
+});
+
+// POST /settings/models — live list of models the configured (or a
+// not-yet-saved, just-typed) key can actually use, instead of hand-typing
+// a model name and finding out it's wrong at scan time. Admin-only: same
+// key-handling trust boundary as the write above, and it's what makes
+// testing a brand-new key before saving it possible.
+router.post('/models', requireYuvomiAdmin, requireCsrf, async (req, res) => {
+  const { provider } = req.body || {};
+  if (!provider || !PROVIDERS[provider]) {
+    return res.status(400).json({ error: 'Unknown or missing provider.', code: 400 });
+  }
+
+  // A key typed into the form but not yet saved takes priority, so an
+  // admin can check a new key before committing it.
+  const typedKey = typeof req.body?.apiKey === 'string' ? req.body.apiKey.trim() : '';
+  const apiKey = typedKey || db.getSetting(keyFieldFor(provider)) || process.env[`${provider.toUpperCase()}_API_KEY`] || null;
+
+  if (!apiKey) {
+    return res.status(409).json({ error: `No ${provider} API key to check yet — paste one first.`, code: 409 });
+  }
+
+  try {
+    const models = await runListModels({ provider, apiKey });
+    res.json({ data: { models } });
+  } catch (err) {
+    res.status(502).json({ error: `Could not list ${provider} models: ${err.message}`, code: 502 });
+  }
+});
+
+export default router;

--- a/services/receipt-tracker/src/routes/stats.js
+++ b/services/receipt-tracker/src/routes/stats.js
@@ -1,0 +1,100 @@
+/**
+ * Spend analysis for the Tracking view: by category, by item (grouped by
+ * canonical_label when set, falling back to the raw OCR text otherwise —
+ * see receipt-tracker/index.js review screen for how canonical labels get
+ * assigned), by merchant, and a time series bucketed by week or month.
+ */
+import express from 'express';
+import * as db from '../db.js';
+import { requireYuvomiSession } from '../auth.js';
+
+const router = express.Router();
+
+function dateFilter(from, to) {
+  const where = [];
+  const params = {};
+  if (from) {
+    where.push('r.purchase_date >= @from');
+    params.from = from;
+  }
+  if (to) {
+    where.push('r.purchase_date <= @to');
+    params.to = to;
+  }
+  return { sql: where.length ? `WHERE ${where.join(' AND ')}` : '', params };
+}
+
+router.get('/', requireYuvomiSession, (req, res) => {
+  const { from, to, bucket = 'month' } = req.query;
+  const { sql: whereSql, params } = dateFilter(from, to);
+  const dateBucket = bucket === 'week' ? "strftime('%Y-W%W', r.purchase_date)" : "strftime('%Y-%m', r.purchase_date)";
+
+  const byCategory = db
+    .get()
+    .prepare(`
+      SELECT i.category AS category, SUM(i.total_price) AS total, COUNT(*) AS count
+      FROM receipt_items i JOIN receipts r ON r.id = i.receipt_id
+      ${whereSql}
+      GROUP BY i.category ORDER BY total DESC
+    `)
+    .all(params);
+
+  const byItem = db
+    .get()
+    .prepare(`
+      SELECT COALESCE(NULLIF(i.canonical_label, ''), i.raw_name) AS label,
+             SUM(i.total_price) AS total, SUM(i.quantity) AS quantity, COUNT(*) AS count
+      FROM receipt_items i JOIN receipts r ON r.id = i.receipt_id
+      ${whereSql}
+      GROUP BY label ORDER BY total DESC
+    `)
+    .all(params);
+
+  // Rolls receipts.merchant up through merchant_groups (e.g. "ShopRite of
+  // Bayonne" + "ShopRite of Metro Plaza" -> "ShopRite") — a merchant with
+  // no group row is its own group.
+  const byMerchant = db
+    .get()
+    .prepare(`
+      SELECT COALESCE(mg.group_name, r.merchant) AS merchant, SUM(r.total) AS total, COUNT(*) AS count
+      FROM receipts r LEFT JOIN merchant_groups mg ON mg.merchant = r.merchant
+      ${whereSql}
+      GROUP BY COALESCE(mg.group_name, r.merchant) ORDER BY total DESC
+    `)
+    .all(params);
+
+  const overTime = db
+    .get()
+    .prepare(`
+      SELECT ${dateBucket} AS bucket, SUM(r.total) AS total, COUNT(*) AS count
+      FROM receipts r
+      ${whereSql}
+      GROUP BY bucket ORDER BY bucket
+    `)
+    .all(params);
+
+  res.json({ data: { byCategory, byItem, byMerchant, overTime } });
+});
+
+// Item-level breakdown within one department, for the "Spend by department"
+// drill-down popup — same date range, grouped the same way as byItem above.
+router.get('/category/:category', requireYuvomiSession, (req, res) => {
+  const { from, to } = req.query;
+  const { sql: dateSql, params } = dateFilter(from, to);
+  const where = dateSql ? `${dateSql} AND i.category = @category` : 'WHERE i.category = @category';
+
+  const items = db
+    .get()
+    .prepare(`
+      SELECT COALESCE(NULLIF(i.canonical_label, ''), i.raw_name) AS label,
+             SUM(i.total_price) AS total, SUM(i.quantity) AS quantity, COUNT(*) AS count
+      FROM receipt_items i JOIN receipts r ON r.id = i.receipt_id
+      ${where}
+      GROUP BY label ORDER BY total DESC
+    `)
+    .all({ ...params, category: req.params.category });
+
+  res.json({ data: { category: req.params.category, items } });
+});
+
+export default router;


### PR DESCRIPTION
## Summary

Backend service for a third-party "Receipts" module — scans a photo/PDF receipt with a vision model (Gemini or Claude, admin supplies the key once), the household reviews/corrects the extraction, then tracks spend by category, item, and merchant over time.

This is the companion-service half described in [MODULES.md](../blob/main/MODULES.md)'s "Modules With A Backend Service" section. The module's client UI half is intentionally **not** in this PR — `modules/*` is already gitignored by this repo, since third-party module UIs aren't meant to live in core.

No core file is touched (nothing under `server/` or `public/` changed). The service owns its own SQLite database and image storage; it never opens `yuvomi.db`. It verifies every request by forwarding the caller's Yuvomi session cookie to the real `GET /api/v1/auth/me` and trusts only that response for identity/role.

## Changes

- `services/receipt-tracker/src/index.js` + `routes/`: settings (vision provider/model/key, admin-only writes), scan (upload → vision extraction, held for review before persisting), receipts (search/CRUD, per-item edit/delete), stats (category/item/merchant/time breakdowns), merchant-groups (roll up e.g. "ShopRite of Bayonne" + "ShopRite of Metro Plaza" under one name for reporting), export (CSV)
- `src/auth.js`: session verification against Yuvomi's own `/api/v1/auth/me`, never a client-supplied user id
- `src/csrf.js`: independent double-submit CSRF (Yuvomi's own CSRF token protects Yuvomi's endpoints, not a module's)
- `src/providers/`: Gemini and Claude behind one interface (`extract`, `listModels`, `classifyItems`, `classifyMerchants`)
- `dev-proxy.js`: local stand-in for the reverse-proxy rule a real deployment needs (routes `/api/extensions/receipt-tracker/*` here, everything else to Yuvomi) — dev tooling only, not part of the running service

## Deployment

Runs as a sibling container in `docker-compose.yml` next to the existing `yuvomi` service, plus one added reverse-proxy rule for `/api/extensions/receipt-tracker/*`. Yuvomi's own image and upgrade path are unaffected either way.

## Checklist

- [ ] `npm test` passes — not run against this change; it's additive and touches no file the suite covers, and the suite doesn't exercise anything under `services/`
- [x] Follows CONTRIBUTING.md conventions
- [x] No new frontend dependencies (Yuvomi's own `public/` frontend is untouched; this is a separate backend service with its own dependency tree, per MODULES.md's guidance for backend-service modules)
- [ ] UI strings use `t('key')` — N/A, this PR is backend-only (no UI strings)
- [ ] CHANGELOG.md updated — not updated; core's shipped behavior doesn't change
