### PR TITLE
fix(pwa): invalidate same-version application caches

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -90,5 +90,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            APP_BUILD_REVISION=${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max,ignore-error=true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A same-version deployment now invalidates the installed PWA shell.** The served service worker
+  receives a build-specific revision, so acceptance builds and rebuilt images no longer reuse an
+  older cache merely because the application version has not changed.
+
 - **An `allowScripts` pin no longer points at a version that is not installed.** The field names
   every package allowed to run install scripts, with an exact version, because the permission
   applies to the reviewed build rather than to the name. Dependabot raises the dependency and the

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,11 +22,6 @@ RUN npm ci --omit=dev
 # ---- Runtime stage ----
 FROM node:24-slim
 
-# Die Build-Revision kommt aus dem unveränderlichen Git-Commit des Build-Jobs.
-# Sie ist kein Installationswert und wird deshalb nicht über .env gesetzt.
-ARG APP_BUILD_REVISION
-ENV APP_BUILD_REVISION=${APP_BUILD_REVISION}
-
 RUN apt-get update && apt-get install -y \
     gosu \
     && rm -rf /var/lib/apt/lists/*
@@ -52,6 +47,12 @@ ENV BACKUP_DIR=/backups
 # Entrypoint: korrigiert Volume-Permissions und startet als node-User
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
+
+# Die Build-Revision kommt aus dem unveränderlichen Git-Commit des Build-Jobs.
+# Sie ist kein Installationswert und wird deshalb nicht über .env gesetzt. Erst
+# nach den Dateisystem-Layern setzen, damit ein neuer Commit deren Cache behält.
+ARG APP_BUILD_REVISION
+ENV APP_BUILD_REVISION=${APP_BUILD_REVISION}
 
 EXPOSE 3000
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,11 @@ RUN npm ci --omit=dev
 # ---- Runtime stage ----
 FROM node:24-slim
 
+# Die Build-Revision kommt aus dem unveränderlichen Git-Commit des Build-Jobs.
+# Sie ist kein Installationswert und wird deshalb nicht über .env gesetzt.
+ARG APP_BUILD_REVISION
+ENV APP_BUILD_REVISION=${APP_BUILD_REVISION}
+
 RUN apt-get update && apt-get install -y \
     gosu \
     && rm -rf /var/lib/apt/lists/*

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "test:i18n": "node --test test/test-i18n.js",
     "test:i18n-plural": "node --test test/test-i18n-plural.js",
     "test:lang-init": "node --test test/test-lang-init.js",
-    "test:sw-api-cache": "node --test test/test-sw-api-cache.js",
+    "test:sw-api-cache": "node --test test/test-sw-api-cache.js test/test-service-worker-build-revision.js",
     "test:sw-precache": "node --test test/test-sw-precache.js",
     "test:modal-utils": "node --loader ./test/test-browser-loader.mjs test/test-modal-utils.js",
     "test:popover-menu": "node --loader ./test/test-browser-loader.mjs --test test/test-popover-menu.js",

--- a/public/sw.js
+++ b/public/sw.js
@@ -17,14 +17,16 @@
  *   → bypassCacheUntil (in-memory + Cache API für SW-Restart-Robustheit)
  */
 
-const APP_RELEASE   = '2.62.0';
-const SHELL_CACHE   = `yuvomi-shell-${APP_RELEASE}`;
-const PAGES_CACHE   = `yuvomi-pages-${APP_RELEASE}`;
-const LOCALES_CACHE = `yuvomi-locales-${APP_RELEASE}`;
-const ASSETS_CACHE  = `yuvomi-assets-${APP_RELEASE}`;
+const APP_RELEASE        = '2.62.0';
+const APP_BUILD_REVISION = '__YUVOMI_BUILD_REVISION__';
+const CACHE_RELEASE      = `${APP_RELEASE}-${APP_BUILD_REVISION}`;
+const SHELL_CACHE        = `yuvomi-shell-${CACHE_RELEASE}`;
+const PAGES_CACHE        = `yuvomi-pages-${CACHE_RELEASE}`;
+const LOCALES_CACHE      = `yuvomi-locales-${CACHE_RELEASE}`;
+const ASSETS_CACHE       = `yuvomi-assets-${CACHE_RELEASE}`;
 // API-Cache bewusst NICHT in ALL_CACHES: er wird bei jedem SW-Update neu benannt
 // (Version im Namen) und bei Logout/Session-Ende gezielt geleert.
-const API_CACHE     = `yuvomi-api-${APP_RELEASE}`;
+const API_CACHE     = `yuvomi-api-${CACHE_RELEASE}`;
 const BYPASS_CACHE  = 'yuvomi-bypass-flag';
 const ALL_CACHES    = [SHELL_CACHE, PAGES_CACHE, LOCALES_CACHE, ASSETS_CACHE];
 

--- a/server/index.js
+++ b/server/index.js
@@ -9,7 +9,7 @@ import helmet from 'helmet';
 import compression from 'compression';
 import rateLimit from 'express-rate-limit';
 import path from 'path';
-import { readFileSync } from 'node:fs';
+import { readFileSync, statSync } from 'node:fs';
 import { createLogger } from './logger.js';
 import * as db from './db.js';
 import { router as authRouter, sessionMiddleware, requireAuth, requireAdmin, isPasswordLoginEnabled } from './auth.js';
@@ -86,13 +86,29 @@ const logYuvomi = createLogger('Yuvomi');
 const { version: APP_VERSION } = JSON.parse(
   readFileSync(new URL('../package.json', import.meta.url), 'utf-8')
 );
-const SERVICE_WORKER_RESPONSE = buildServiceWorkerResponse(
-  readFileSync(new URL('../public/sw.js', import.meta.url), 'utf-8'),
-  {
-    appVersion: APP_VERSION,
-    buildRevision: process.env.APP_BUILD_REVISION,
-  },
-);
+const SERVICE_WORKER_PATH = new URL('../public/sw.js', import.meta.url);
+const SERVICE_WORKER_OPTIONS = {
+  appVersion: APP_VERSION,
+  buildRevision: process.env.APP_BUILD_REVISION,
+};
+let serviceWorkerMtimeMs;
+let serviceWorkerResponse;
+
+function getServiceWorkerResponse() {
+  const mtimeMs = statSync(SERVICE_WORKER_PATH).mtimeMs;
+  if (serviceWorkerMtimeMs !== mtimeMs) {
+    serviceWorkerResponse = buildServiceWorkerResponse(
+      readFileSync(SERVICE_WORKER_PATH, 'utf-8'),
+      SERVICE_WORKER_OPTIONS,
+    );
+    serviceWorkerMtimeMs = mtimeMs;
+  }
+  return serviceWorkerResponse;
+}
+
+// Das prüft die Build-Revision schon beim Start und liefert in der Entwicklung
+// nach einer sw.js-Änderung dennoch die neue Quelle ohne manuellen Neustart.
+getServiceWorkerResponse();
 const DEFAULT_APP_NAME = 'Yuvomi';
 
 const app  = express();
@@ -204,14 +220,16 @@ if (process.env.NODE_ENV === 'production' && process.env.ENABLE_API_DOCS !== 'tr
 // HTML + JS + CSS: no-cache (Browser revalidiert via ETag/304, kein stale Content
 //   nach Deployment). Bei unverändertem File → 304 Not Modified ohne Übertragung.
 // Bilder + Icons + Fonts: 30 Tage immutable (ändern sich praktisch nie).
-// manifest.json + sw.js: no-cache (PWA-Updates sollen sofort greifen).
+// manifest.json: no-cache (PWA-Updates sollen sofort greifen).
+// /sw.js wird direkt darunter als no-store-Antwort gerendert.
 // --------------------------------------------------------
 app.get('/sw.js', (_req, res) => {
-  res.type(SERVICE_WORKER_RESPONSE.contentType);
-  res.setHeader('Cache-Control', SERVICE_WORKER_RESPONSE.cacheControl);
-  res.setHeader('CDN-Cache-Control', SERVICE_WORKER_RESPONSE.cdnCacheControl);
-  res.setHeader('Cloudflare-CDN-Cache-Control', SERVICE_WORKER_RESPONSE.cloudflareCdnCacheControl);
-  res.send(SERVICE_WORKER_RESPONSE.body);
+  const response = getServiceWorkerResponse();
+  res.type(response.contentType);
+  res.setHeader('Cache-Control', response.cacheControl);
+  res.setHeader('CDN-Cache-Control', response.cdnCacheControl);
+  res.setHeader('Cloudflare-CDN-Cache-Control', response.cloudflareCdnCacheControl);
+  res.send(response.body);
 });
 
 app.use(express.static(path.join(import.meta.dirname, '..', 'public'), {
@@ -230,7 +248,7 @@ app.use(express.static(path.join(import.meta.dirname, '..', 'public'), {
     } else if (['.png', '.jpg', '.jpeg', '.ico', '.svg', '.webp', '.woff2', '.woff'].includes(ext)) {
       res.setHeader('Cache-Control', 'public, max-age=2592000, immutable'); // 30 Tage
     } else {
-      // HTML, JS, CSS, JSON, manifest, sw - immer revalidieren
+      // HTML, JS, CSS, JSON und manifest immer revalidieren.
       res.setHeader('Cache-Control', 'no-cache, must-revalidate');
     }
     // manifest.json: korrekter MIME-Type für PWA-Erkennung durch Chrome/Android

--- a/server/index.js
+++ b/server/index.js
@@ -9,7 +9,7 @@ import helmet from 'helmet';
 import compression from 'compression';
 import rateLimit from 'express-rate-limit';
 import path from 'path';
-import { readFileSync, statSync } from 'node:fs';
+import { readFileSync } from 'node:fs';
 import { createLogger } from './logger.js';
 import * as db from './db.js';
 import { router as authRouter, sessionMiddleware, requireAuth, requireAdmin, isPasswordLoginEnabled } from './auth.js';
@@ -77,7 +77,7 @@ import scheduleRouter from './routes/schedule.js';
 import { moduleForPath, requiredAccess, tokenAllows } from './scopes.js';
 import { moduleAccessVerdict, MODULE_ACCESS_DENIED, MODULE_ACCESS_READ_ONLY } from './permissions.js';
 import { BODY_LIMIT, MAX_UPLOAD_BYTES, MAX_UPLOAD_MB } from './utils/upload-limit.js';
-import { buildServiceWorkerResponse } from './utils/service-worker.js';
+import { createServiceWorkerResponseLoader } from './utils/service-worker.js';
 
 const log     = createLogger('Server');
 const logSync = createLogger('Sync');
@@ -91,20 +91,10 @@ const SERVICE_WORKER_OPTIONS = {
   appVersion: APP_VERSION,
   buildRevision: process.env.APP_BUILD_REVISION,
 };
-let serviceWorkerMtimeMs;
-let serviceWorkerResponse;
-
-function getServiceWorkerResponse() {
-  const mtimeMs = statSync(SERVICE_WORKER_PATH).mtimeMs;
-  if (serviceWorkerMtimeMs !== mtimeMs) {
-    serviceWorkerResponse = buildServiceWorkerResponse(
-      readFileSync(SERVICE_WORKER_PATH, 'utf-8'),
-      SERVICE_WORKER_OPTIONS,
-    );
-    serviceWorkerMtimeMs = mtimeMs;
-  }
-  return serviceWorkerResponse;
-}
+const getServiceWorkerResponse = createServiceWorkerResponseLoader(
+  SERVICE_WORKER_PATH,
+  SERVICE_WORKER_OPTIONS,
+);
 
 // Das prüft die Build-Revision schon beim Start und liefert in der Entwicklung
 // nach einer sw.js-Änderung dennoch die neue Quelle ohne manuellen Neustart.

--- a/server/index.js
+++ b/server/index.js
@@ -77,6 +77,7 @@ import scheduleRouter from './routes/schedule.js';
 import { moduleForPath, requiredAccess, tokenAllows } from './scopes.js';
 import { moduleAccessVerdict, MODULE_ACCESS_DENIED, MODULE_ACCESS_READ_ONLY } from './permissions.js';
 import { BODY_LIMIT, MAX_UPLOAD_BYTES, MAX_UPLOAD_MB } from './utils/upload-limit.js';
+import { buildServiceWorkerResponse } from './utils/service-worker.js';
 
 const log     = createLogger('Server');
 const logSync = createLogger('Sync');
@@ -84,6 +85,13 @@ const logYuvomi = createLogger('Yuvomi');
 
 const { version: APP_VERSION } = JSON.parse(
   readFileSync(new URL('../package.json', import.meta.url), 'utf-8')
+);
+const SERVICE_WORKER_RESPONSE = buildServiceWorkerResponse(
+  readFileSync(new URL('../public/sw.js', import.meta.url), 'utf-8'),
+  {
+    appVersion: APP_VERSION,
+    buildRevision: process.env.APP_BUILD_REVISION,
+  },
 );
 const DEFAULT_APP_NAME = 'Yuvomi';
 
@@ -198,6 +206,14 @@ if (process.env.NODE_ENV === 'production' && process.env.ENABLE_API_DOCS !== 'tr
 // Bilder + Icons + Fonts: 30 Tage immutable (ändern sich praktisch nie).
 // manifest.json + sw.js: no-cache (PWA-Updates sollen sofort greifen).
 // --------------------------------------------------------
+app.get('/sw.js', (_req, res) => {
+  res.type(SERVICE_WORKER_RESPONSE.contentType);
+  res.setHeader('Cache-Control', SERVICE_WORKER_RESPONSE.cacheControl);
+  res.setHeader('CDN-Cache-Control', SERVICE_WORKER_RESPONSE.cdnCacheControl);
+  res.setHeader('Cloudflare-CDN-Cache-Control', SERVICE_WORKER_RESPONSE.cloudflareCdnCacheControl);
+  res.send(SERVICE_WORKER_RESPONSE.body);
+});
+
 app.use(express.static(path.join(import.meta.dirname, '..', 'public'), {
   etag: true,
   lastModified: true,

--- a/server/utils/service-worker.js
+++ b/server/utils/service-worker.js
@@ -3,6 +3,8 @@
  * Zweck: Eine deployment-spezifische, scriptsichere Cache-Revision in sw.js einsetzen.
  */
 
+import { readFileSync, statSync } from 'node:fs';
+
 const BUILD_REVISION_TOKEN = '__YUVOMI_BUILD_REVISION__';
 const SAFE_BUILD_REVISION = /^[A-Za-z0-9._-]{1,80}$/;
 
@@ -24,5 +26,22 @@ export function buildServiceWorkerResponse(source, { appVersion, buildRevision }
     cacheControl: 'no-store, max-age=0',
     cdnCacheControl: 'no-store',
     cloudflareCdnCacheControl: 'no-store',
+  };
+}
+
+export function createServiceWorkerResponseLoader(sourcePath, options) {
+  let cachedMtimeMs;
+  let cachedResponse;
+
+  return function loadServiceWorkerResponse() {
+    const mtimeMs = statSync(sourcePath).mtimeMs;
+    if (cachedMtimeMs !== mtimeMs) {
+      cachedResponse = buildServiceWorkerResponse(
+        readFileSync(sourcePath, 'utf8'),
+        options,
+      );
+      cachedMtimeMs = mtimeMs;
+    }
+    return cachedResponse;
   };
 }

--- a/server/utils/service-worker.js
+++ b/server/utils/service-worker.js
@@ -1,6 +1,6 @@
 /**
- * Module: Service worker response rendering
- * Purpose: Inject a deployment-specific, script-safe cache revision into sw.js.
+ * Modul: Service-Worker-Antwort erzeugen
+ * Zweck: Eine deployment-spezifische, scriptsichere Cache-Revision in sw.js einsetzen.
  */
 
 const BUILD_REVISION_TOKEN = '__YUVOMI_BUILD_REVISION__';
@@ -9,14 +9,17 @@ const SAFE_BUILD_REVISION = /^[A-Za-z0-9._-]{1,80}$/;
 export function renderServiceWorkerSource(source, buildRevision) {
   const revision = String(buildRevision || '').trim();
   if (!SAFE_BUILD_REVISION.test(revision)) {
-    throw new Error('Invalid service worker build revision.');
+    throw new Error(
+      `[SW] APP_BUILD_REVISION must match /^[A-Za-z0-9._-]{1,80}$/ (got ${JSON.stringify(revision)}).`,
+    );
   }
   return String(source).replaceAll(BUILD_REVISION_TOKEN, revision);
 }
 
 export function buildServiceWorkerResponse(source, { appVersion, buildRevision } = {}) {
+  const revision = String(buildRevision || '').trim() || appVersion;
   return {
-    body: renderServiceWorkerSource(source, buildRevision || appVersion),
+    body: renderServiceWorkerSource(source, revision),
     contentType: 'text/javascript; charset=utf-8',
     cacheControl: 'no-store, max-age=0',
     cdnCacheControl: 'no-store',

--- a/server/utils/service-worker.js
+++ b/server/utils/service-worker.js
@@ -1,0 +1,25 @@
+/**
+ * Module: Service worker response rendering
+ * Purpose: Inject a deployment-specific, script-safe cache revision into sw.js.
+ */
+
+const BUILD_REVISION_TOKEN = '__YUVOMI_BUILD_REVISION__';
+const SAFE_BUILD_REVISION = /^[A-Za-z0-9._-]{1,80}$/;
+
+export function renderServiceWorkerSource(source, buildRevision) {
+  const revision = String(buildRevision || '').trim();
+  if (!SAFE_BUILD_REVISION.test(revision)) {
+    throw new Error('Invalid service worker build revision.');
+  }
+  return String(source).replaceAll(BUILD_REVISION_TOKEN, revision);
+}
+
+export function buildServiceWorkerResponse(source, { appVersion, buildRevision } = {}) {
+  return {
+    body: renderServiceWorkerSource(source, buildRevision || appVersion),
+    contentType: 'text/javascript; charset=utf-8',
+    cacheControl: 'no-store, max-age=0',
+    cdnCacheControl: 'no-store',
+    cloudflareCdnCacheControl: 'no-store',
+  };
+}

--- a/test/test-docker-publish.js
+++ b/test/test-docker-publish.js
@@ -17,10 +17,22 @@ test('Docker publish treats the remote build cache as an optional optimization',
 });
 
 test('Docker publishing injects the immutable Git revision into the image', () => {
-  assert.match(dockerfile, /^ARG APP_BUILD_REVISION$/m);
-  assert.match(dockerfile, /^ENV APP_BUILD_REVISION=\$\{APP_BUILD_REVISION\}$/m);
+  const runtimeStage = dockerfile.slice(dockerfile.lastIndexOf('\nFROM ') + 1);
+  assert.match(runtimeStage, /^ARG APP_BUILD_REVISION$/m);
+  assert.match(runtimeStage, /^ENV APP_BUILD_REVISION=\$\{APP_BUILD_REVISION\}$/m);
+  assert.ok(
+    runtimeStage.indexOf('ARG APP_BUILD_REVISION') > runtimeStage.lastIndexOf('\nRUN ')
+      && runtimeStage.indexOf('ARG APP_BUILD_REVISION') > runtimeStage.lastIndexOf('\nCOPY '),
+    'The per-commit revision must not invalidate stable runtime filesystem layers',
+  );
+
+  const buildStepStart = workflow.indexOf('      - name: Build and push');
+  assert.notEqual(buildStepStart, -1, 'The Docker build-and-push step must exist');
+  const nextStep = workflow.indexOf('\n      - name:', buildStepStart + 1);
+  const buildStep = workflow.slice(buildStepStart, nextStep === -1 ? undefined : nextStep);
+  assert.match(buildStep, /uses: docker\/build-push-action@v7/);
   assert.match(
-    workflow,
+    buildStep,
     /build-args:\s*\|\s*APP_BUILD_REVISION=\$\{\{ github\.sha \}\}/,
   );
 });

--- a/test/test-docker-publish.js
+++ b/test/test-docker-publish.js
@@ -42,7 +42,7 @@ test('Docker publishing injects the immutable Git revision into the image', () =
   );
 
   const buildStep = namedWorkflowStep(workflow, 'Build and push');
-  assert.match(buildStep, /uses: docker\/build-push-action@v7/);
+  assert.match(buildStep, /uses: docker\/build-push-action@/);
   assert.match(
     buildStep,
     /build-args:\s*\|\s*APP_BUILD_REVISION=\$\{\{ github\.sha \}\}/,

--- a/test/test-docker-publish.js
+++ b/test/test-docker-publish.js
@@ -6,11 +6,21 @@ const workflow = readFileSync(
   new URL('../.github/workflows/docker-publish.yml', import.meta.url),
   'utf8'
 );
+const dockerfile = readFileSync(new URL('../Dockerfile', import.meta.url), 'utf8');
 
 test('Docker publish treats the remote build cache as an optional optimization', () => {
   assert.match(
     workflow,
     /cache-to:\s*type=gha,mode=max,ignore-error=true/,
     'A failed GitHub Actions cache export must not fail an otherwise successful image push'
+  );
+});
+
+test('Docker publishing injects the immutable Git revision into the image', () => {
+  assert.match(dockerfile, /^ARG APP_BUILD_REVISION$/m);
+  assert.match(dockerfile, /^ENV APP_BUILD_REVISION=\$\{APP_BUILD_REVISION\}$/m);
+  assert.match(
+    workflow,
+    /build-args:\s*\|\s*APP_BUILD_REVISION=\$\{\{ github\.sha \}\}/,
   );
 });

--- a/test/test-docker-publish.js
+++ b/test/test-docker-publish.js
@@ -8,6 +8,19 @@ const workflow = readFileSync(
 );
 const dockerfile = readFileSync(new URL('../Dockerfile', import.meta.url), 'utf8');
 
+function namedWorkflowStep(source, name) {
+  const lines = source.split('\n');
+  const start = lines.findIndex((line) => line === `      - name: ${name}`);
+  assert.notEqual(start, -1, `The ${name} workflow step must exist`);
+  let end = start + 1;
+  while (end < lines.length) {
+    const line = lines[end];
+    if (line.trim() && /^ {0,6}\S/.test(line)) break;
+    end += 1;
+  }
+  return lines.slice(start, end).join('\n');
+}
+
 test('Docker publish treats the remote build cache as an optional optimization', () => {
   assert.match(
     workflow,
@@ -18,18 +31,17 @@ test('Docker publish treats the remote build cache as an optional optimization',
 
 test('Docker publishing injects the immutable Git revision into the image', () => {
   const runtimeStage = dockerfile.slice(dockerfile.lastIndexOf('\nFROM ') + 1);
-  assert.match(runtimeStage, /^ARG APP_BUILD_REVISION$/m);
-  assert.match(runtimeStage, /^ENV APP_BUILD_REVISION=\$\{APP_BUILD_REVISION\}$/m);
+  const revisionArg = runtimeStage.indexOf('\nARG APP_BUILD_REVISION\n');
+  const revisionEnv = runtimeStage.indexOf('\nENV APP_BUILD_REVISION=${APP_BUILD_REVISION}\n');
+  assert.notEqual(revisionArg, -1, 'The runtime stage must declare APP_BUILD_REVISION');
+  assert.ok(revisionEnv > revisionArg, 'ARG APP_BUILD_REVISION must precede the ENV that expands it');
   assert.ok(
-    runtimeStage.indexOf('ARG APP_BUILD_REVISION') > runtimeStage.lastIndexOf('\nRUN ')
-      && runtimeStage.indexOf('ARG APP_BUILD_REVISION') > runtimeStage.lastIndexOf('\nCOPY '),
+    revisionArg > runtimeStage.lastIndexOf('\nRUN ')
+      && revisionArg > runtimeStage.lastIndexOf('\nCOPY '),
     'The per-commit revision must not invalidate stable runtime filesystem layers',
   );
 
-  const buildStepStart = workflow.indexOf('      - name: Build and push');
-  assert.notEqual(buildStepStart, -1, 'The Docker build-and-push step must exist');
-  const nextStep = workflow.indexOf('\n      - name:', buildStepStart + 1);
-  const buildStep = workflow.slice(buildStepStart, nextStep === -1 ? undefined : nextStep);
+  const buildStep = namedWorkflowStep(workflow, 'Build and push');
   assert.match(buildStep, /uses: docker\/build-push-action@v7/);
   assert.match(
     buildStep,

--- a/test/test-frontend-audit.js
+++ b/test/test-frontend-audit.js
@@ -400,14 +400,17 @@ test('service worker precaches every supported locale file', () => {
   assert.deepEqual(precachedLocales, supportedLocales.sort(), 'Service worker APP_LOCALES must precache every supported locale');
 });
 
-test('service worker release caches track package version and include the early locale bootstrap', () => {
+test('service worker release caches track package and deployment revisions and include the early locale bootstrap', () => {
   const pkg = JSON.parse(read('../package.json'));
   const sw = read('../public/sw.js');
   const release = sw.match(/const APP_RELEASE\s*=\s*['"]([^'"]+)['"]/)?.[1];
 
   assert.equal(release, pkg.version, 'Service worker APP_RELEASE must match package.json');
-  assert.match(sw, /const SHELL_CACHE\s*=\s*`yuvomi-shell-\$\{APP_RELEASE\}`/);
-  assert.match(sw, /const PAGES_CACHE\s*=\s*`yuvomi-pages-\$\{APP_RELEASE\}`/);
+  assert.match(sw, /const APP_BUILD_REVISION\s*=\s*['"]__YUVOMI_BUILD_REVISION__['"]/);
+  assert.match(sw, /const CACHE_RELEASE\s*=\s*`\$\{APP_RELEASE\}-\$\{APP_BUILD_REVISION\}`/);
+  for (const cache of ['shell', 'pages', 'locales', 'assets', 'api']) {
+    assert.match(sw, new RegExp(`yuvomi-${cache}-\\$\\{CACHE_RELEASE\\}`));
+  }
   assert.match(sw, /['"]\/lang-init\.js['"]/, 'early lang/dir bootstrap must be available offline');
 });
 

--- a/test/test-installer-schema.js
+++ b/test/test-installer-schema.js
@@ -940,3 +940,73 @@ test('der Dokument-Mount zielt auf DOCUMENT_STORAGE_LOCAL_PATH, nie auf einen fe
     'Der Host-Ordner wird auf ein festes Ziel gemountet, während die App den konfigurierten '
     + `Pfad benutzt:\n${offenders.join('\n')}`);
 });
+
+// ── Regel-Guard: gelesene Env-Variable ⇄ .env.example ───────────────────────
+//
+// Die dritte Prüfrichtung liest von außen nach innen: eine Variable, die sowohl
+// in .env.example als auch im ENV_SCHEMA fehlt, wäre für die Guards darüber
+// unsichtbar. Jede literal gelesene Laufzeitvariable muss deshalb dokumentiert
+// sein oder hier mit Grund bewusst ausgenommen werden.
+
+const INTENTIONALLY_UNDOCUMENTED = {
+  APP_BUILD_REVISION:
+    'Internal build revision injected by deployment infrastructure; not an installer or household setting.',
+  OIKOS_INSTALLER_ROOT:
+    'Interner Pfad des Installer-Prozesses (tools/installer/install-server.js), kein '
+    + 'Deployment-Wert. Er beschreibt, wo der Installer selbst liegt, waehrend .env.example '
+    + 'die Variablen der fertigen Installation dokumentiert - dort waere er eine Zeile, die '
+    + 'niemand setzen darf.',
+};
+
+/** Alle literal gelesenen Env-Namen aus Laufzeitcode, als Map Name → erste Fundstelle. */
+function literalEnvReads() {
+  const roots = ['server', 'tools'];
+  const found = new Map();
+  const walk = (dir) => {
+    for (const entry of readdirSync(new URL(`../${dir}`, import.meta.url), { withFileTypes: true })) {
+      if (entry.name === 'node_modules') continue;
+      const rel = `${dir}/${entry.name}`;
+      if (entry.isDirectory()) { walk(rel); continue; }
+      if (!entry.name.endsWith('.js')) continue;
+      const src = readFileSync(new URL(`../${rel}`, import.meta.url), 'utf8');
+      const hits = [
+        ...src.matchAll(/process\.env\.([A-Z][A-Z0-9_]*)/g),
+        ...src.matchAll(/process\.env\[\s*['"]([A-Z][A-Z0-9_]*)['"]\s*\]/g),
+      ];
+      for (const m of hits) if (!found.has(m[1])) found.set(m[1], rel);
+    }
+  };
+  for (const root of roots) walk(root);
+  return found;
+}
+
+test('jede zur Laufzeit gelesene Env-Variable ist in .env.example dokumentiert', () => {
+  const documented = new Set(documentedKeys());
+  const undocumented = [...literalEnvReads()]
+    .filter(([key]) => !documented.has(key) && !(key in INTENTIONALLY_UNDOCUMENTED))
+    .map(([key, file]) => `${key} (${file})`)
+    .sort();
+  assert.deepEqual(undocumented, [],
+    'Diese Variablen werden gelesen, stehen aber nicht in .env.example. Damit sind sie auch '
+    + 'für die beiden Guards darüber unsichtbar. Dokumentiere sie in .env.example (und '
+    + 'entscheide dort, ob sie zusätzlich ins ENV_SCHEMA gehören) oder nimm sie mit '
+    + `Begründung in INTENTIONALLY_UNDOCUMENTED auf. Offen:\n${undocumented.join('\n')}`);
+});
+
+test('die Karte der undokumentierten Variablen enthält keine Karteileichen', () => {
+  const read = literalEnvReads();
+  const documented = new Set(documentedKeys());
+  for (const [key, reason] of Object.entries(INTENTIONALLY_UNDOCUMENTED)) {
+    assert.ok(read.has(key), `${key} ist ausgenommen, wird aber nirgends (mehr) gelesen`);
+    assert.ok(!documented.has(key),
+      `${key} ist als undokumentiert ausgenommen, steht aber in .env.example`);
+    assert.ok(typeof reason === 'string' && reason.length > 15, `${key} braucht eine echte Begründung`);
+  }
+});
+
+test('der Scanner findet überhaupt etwas', () => {
+  const read = literalEnvReads();
+  assert.ok(read.size > 40,
+    `Nur ${read.size} Env-Lesestellen gefunden - der Verzeichnis-Walk ist vermutlich kaputt`);
+  assert.ok(read.has('SESSION_SECRET'), 'SESSION_SECRET muss unter den Fundstellen sein');
+});

--- a/test/test-service-worker-build-revision.js
+++ b/test/test-service-worker-build-revision.js
@@ -4,7 +4,9 @@
  * Run: node --test test/test-service-worker-build-revision.js
  */
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import test from 'node:test';
 
 const serviceWorkerModule = await import('../server/utils/service-worker.js');
@@ -72,4 +74,31 @@ test('falls back to the app version when APP_BUILD_REVISION is blank after trimm
   );
 
   assert.equal(response.body, "globalThis.cacheRevision = '2.59.0';");
+});
+
+test('reloads an edited service worker source from an isolated file', () => {
+  const directory = mkdtempSync(join(tmpdir(), 'yuvomi-service-worker-'));
+  const sourcePath = join(directory, 'sw.js');
+
+  try {
+    writeFileSync(sourcePath, "globalThis.cacheRevision = '__YUVOMI_BUILD_REVISION__';\n");
+    const load = serviceWorkerModule.createServiceWorkerResponseLoader(sourcePath, {
+      appVersion: '2.59.0',
+      buildRevision: 'acceptance-route-test',
+    });
+
+    assert.equal(
+      load().body,
+      "globalThis.cacheRevision = 'acceptance-route-test';\n",
+    );
+
+    writeFileSync(
+      sourcePath,
+      "globalThis.cacheRevision = '__YUVOMI_BUILD_REVISION__';\n// edited\n",
+    );
+
+    assert.match(load().body, /\/\/ edited/);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
 });

--- a/test/test-service-worker-build-revision.js
+++ b/test/test-service-worker-build-revision.js
@@ -1,0 +1,50 @@
+/**
+ * Module: Service worker build revision
+ * Purpose: Keep same-version acceptance images from reusing an older PWA shell.
+ * Run: node --test test/test-service-worker-build-revision.js
+ */
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const serviceWorkerModule = await import('../server/utils/service-worker.js').catch(() => ({}));
+
+test('renders a distinct service worker response for each same-version build revision', () => {
+  assert.equal(typeof serviceWorkerModule.renderServiceWorkerSource, 'function');
+
+  const template = "globalThis.cacheRevision = '__YUVOMI_BUILD_REVISION__';";
+  const first = serviceWorkerModule.renderServiceWorkerSource(template, 'acceptance-a');
+  const second = serviceWorkerModule.renderServiceWorkerSource(template, 'acceptance-b');
+
+  assert.equal(first, "globalThis.cacheRevision = 'acceptance-a';");
+  assert.equal(second, "globalThis.cacheRevision = 'acceptance-b';");
+  assert.notEqual(first, second);
+});
+
+test('the shipped service worker gives same-version builds different cache namespaces', () => {
+  const source = readFileSync(new URL('../public/sw.js', import.meta.url), 'utf8');
+  const first = serviceWorkerModule.renderServiceWorkerSource(source, 'acceptance-a');
+  const second = serviceWorkerModule.renderServiceWorkerSource(source, 'acceptance-b');
+
+  assert.notEqual(first, second);
+  assert.match(first, /const APP_BUILD_REVISION\s*=\s*'acceptance-a'/);
+  assert.match(first, /yuvomi-shell-\$\{CACHE_RELEASE\}/);
+  assert.doesNotMatch(first, /__YUVOMI_BUILD_REVISION__/);
+});
+
+test('builds a non-cacheable service worker response and falls back to the app version', () => {
+  assert.equal(typeof serviceWorkerModule.buildServiceWorkerResponse, 'function');
+
+  const response = serviceWorkerModule.buildServiceWorkerResponse(
+    "globalThis.cacheRevision = '__YUVOMI_BUILD_REVISION__';",
+    { appVersion: '2.59.0', buildRevision: '' },
+  );
+
+  assert.deepEqual(response, {
+    body: "globalThis.cacheRevision = '2.59.0';",
+    contentType: 'text/javascript; charset=utf-8',
+    cacheControl: 'no-store, max-age=0',
+    cdnCacheControl: 'no-store',
+    cloudflareCdnCacheControl: 'no-store',
+  });
+});

--- a/test/test-service-worker-build-revision.js
+++ b/test/test-service-worker-build-revision.js
@@ -1,13 +1,13 @@
 /**
- * Module: Service worker build revision
- * Purpose: Keep same-version acceptance images from reusing an older PWA shell.
+ * Modul: Service-Worker-Build-Revision
+ * Zweck: Gleichversionige Images dürfen keine ältere PWA-Shell wiederverwenden.
  * Run: node --test test/test-service-worker-build-revision.js
  */
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
-const serviceWorkerModule = await import('../server/utils/service-worker.js').catch(() => ({}));
+const serviceWorkerModule = await import('../server/utils/service-worker.js');
 
 test('renders a distinct service worker response for each same-version build revision', () => {
   assert.equal(typeof serviceWorkerModule.renderServiceWorkerSource, 'function');
@@ -47,4 +47,29 @@ test('builds a non-cacheable service worker response and falls back to the app v
     cdnCacheControl: 'no-store',
     cloudflareCdnCacheControl: 'no-store',
   });
+});
+
+test('rejects unsafe APP_BUILD_REVISION values with the variable name and allowed format', () => {
+  for (const value of [
+    "a'; fetch('//evil')//",
+    'a\\',
+    'a\nb',
+    '</script>',
+    'a'.repeat(81),
+    '',
+  ]) {
+    assert.throws(
+      () => serviceWorkerModule.renderServiceWorkerSource('revision: __YUVOMI_BUILD_REVISION__', value),
+      /\[SW\] APP_BUILD_REVISION must match \/\^\[A-Za-z0-9\._-\]\{1,80\}\$\//,
+    );
+  }
+});
+
+test('falls back to the app version when APP_BUILD_REVISION is blank after trimming', () => {
+  const response = serviceWorkerModule.buildServiceWorkerResponse(
+    "globalThis.cacheRevision = '__YUVOMI_BUILD_REVISION__';",
+    { appVersion: '2.59.0', buildRevision: '   ' },
+  );
+
+  assert.equal(response.body, "globalThis.cacheRevision = '2.59.0';");
 });

--- a/test/test-setup.js
+++ b/test/test-setup.js
@@ -10,6 +10,7 @@ process.env.SESSION_SECRET = 'test-setup-secret-minimum-32-chars-x';
 process.env.DB_PATH = join(tmpDir, 'test.db');
 process.env.SESSION_SECURE = 'false';
 process.env.PORT = '13099';
+process.env.APP_BUILD_REVISION = 'acceptance-route-test';
 
 // Dynamic import so env vars are set before module initialization
 const { default: app } = await import('../server/index.js');
@@ -74,6 +75,16 @@ test('GET /api/v1/version: setup_required is true when no users exist', async ()
   const data = await res.json();
   assert.equal(data.setup_required, true);
   assert.equal(data.version, undefined);
+});
+
+test('GET /sw.js injects the build revision and forbids intermediary caching', async () => {
+  const res = await fetch(`${BASE}/sw.js`);
+  const body = await res.text();
+
+  assert.equal(res.status, 200);
+  assert.equal(res.headers.get('cache-control'), 'no-store, max-age=0');
+  assert.match(body, /const APP_BUILD_REVISION\s*=\s*'acceptance-route-test'/);
+  assert.doesNotMatch(body, /__YUVOMI_BUILD_REVISION__/);
 });
 
 test('GET /openapi.json: 401 without authentication', async () => {

--- a/test/test-setup.js
+++ b/test/test-setup.js
@@ -1,6 +1,6 @@
 import { test, after } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -85,6 +85,21 @@ test('GET /sw.js injects the build revision and forbids intermediary caching', a
   assert.equal(res.headers.get('cache-control'), 'no-store, max-age=0');
   assert.match(body, /const APP_BUILD_REVISION\s*=\s*'acceptance-route-test'/);
   assert.doesNotMatch(body, /__YUVOMI_BUILD_REVISION__/);
+});
+
+test('GET /sw.js reflects service-worker edits without restarting the development server', async () => {
+  const file = new URL('../public/sw.js', import.meta.url);
+  const source = readFileSync(file, 'utf8');
+  const marker = '// test: service-worker reload';
+
+  try {
+    writeFileSync(file, `${source}\n${marker}\n`);
+    const res = await fetch(`${BASE}/sw.js`);
+
+    assert.match(await res.text(), new RegExp(marker));
+  } finally {
+    writeFileSync(file, source);
+  }
 });
 
 test('GET /openapi.json: 401 without authentication', async () => {

--- a/test/test-setup.js
+++ b/test/test-setup.js
@@ -1,6 +1,6 @@
 import { test, after } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -85,21 +85,6 @@ test('GET /sw.js injects the build revision and forbids intermediary caching', a
   assert.equal(res.headers.get('cache-control'), 'no-store, max-age=0');
   assert.match(body, /const APP_BUILD_REVISION\s*=\s*'acceptance-route-test'/);
   assert.doesNotMatch(body, /__YUVOMI_BUILD_REVISION__/);
-});
-
-test('GET /sw.js reflects service-worker edits without restarting the development server', async () => {
-  const file = new URL('../public/sw.js', import.meta.url);
-  const source = readFileSync(file, 'utf8');
-  const marker = '// test: service-worker reload';
-
-  try {
-    writeFileSync(file, `${source}\n${marker}\n`);
-    const res = await fetch(`${BASE}/sw.js`);
-
-    assert.match(await res.text(), new RegExp(marker));
-  } finally {
-    writeFileSync(file, source);
-  }
 });
 
 test('GET /openapi.json: 401 without authentication', async () => {

--- a/test/test-sw-api-cache.js
+++ b/test/test-sw-api-cache.js
@@ -19,8 +19,13 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { createContext, runInContext } from 'node:vm';
+import { renderServiceWorkerSource } from '../server/utils/service-worker.js';
 
-const SRC = readFileSync(new URL('../public/sw.js', import.meta.url), 'utf8');
+const TEST_BUILD_REVISION = 'sw-api-cache-test';
+const SRC = renderServiceWorkerSource(
+  readFileSync(new URL('../public/sw.js', import.meta.url), 'utf8'),
+  TEST_BUILD_REVISION,
+);
 const ORIGIN = 'https://app.test';
 
 // --------------------------------------------------------
@@ -256,15 +261,16 @@ test('activate entfernt alte Vorversions- und Legacy-oikos-Caches, behält aktue
   const pkg = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8'));
   await env.caches.open('yuvomi-api-0.0.1');                 // Vorversion → löschen
   await env.caches.open('oikos-shell-0.0.1');               // Legacy-Rename → löschen
-  await env.caches.open(`yuvomi-shell-${pkg.version}`);     // aktuell → behalten
-  await env.caches.open(`yuvomi-api-${pkg.version}`);       // aktuell → behalten
+  const currentRelease = `${pkg.version}-${TEST_BUILD_REVISION}`;
+  await env.caches.open(`yuvomi-shell-${currentRelease}`);  // aktuell → behalten
+  await env.caches.open(`yuvomi-api-${currentRelease}`);    // aktuell → behalten
 
   await dispatchActivate(env);
 
   assert.equal(await env.caches.has('yuvomi-api-0.0.1'), false, 'alter API-Cache muss weg sein');
   assert.equal(await env.caches.has('oikos-shell-0.0.1'), false, 'Legacy-oikos-Cache muss weg sein');
-  assert.equal(await env.caches.has(`yuvomi-shell-${pkg.version}`), true, 'aktueller Shell-Cache bleibt');
-  assert.equal(await env.caches.has(`yuvomi-api-${pkg.version}`), true, 'aktueller API-Cache bleibt');
+  assert.equal(await env.caches.has(`yuvomi-shell-${currentRelease}`), true, 'aktueller Shell-Cache bleibt');
+  assert.equal(await env.caches.has(`yuvomi-api-${currentRelease}`), true, 'aktueller API-Cache bleibt');
 });
 
 test('im Bypass-Fenster (nach SW-Update) wird die API nicht gecacht', async () => {


### PR DESCRIPTION
## Summary

Makes service-worker cache identity include a build revision as well as the semantic application version. Rebuilding or redeploying the same Yuvomi version can therefore no longer leave an installed PWA on an older application shell.

This was discovered while acceptance-testing the Documents work and has been split out of #989 because it is an independent PWA concern.

## How it works

- The shipped service worker contains a build-revision placeholder.
- `/sw.js` is rendered with a validated concrete revision for each build/deployment.
- Cache namespaces use `APP_RELEASE` plus that revision.
- The response uses `no-store` and CDN-bypass headers.
- Development/test fallback remains deterministic when no external build revision is supplied.

## Scope

- No Documents routes, UI, upload logic or translations are changed.
- No database migration is included.
- Existing API cache clearing and update-bypass behavior is preserved.

## Verification

- [x] Full `npm test` at `9860fb60`
- [x] Focused service-worker, Docker publish and setup coverage: 31 tests, 0 failures
- [x] The isolated reload test leaves tracked `public/sw.js` byte-for-byte unchanged
- [x] `git diff --check f6afbbc3..9860fb60`
- [x] Independent Superpowers review: approved with no remaining findings
- [x] No deployment performed

AI-assisted implementation and review using OpenAI Codex.
