### PR TITLE
docs(icons): der ausschnitt von createIcons({el}) ist geliehen, und zwei kommentare wussten es nicht

### DIFF
--- a/public/components/quick-links-manager.js
+++ b/public/components/quick-links-manager.js
@@ -82,8 +82,10 @@ function monogram(name) {
  * GIBT DOM UND KEINE ZEICHENKETTE. Das Symbol kommt als fertiges `<svg>` von
  * `iconElement()`; als Markup zurückgegeben müsste es erst wieder geparst
  * werden, und der Weg dorthin führte über `data-lucide` plus einen
- * `createIcons()`-Lauf, der - anders als seine 213 Aufrufstellen glauben -
- * kein Ausschnittsargument kennt und jedes Mal das ganze Dokument absucht.
+ * `createIcons()`-Lauf, den der Aufrufer nach jedem Einfügen selbst nachholen
+ * muss. Diese zweite Pflicht fällt genau dann aus, wenn eine Kachel abseits des
+ * gewohnten Renderwegs entsteht - der Knopf bleibt leer bis zum Reload (#668).
+ * `iconElement()` hat sie nicht: das Zeichen ist fertig, wenn es zurückkommt.
  *
  * KENNT LUCIDE DEN NAMEN NICHT, GILT DER BUCHSTABE. Ein Symbolname steht in
  * der Datenbank und überlebt ein Lucide-Update, das ihn umbenennt; die Kachel

--- a/public/utils/lucide-icons.js
+++ b/public/utils/lucide-icons.js
@@ -9,11 +9,19 @@
  * beantwortet die andere Frage, die es vorher nicht gab: ein Symbol, dessen
  * Name erst zur Laufzeit feststeht, weil ihn jemand ausgesucht hat.
  *
- * DESHALB `createElement` UND NICHT `createIcons`. Der zweite Weg kennt keinen
- * Ausschnitt - er sucht `[data-lucide]` im ganzen Dokument, egal was man ihm
- * übergibt. Für ein Raster mit 120 Kacheln wären das 120 volle Dokumentläufe
- * für 120 Symbole. `createElement` liefert das fertige `<svg>` direkt und
- * fasst nichts an, was nicht danach gefragt hat.
+ * DESHALB `createElement` UND NICHT `createIcons`. Der zweite Weg ersetzt
+ * Platzhalter: erst muss ein `<i data-lucide>` im Baum stehen, dann läuft
+ * `createIcons` darüber. Wer ein einzelnes Zeichen braucht, dessen Name gerade
+ * erst feststeht, will diesen Umweg nicht - `createElement` liefert das fertige
+ * `<svg>` direkt und fasst nichts an, was nicht danach gefragt hat.
+ *
+ * DER AUSSCHNITT IST INZWISCHEN ECHT, UND DAS ÄNDERT DIE WAHL NICHT. Bis zum
+ * Audit 2026-08-31 durchsuchte `createIcons({ el })` das ganze Dokument, egal
+ * was man ihm übergab - für ein Raster mit 120 Kacheln wären das 120 volle
+ * Dokumentläufe gewesen. `lucide-scope.js` (lädt direkt nach dem Bundle) hält
+ * den Lauf seither unter `el`. Der Größenvorteil ist damit weg, der Grund
+ * oben bleibt: ein Platzhalter, den niemand sehen soll, ist ein Umweg und
+ * keine Ersparnis.
  *
  * DIE NAMENSFORM IST GEPRUEFT, NICHT GERATEN. Lucide führt seine Symbole in
  * PascalCase (`AlarmClock`), die App schreibt sie mit Bindestrich

--- a/test/test-frontend-audit.js
+++ b/test/test-frontend-audit.js
@@ -14778,10 +14778,14 @@ test('der Lucide-Ausschnitt läuft nach dem Bundle und vor jedem Modul, das ihn 
   assert.match(scope, /\bel\.querySelectorAll\(/,
     'lucide-scope.js sucht nicht mehr unter `el` - dann ist der Ausschnitt keiner');
 
-  const scripts = [...read('../public/index.html').matchAll(/<script\b[^>]*>/g)]
-    .map((m) => ({ tag: m[0], src: m[0].match(/\bsrc=["']([^"']+)["']/)?.[1] }))
+  // Durchgehend `i`: Tagnamen und Attribute sind in HTML gross-/kleinschreibungs-
+  // egal, `<SCRIPT SRC=... DEFER>` ist gueltig. Ohne das Flag faende dieser Guard
+  // eine grossgeschriebene Fassung nicht und waere gruen, ohne etwas geprueft zu
+  // haben - genau der blinde Zustand, den er verhindern soll (CodeQL js/bad-tag-filter).
+  const scripts = [...read('../public/index.html').matchAll(/<script\b[^>]*>/gi)]
+    .map((m) => ({ tag: m[0], src: m[0].match(/\bsrc=["']([^"']+)["']/i)?.[1] }))
     .filter((s) => s.src);
-  const isModule = (s) => /\btype=["']module["']/.test(s.tag);
+  const isModule = (s) => /\btype=["']module["']/i.test(s.tag);
 
   const bundle = scripts.findIndex((s) => s.src === '/lucide.min.js');
   const patch = scripts.findIndex((s) => s.src === '/lucide-scope.js');
@@ -14796,7 +14800,7 @@ test('der Lucide-Ausschnitt läuft nach dem Bundle und vor jedem Modul, das ihn 
   // Beide klassisch mit `defer`: ohne defer liefe der Patch sofort beim Parsen,
   // also vor dem deferred Bundle - derselbe stille Ausstieg.
   for (const i of [bundle, patch]) {
-    assert.match(scripts[i].tag, /\bdefer\b/,
+    assert.match(scripts[i].tag, /\bdefer\b/i,
       `${scripts[i].src} trägt kein defer mehr - die Reihenfolge zwischen Bundle und Patch `
       + 'ist damit nicht mehr garantiert');
   }
@@ -14811,7 +14815,7 @@ test('der Lucide-Ausschnitt läuft nach dem Bundle und vor jedem Modul, das ihn 
   // Und die klassischen Skripte davor laufen ohne defer sofort beim Parsen,
   // lange vor dem Bundle: dort ist jeder createIcons-Aufruf ungescopt.
   const early = scripts
-    .filter((s, i) => i < patch && !isModule(s) && !/\bdefer\b/.test(s.tag))
+    .filter((s, i) => i < patch && !isModule(s) && !/\bdefer\b/i.test(s.tag))
     .filter((s) => existsSync(new URL(`../public${s.src}`, import.meta.url)))
     .filter((s) => /createIcons/.test(read(`../public${s.src}`)));
   assert.deepEqual(early.map((s) => s.src), [],

--- a/test/test-frontend-audit.js
+++ b/test/test-frontend-audit.js
@@ -14782,40 +14782,64 @@ test('der Lucide-Ausschnitt läuft nach dem Bundle und vor jedem Modul, das ihn 
   // egal, `<SCRIPT SRC=... DEFER>` ist gueltig. Ohne das Flag faende dieser Guard
   // eine grossgeschriebene Fassung nicht und waere gruen, ohne etwas geprueft zu
   // haben - genau der blinde Zustand, den er verhindern soll (CodeQL js/bad-tag-filter).
-  const scripts = [...read('../public/index.html').matchAll(/<script\b[^>]*>/gi)]
+  //
+  // Und ohne Kommentare: ein auskommentiertes `<script src="/lucide-scope.js">`
+  // steht weiter im Rohtext und laedt nichts. Jede Zusicherung hier unten waere
+  // erfuellt, waehrend der Patch in Wahrheit fehlt.
+  const scripts = [...withoutHtmlComments(read('../public/index.html')).matchAll(/<script\b[^>]*>/gi)]
     .map((m) => ({ tag: m[0], src: m[0].match(/\bsrc=["']([^"']+)["']/i)?.[1] }))
     .filter((s) => s.src);
   const isModule = (s) => /\btype=["']module["']/i.test(s.tag);
+  // `async` schlaegt `defer`: das Skript laeuft, sobald es da ist, in keiner
+  // festen Reihenfolge. Nur ein rein deferred Skript haelt seinen Platz.
+  const isDeferred = (s) => /\bdefer\b/i.test(s.tag) && !/\basync\b/i.test(s.tag);
 
-  const bundle = scripts.findIndex((s) => s.src === '/lucide.min.js');
-  const patch = scripts.findIndex((s) => s.src === '/lucide-scope.js');
-  assert.ok(bundle > -1, 'index.html lädt /lucide.min.js nicht mehr');
-  assert.ok(patch > -1,
+  const positionsOf = (src) => scripts.flatMap((s, i) => (s.src === src ? [i] : []));
+  const bundleAt = positionsOf('/lucide.min.js');
+  const patchAt = positionsOf('/lucide-scope.js');
+  assert.ok(bundleAt.length > 0, 'index.html lädt /lucide.min.js nicht mehr');
+  assert.ok(patchAt.length > 0,
     'index.html lädt /lucide-scope.js nicht mehr - createIcons({ el }) durchsucht dann wieder '
     + 'das ganze Dokument, und zwar an allen Aufrufstellen auf einmal');
+  // Genau einmal, und das ist keine Formalie: ein zweites Bundle-Tag NACH dem
+  // Patch laedt das UMD erneut und ersetzt `window.lucide` samt gepatchtem
+  // createIcons. Reihenfolge und defer stimmten weiter, der Ausschnitt waere weg.
+  assert.deepEqual([bundleAt.length, patchAt.length], [1, 1],
+    'lucide.min.js und lucide-scope.js stehen nicht mehr genau einmal in index.html. '
+    + 'Ein zweites Bundle-Tag hinter dem Patch ueberschreibt window.lucide und damit den Patch');
+  const [bundle] = bundleAt;
+  const [patch] = patchAt;
   assert.ok(patch > bundle,
     'lucide-scope.js steht vor lucide.min.js. Es findet `window.lucide` dann noch nicht und '
     + 'steigt still aus - der Ausschnitt ist wirkungslos, ohne dass irgendwo etwas bricht');
 
-  // Beide klassisch mit `defer`: ohne defer liefe der Patch sofort beim Parsen,
-  // also vor dem deferred Bundle - derselbe stille Ausstieg.
+  // Beide rein deferred: ohne `defer` liefe der Patch sofort beim Parsen, mit
+  // `async` in unbestimmter Reihenfolge. Beides endet im selben stillen
+  // Ausstieg, weil `window.lucide` dann noch nicht da ist.
   for (const i of [bundle, patch]) {
-    assert.match(scripts[i].tag, /\bdefer\b/i,
-      `${scripts[i].src} trägt kein defer mehr - die Reihenfolge zwischen Bundle und Patch `
-      + 'ist damit nicht mehr garantiert');
+    assert.ok(isDeferred(scripts[i]),
+      `${scripts[i].src} ist nicht mehr rein deferred (defer, kein async) - die Reihenfolge `
+      + 'zwischen Bundle und Patch ist damit nicht mehr garantiert');
   }
 
-  // Module laufen zwar nach den defer-Skripten, aber untereinander in
-  // Dokumentreihenfolge: eines vor dem Patch bekäme beim ersten createIcons
-  // noch das ungepatchte Original.
+  // Nicht-async-Module und defer-Skripte teilen sich EINE Warteschlange und
+  // laufen in Dokumentreihenfolge - Module sind keine spaetere Phase. Ein Modul
+  // vor dem Patch bekaeme beim ersten createIcons noch das ungepatchte Original.
   assert.deepEqual(
     scripts.filter((s, i) => i < patch && isModule(s)).map((s) => s.src), [],
     'Diese Module stehen in index.html vor lucide-scope.js und laufen damit vor dem Patch');
 
-  // Und die klassischen Skripte davor laufen ohne defer sofort beim Parsen,
-  // lange vor dem Bundle: dort ist jeder createIcons-Aufruf ungescopt.
+  // WER LAEUFT VOR DEM PATCH? Zwei Wege, und die Tag-Position beantwortet nur
+  // den einen. Ein klassisches Skript ohne `defer` blockiert den Parser und
+  // laeuft SOFORT an seiner Stelle, also vor jedem deferred Skript - auch wenn
+  // sein Tag hinter dem Patch steht. Ein deferred Skript oder Modul haelt
+  // dagegen seinen Platz in der Warteschlange und ist nur dann zu frueh, wenn
+  // es vor dem Patch steht. Die erste Fassung filterte nur nach Position und
+  // war fuer den ersten Fall blind.
+  const runsBeforePatch = (s, i) => (!isDeferred(s) && !isModule(s)) || i < patch;
   const early = scripts
-    .filter((s, i) => i < patch && !isModule(s) && !/\bdefer\b/i.test(s.tag))
+    // Bundle und Patch selbst rufen nicht auf, sie definieren bzw. ersetzen.
+    .filter((s, i) => runsBeforePatch(s, i) && i !== bundle && i !== patch)
     .filter((s) => existsSync(new URL(`../public${s.src}`, import.meta.url)))
     .filter((s) => /createIcons/.test(read(`../public${s.src}`)));
   assert.deepEqual(early.map((s) => s.src), [],

--- a/test/test-frontend-audit.js
+++ b/test/test-frontend-audit.js
@@ -14744,3 +14744,76 @@ test('jede auf Touch ausgeblendete Karten-Aktion hat einen Weg in der Leseansich
     `der Anlege-Knopf haengt nicht mehr an "${gate[1]}" - der Guard misst dann eine `
     + 'Bedingung, die den Knopf gar nicht mehr gattert');
 });
+
+/**
+ * DER AUSSCHNITT VON `createIcons({ el })` IST GELIEHEN, NICHT EINGEBAUT.
+ *
+ * Über zweihundert Aufrufstellen übergeben `{ el }` und nehmen an, nur unter
+ * diesem Knoten werde gezeichnet. Die gebündelte Lucide-Fassung kennt den
+ * Parameter nicht - sie sucht `[data-lucide]` im ganzen Dokument, egal was man
+ * ihr übergibt. Erst `public/lucide-scope.js` biegt die Funktion um (Audit
+ * 2026-08-31, P2); ohne diese Datei ist der Parameter genau die Lüge, für die
+ * ihn beim Lesen jeder hält.
+ *
+ * Der Patch hängt an einer Reihenfolge, die man ihm nicht ansieht: er steigt
+ * still aus, wenn `window.lucide` bei seinem Lauf noch fehlt. Rutscht er vor
+ * das Bundle, verliert er sein `defer` oder fällt er ganz weg, dann fallen alle
+ * Aufrufstellen gleichzeitig auf den Volldokument-Scan zurück - ohne Fehler,
+ * ohne sichtbaren Unterschied, nur langsamer. Ein Kommentar kann das nicht
+ * halten, weil ihn die Datei, die ihn bricht, gar nicht enthält.
+ */
+test('der Lucide-Ausschnitt läuft nach dem Bundle und vor jedem Modul, das ihn braucht', () => {
+  const scope = read('../public/lucide-scope.js');
+
+  // Reichweiten-Nachweis: ohne Aufrufer prüft dieser Guard nichts.
+  const callers = walkJsFiles('../public/')
+    .filter((file) => !/lucide(\.min)?\.js$/.test(file) && !file.includes('/vendor/'))
+    .filter((file) => /createIcons\(\{\s*el/.test(read(file)));
+  assert.ok(callers.length >= 30,
+    `Nur ${callers.length} Dateien rufen createIcons({ el }) - das Muster greift nicht mehr`);
+
+  // Der Patch muss tun, was die Aufrufstellen annehmen: unter `el` bleiben.
+  assert.match(scope, /lucide\.createIcons\s*=/,
+    'lucide-scope.js biegt createIcons nicht mehr um - der el-Parameter ist dann wieder wirkungslos');
+  assert.match(scope, /\bel\.querySelectorAll\(/,
+    'lucide-scope.js sucht nicht mehr unter `el` - dann ist der Ausschnitt keiner');
+
+  const scripts = [...read('../public/index.html').matchAll(/<script\b[^>]*>/g)]
+    .map((m) => ({ tag: m[0], src: m[0].match(/\bsrc=["']([^"']+)["']/)?.[1] }))
+    .filter((s) => s.src);
+  const isModule = (s) => /\btype=["']module["']/.test(s.tag);
+
+  const bundle = scripts.findIndex((s) => s.src === '/lucide.min.js');
+  const patch = scripts.findIndex((s) => s.src === '/lucide-scope.js');
+  assert.ok(bundle > -1, 'index.html lädt /lucide.min.js nicht mehr');
+  assert.ok(patch > -1,
+    'index.html lädt /lucide-scope.js nicht mehr - createIcons({ el }) durchsucht dann wieder '
+    + 'das ganze Dokument, und zwar an allen Aufrufstellen auf einmal');
+  assert.ok(patch > bundle,
+    'lucide-scope.js steht vor lucide.min.js. Es findet `window.lucide` dann noch nicht und '
+    + 'steigt still aus - der Ausschnitt ist wirkungslos, ohne dass irgendwo etwas bricht');
+
+  // Beide klassisch mit `defer`: ohne defer liefe der Patch sofort beim Parsen,
+  // also vor dem deferred Bundle - derselbe stille Ausstieg.
+  for (const i of [bundle, patch]) {
+    assert.match(scripts[i].tag, /\bdefer\b/,
+      `${scripts[i].src} trägt kein defer mehr - die Reihenfolge zwischen Bundle und Patch `
+      + 'ist damit nicht mehr garantiert');
+  }
+
+  // Module laufen zwar nach den defer-Skripten, aber untereinander in
+  // Dokumentreihenfolge: eines vor dem Patch bekäme beim ersten createIcons
+  // noch das ungepatchte Original.
+  assert.deepEqual(
+    scripts.filter((s, i) => i < patch && isModule(s)).map((s) => s.src), [],
+    'Diese Module stehen in index.html vor lucide-scope.js und laufen damit vor dem Patch');
+
+  // Und die klassischen Skripte davor laufen ohne defer sofort beim Parsen,
+  // lange vor dem Bundle: dort ist jeder createIcons-Aufruf ungescopt.
+  const early = scripts
+    .filter((s, i) => i < patch && !isModule(s) && !/\bdefer\b/.test(s.tag))
+    .filter((s) => existsSync(new URL(`../public${s.src}`, import.meta.url)))
+    .filter((s) => /createIcons/.test(read(`../public${s.src}`)));
+  assert.deepEqual(early.map((s) => s.src), [],
+    'Diese Skripte laufen vor dem Patch und rufen createIcons - der Aufruf ist dort ungescopt');
+});

--- a/test/test-sw-precache.js
+++ b/test/test-sw-precache.js
@@ -42,6 +42,7 @@ import { readFileSync, existsSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { createContext, runInContext } from 'node:vm';
 import { posix } from 'node:path';
+import { withoutHtmlComments } from './source-text.js';
 
 const PUBLIC_DIR = fileURLToPath(new URL('../public/', import.meta.url));
 const SRC = readFileSync(new URL('../public/sw.js', import.meta.url), 'utf8');
@@ -162,9 +163,13 @@ test('jedes eager geladene Stylesheet aus index.html ist precacht', () => {
   // Nur `rel="stylesheet"` ohne `media`/`onload`-Umweg: das sind die, die den
   // ersten Render blockieren. Ein per Router nachgeladenes Seiten-CSS zählt
   // nicht - es kommt erst, wenn die Shell schon steht.
+  // Schreibungstoleranz durchgehend: sobald der Regex `<LINK REL=...>` findet,
+  // muessen die Ausschluesse `MEDIA=`/`ONLOAD=` genauso finden - sonst zaehlt ein
+  // grossgeschriebenes Print-Stylesheet als eager und der Guard verlangt es im
+  // Precache, obwohl es den ersten Render nie blockiert.
   const eager = [...html.matchAll(/<link\b[^>]*\brel=["']stylesheet["'][^>]*>/gi)]
     .map((m) => m[0])
-    .filter((tag) => !/\bmedia=/.test(tag) && !/\bonload=/.test(tag))
+    .filter((tag) => !/\bmedia=/i.test(tag) && !/\bonload=/i.test(tag))
     .map((tag) => tag.match(/\bhref=["']([^"']+)["']/)?.[1])
     .filter(Boolean);
 
@@ -187,13 +192,19 @@ test('jedes eager geladene Stylesheet aus index.html ist precacht', () => {
 // Aufrufstellen seinen Ausschnitt (siehe Dateikopf). Offline fehlte es, und die
 // App liefe sichtbar unverändert weiter, nur langsamer.
 test('jedes von index.html geladene Skript ist precacht', () => {
-  const html = readFileSync(PUBLIC_DIR + 'index.html', 'utf8');
   // `i`, weil Tagname und Attribute in HTML schreibungsegal sind: eine
   // grossgeschriebene Fassung faende der Guard sonst nicht und meldete gruen,
-  // obwohl er nichts gesehen hat (CodeQL js/bad-tag-filter).
+  // obwohl er nichts gesehen hat (CodeQL js/bad-tag-filter). Und ohne
+  // Kommentare, damit ein auskommentiertes Tag nicht als geladen zaehlt.
+  const html = withoutHtmlComments(readFileSync(PUBLIC_DIR + 'index.html', 'utf8'));
   const scripts = [...html.matchAll(/<script\b[^>]*\bsrc=["']([^"']+)["'][^>]*>/gi)]
     .map((m) => m[1])
-    .filter((src) => src.startsWith('/')); // fremde Herkunft precacht der SW nicht
+    // Ausgeschlossen wird nur echte Fremdherkunft (Schema oder protokollrelativ).
+    // Ein relatives `src="analytics.js"` ist same-origin und muss genauso
+    // precacht sein; ein Filter auf fuehrenden Slash haette es stillschweigend
+    // uebersprungen und den Guard fuer genau diesen Fall gruen gelassen.
+    .filter((src) => !/^(?:[a-z][a-z0-9+.-]*:|\/\/)/i.test(src))
+    .map((src) => (src.startsWith('/') ? src : posix.resolve('/', src)));
 
   // Reichweiten-Nachweis: findet das Muster nichts, prüft die Assertion nichts.
   assert.ok(scripts.length >= 5, `Nur ${scripts.length} Skripte gefunden - das Muster greift nicht mehr`);

--- a/test/test-sw-precache.js
+++ b/test/test-sw-precache.js
@@ -28,6 +28,10 @@
  *     Modulgraph oben sieht nur JS; CSS hängt an keinem `import`, und so lagen
  *     11 der 18 eager geladenen Stylesheets außerhalb des Precache, ohne dass
  *     eine Zeile dieser Datei das bemerken konnte
+ *   - jedes von index.html geladene Skript ist precacht. Der Modulgraph oben
+ *     beginnt erst bei den Einträgen der Precache-Liste; ein Skript, das dort
+ *     fehlt, wird von keinem `import` erreicht und fällt deshalb durch beide
+ *     Netze
  *   - Precache-Bucket und fetch-Routing stimmen überein (ein im SHELL_CACHE
  *     abgelegtes Modul darf nicht aus dem PAGES_CACHE bedient werden)
  *   - keine Doppeleinträge zwischen den Listen
@@ -173,6 +177,30 @@ test('jedes eager geladene Stylesheet aus index.html ist precacht', () => {
     missing, [],
     'Diese Stylesheets lädt index.html eager, der Service Worker precacht sie aber nicht. '
     + `Der allererste Offline-Start rendert damit ungestylt:\n  ${missing.join('\n  ')}`,
+  );
+});
+
+// Dieselbe Lücke wie oben, nur für JS: der Modulgraph-Test folgt `import`-Kanten
+// ab der Precache-Liste und sieht deshalb nie, was index.html per <script> lädt
+// und die Liste vergisst. `lucide-scope.js` ist genau so ein Fall - es hängt an
+// keinem Import, sondern gibt `createIcons({ el })` an über zweihundert
+// Aufrufstellen seinen Ausschnitt (siehe Dateikopf). Offline fehlte es, und die
+// App liefe sichtbar unverändert weiter, nur langsamer.
+test('jedes von index.html geladene Skript ist precacht', () => {
+  const html = readFileSync(PUBLIC_DIR + 'index.html', 'utf8');
+  const scripts = [...html.matchAll(/<script\b[^>]*\bsrc=["']([^"']+)["'][^>]*>/g)]
+    .map((m) => m[1])
+    .filter((src) => src.startsWith('/')); // fremde Herkunft precacht der SW nicht
+
+  // Reichweiten-Nachweis: findet das Muster nichts, prüft die Assertion nichts.
+  assert.ok(scripts.length >= 5, `Nur ${scripts.length} Skripte gefunden - das Muster greift nicht mehr`);
+
+  const shell = new Set(APP_SHELL);
+  const missing = scripts.filter((src) => !shell.has(src));
+  assert.deepEqual(
+    missing, [],
+    'Diese Skripte lädt index.html, der Service Worker precacht sie aber nicht. '
+    + `Offline fehlen sie ersatzlos:\n  ${missing.join('\n  ')}`,
   );
 });
 

--- a/test/test-sw-precache.js
+++ b/test/test-sw-precache.js
@@ -162,7 +162,7 @@ test('jedes eager geladene Stylesheet aus index.html ist precacht', () => {
   // Nur `rel="stylesheet"` ohne `media`/`onload`-Umweg: das sind die, die den
   // ersten Render blockieren. Ein per Router nachgeladenes Seiten-CSS zählt
   // nicht - es kommt erst, wenn die Shell schon steht.
-  const eager = [...html.matchAll(/<link\b[^>]*\brel=["']stylesheet["'][^>]*>/g)]
+  const eager = [...html.matchAll(/<link\b[^>]*\brel=["']stylesheet["'][^>]*>/gi)]
     .map((m) => m[0])
     .filter((tag) => !/\bmedia=/.test(tag) && !/\bonload=/.test(tag))
     .map((tag) => tag.match(/\bhref=["']([^"']+)["']/)?.[1])
@@ -188,7 +188,10 @@ test('jedes eager geladene Stylesheet aus index.html ist precacht', () => {
 // App liefe sichtbar unverändert weiter, nur langsamer.
 test('jedes von index.html geladene Skript ist precacht', () => {
   const html = readFileSync(PUBLIC_DIR + 'index.html', 'utf8');
-  const scripts = [...html.matchAll(/<script\b[^>]*\bsrc=["']([^"']+)["'][^>]*>/g)]
+  // `i`, weil Tagname und Attribute in HTML schreibungsegal sind: eine
+  // grossgeschriebene Fassung faende der Guard sonst nicht und meldete gruen,
+  // obwohl er nichts gesehen hat (CodeQL js/bad-tag-filter).
+  const scripts = [...html.matchAll(/<script\b[^>]*\bsrc=["']([^"']+)["'][^>]*>/gi)]
     .map((m) => m[1])
     .filter((src) => src.startsWith('/')); // fremde Herkunft precacht der SW nicht
 

--- a/test/test-sw-precache.js
+++ b/test/test-sw-precache.js
@@ -163,14 +163,17 @@ test('jedes eager geladene Stylesheet aus index.html ist precacht', () => {
   // Nur `rel="stylesheet"` ohne `media`/`onload`-Umweg: das sind die, die den
   // ersten Render blockieren. Ein per Router nachgeladenes Seiten-CSS zählt
   // nicht - es kommt erst, wenn die Shell schon steht.
-  // Schreibungstoleranz durchgehend: sobald der Regex `<LINK REL=...>` findet,
-  // muessen die Ausschluesse `MEDIA=`/`ONLOAD=` genauso finden - sonst zaehlt ein
-  // grossgeschriebenes Print-Stylesheet als eager und der Guard verlangt es im
-  // Precache, obwohl es den ersten Render nie blockiert.
+  // Schreibungstoleranz durchgehend, und "durchgehend" heisst JEDER Schritt.
+  // Sobald der Regex `<LINK REL=...>` findet, muessen die Ausschluesse `MEDIA=`
+  // /`ONLOAD=` genauso finden - sonst zaehlt ein grossgeschriebenes
+  // Print-Stylesheet als eager. Und `HREF=` muss es auch: ein Treffer, dessen
+  // Adresse nicht gelesen wird, faellt hier als `undefined` durch `filter(Boolean)`
+  // und wird nie gegen APP_SHELL geprueft - der Guard verliert ihn lautlos,
+  // waehrend die Reichweiten-Schwelle darunter weiter erfuellt ist.
   const eager = [...html.matchAll(/<link\b[^>]*\brel=["']stylesheet["'][^>]*>/gi)]
     .map((m) => m[0])
     .filter((tag) => !/\bmedia=/i.test(tag) && !/\bonload=/i.test(tag))
-    .map((tag) => tag.match(/\bhref=["']([^"']+)["']/)?.[1])
+    .map((tag) => tag.match(/\bhref=["']([^"']+)["']/i)?.[1])
     .filter(Boolean);
 
   // Reichweiten-Nachweis: findet das Muster nichts, prüft die Assertion nichts.


### PR DESCRIPTION
## Summary

The premise this task started from was out of date, and that turned out to be the finding.

`createIcons({ el })` **does** scope now. Since 2e64ee74 (audit 2026-08-31) `public/lucide-scope.js` rewrites the function: with `el` it only replaces below `el`, without `el` the original runs. The 219 call sites across 56 files are therefore honest, and **none of them changed here**. Stripping the parameter or rewriting them onto `createElement()` per icon would have made things worse, not better.

## The two comments that still said otherwise

Both claimed `createIcons` knows no scope and rescans the whole document every time. The finding had inverted without anyone catching up: whoever read them believed in a *missing* boundary that exists, and would have removed the parameter on the next cleanup. That would also have turned two existing guards red. `test-frontend-audit.js` requires `window.lucide?.createIcons({ el: output })` verbatim for admin-api.js, and the "render functions with multiple callers materialise their own icons" guard names `createIcons({ el: ... })` as the fix in its own failure message.

Each comment keeps its conclusion and loses only its dead reasoning:

- **`public/components/quick-links-manager.js`** - the reason for returning DOM instead of a string is no longer the document scan, but the second obligation the placeholder route puts on the caller, which fails exactly when a tile is built outside the usual render path (#668).
- **`public/utils/lucide-icons.js`** - `createElement` is still the right choice, now because of the placeholder round-trip rather than the 120 document passes. The old arithmetic stays alongside as history, so the question does not get asked a third time.

## Two guards, because the scope is borrowed, not built in

The patch bails out silently when `window.lucide` is not there yet on its run. If it slips before the bundle in `index.html`, loses its `defer`, drops out of the service worker precache or disappears entirely, then all 219 calls fall back to the full-document scan at once: no error, no visible difference, just slower. A comment cannot hold that, because the file that breaks it does not contain the comment.

- **`test/test-frontend-audit.js`** - order bundle, then patch, then modules; `defer` on both; plus the scoping core inside the patch itself. Counter-checked with five breakage scenarios, each red for its own reason (removed from index.html, moved before the bundle, `defer` stripped, a module hoisted above it, the scoping core replaced by a document-wide query).
- **`test/test-sw-precache.js`** - the module-graph test there follows only `import` edges and never saw a `<script>` without an importer. Without this second guard the first one would be green and the thing broken offline regardless.

## Changes

- `public/components/quick-links-manager.js` - comment corrected
- `public/utils/lucide-icons.js` - comment corrected
- `test/test-frontend-audit.js` - new guard on the patch's load order
- `test/test-sw-precache.js` - new guard extending the stylesheet parity rule to scripts

## Checklist

- [x] Full `npm test` passes: 235 suites, exit 0, no failures. Individually verified beforehand: `test:frontend-audit` (337 tests), `test:sw-precache`, `test:lucide-icons`, `test:quick-links`, `test:module-icon-size`, `test:layer-boundary`, `test:typography`.
- [x] Follows CONTRIBUTING.md conventions
- [x] No new frontend dependencies
- [x] No UI strings touched (comments and tests only)
- [x] No CHANGELOG entry: nothing user-facing changes. The diff under `public/` is comment lines only.
