### PR TITLE
fix(ui): an extension module's permission key survives the permissions matrix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   hung off it, so the household kept getting notified for an event that no longer existed. The
   orphan is now removed with the event.
 
+- **An extension module's access level can be saved again** (#1009). Changing the access level for
+  a third-party module under Settings → Administration → Roles & permissions failed with
+  `Unknown module: ext`, and extension widget permissions failed the same way. The server was
+  right to refuse: the permissions page labels each control with `module:<key>`, and because a
+  third-party module's key is itself `ext:<moduleId>`, splitting that label on every colon kept
+  only `ext`. It now splits at the first colon, so the rest of the key survives - which also
+  repairs the second, silent consequence, where the widget list of an extension module was rebuilt
+  under a key that matched nothing. A shared helper carries the rule, and a guard keeps the call
+  site from parsing the label itself again.
+
 ## [2.64.0] - 2026-09-02
 
 ### Added

--- a/public/settings/pages/admin-permissions.js
+++ b/public/settings/pages/admin-permissions.js
@@ -17,6 +17,7 @@ import { prefersInkText } from '/utils/contrast.js';
 import { confirmModal } from '/components/modal.js';
 import { createRetryState } from '/settings/components.js';
 import { resolveExtensionLabel } from '/utils/extension-i18n.js';
+import { parsePermissionGroup } from '/utils/permission-group.js';
 
 // ── Statik ───────────────────────────────────────────────────────────────────
 
@@ -524,7 +525,12 @@ function bindEvents(container) {
 }
 
 function applySegment(container, opt) {
-  const [type, key] = String(opt.dataset.group).split(':');
+  // Am ERSTEN Doppelpunkt trennen, nicht an allen (#1009): der Schluessel eines
+  // Fremdmoduls ist selbst `ext:<modulId>` und eine Fremd-Widget-Id
+  // `<modulId>:<widgetId>`. Ein destrukturierendes split(':') behielt davon nur
+  // `ext` bzw. die Modul-Id, und der Server wies das zu Recht ab.
+  const { type, key } = parsePermissionGroup(opt.dataset.group);
+  if (!key) return;
   const value = opt.dataset.value;
   if (type === 'module') state.draft.modules[key] = value;
   else state.draft.widgets[key] = value;

--- a/public/sw.js
+++ b/public/sw.js
@@ -154,6 +154,7 @@ const APP_SHELL = [
   '/utils/pantry-locations.js',
   '/utils/pantry-status.js',
   '/utils/pantry-units.js',
+  '/utils/permission-group.js',
   '/utils/phone.js',
   '/utils/popover-menu.js',
   '/utils/quick-link-url.js',

--- a/public/utils/permission-group.js
+++ b/public/utils/permission-group.js
@@ -1,0 +1,43 @@
+/**
+ * Modul: Gruppenschluessel der Rechtematrix zerlegen (#1009)
+ * Zweck: Aus `typ:schluessel` die beiden Teile holen, wenn der SCHLUESSEL
+ *        selbst Doppelpunkte enthalten darf.
+ * Abhaengigkeiten: keine
+ *
+ * WARUM DAS EINE EIGENE DATEI IST UND KEIN split(':'). Die Rechtematrix
+ * beschriftet jedes Segment-Control mit `module:<schluessel>` bzw.
+ * `widget:<id>`. Fuer Kernmodule ist das ein Paar; fuer Fremdmodule nicht:
+ *
+ *   module:tasks              -> Kernmodul
+ *   module:ext:mein-modul     -> Fremdmodul, Schluessel ist `ext:<modulId>`
+ *   widget:countdown          -> Kern-Widget
+ *   widget:mein-modul:kachel  -> Fremd-Widget, Id ist `<modulId>:<widgetId>`
+ *
+ * `const [type, key] = String(group).split(':')` nimmt aus den letzten beiden
+ * Zeilen `key = 'ext'` bzw. `key = 'mein-modul'` - der Rest faellt weg. Genau
+ * das war #1009: der Entwurf trug danach `modules['ext']`, und der Server
+ * antwortete voellig zu Recht `Unknown module: ext`. Der Fehler sah nach einem
+ * Serverproblem aus und stand in der Oberflaeche.
+ *
+ * Getrennt wird deshalb am ERSTEN Doppelpunkt: der Typ ist ein einzelnes Wort,
+ * alles danach gehoert dem Schluessel. Dasselbe Muster wie `${var##*:}` in der
+ * Shell, nur mit umgekehrter Blickrichtung - und mit demselben Fallstrick.
+ *
+ * NICHT ZU VERWECHSELN mit `id.split(':')[0]` an einer Widget-Id: dort ist die
+ * ERSTE Komponente gesucht (die Modul-Id), und dafuer ist split richtig.
+ */
+
+/**
+ * Zerlegt einen Gruppenschluessel in Typ und Schluessel.
+ *
+ * @param {string} group - z.B. `module:ext:mein-modul`
+ * @returns {{type: string, key: string}} - leerer `key`, wenn kein
+ *   Doppelpunkt vorkommt oder nichts dahinter steht. Der Aufrufer bricht
+ *   darauf ab, statt `undefined` als Schluessel weiterzureichen.
+ */
+export function parsePermissionGroup(group) {
+  const raw = String(group ?? '');
+  const sep = raw.indexOf(':');
+  if (sep < 0) return { type: raw, key: '' };
+  return { type: raw.slice(0, sep), key: raw.slice(sep + 1) };
+}

--- a/test/test-extension-permissions.js
+++ b/test/test-extension-permissions.js
@@ -208,3 +208,83 @@ test('a colliding api.prefix never reaches PREFIX_TO_MODULE', async () => {
   assert.ok(!catalog.scopeModuleKeys.includes('ext:taskextras'));
   assert.equal(moduleForPath('/tasks/5'), 'tasks');
 });
+
+// ---------------------------------------------------------------------------
+// #1009: der Gruppenschluessel der Rechtematrix
+//
+// Gemeldet als Serverfehler ("Unknown module: ext"), und der Server hatte
+// recht: moduleKeySet() mischt die Extension-Module ein, die Menge KENNT den
+// Schluessel. Abgeschnitten wurde er in der Oberflaeche, weil
+// `const [type, key] = String(group).split(':')` bei `module:ext:<id>` nach
+// zwei Feldern aufhoert. Die Regel steht jetzt in einer eigenen Datei; hier
+// wird sie geprueft, und darunter, dass die Aufrufstelle sie auch benutzt.
+// ---------------------------------------------------------------------------
+
+test('parsePermissionGroup trennt am ersten Doppelpunkt, nicht an allen (#1009)', async () => {
+  const { parsePermissionGroup } = await import('../public/utils/permission-group.js');
+
+  // Kernmodule und Kern-Widgets: ein Paar, unveraendertes Verhalten.
+  assert.deepEqual(parsePermissionGroup('module:tasks'), { type: 'module', key: 'tasks' });
+  assert.deepEqual(parsePermissionGroup('widget:countdown'), { type: 'widget', key: 'countdown' });
+
+  // DER GEMELDETE FALL. Der Schluessel eines Fremdmoduls ist `ext:<modulId>`
+  // (extensionPermissionKey), das Markup schreibt `module:${key}`.
+  assert.deepEqual(
+    parsePermissionGroup('module:ext:mein-modul'),
+    { type: 'module', key: 'ext:mein-modul' },
+    'der Schluessel eines Fremdmoduls behaelt sein ext:-Praefix',
+  );
+
+  // Dieselbe Falle eine Ebene tiefer: eine Fremd-Widget-Id ist
+  // `<modulId>:<widgetId>`, der Gruppenschluessel also dreiteilig.
+  assert.deepEqual(
+    parsePermissionGroup('widget:mein-modul:kachel'),
+    { type: 'widget', key: 'mein-modul:kachel' },
+    'die Widget-Id bleibt vollstaendig',
+  );
+
+  // Modul-Ids duerfen Bindestriche und Ziffern tragen; mehr als drei
+  // Komponenten sind damit nicht ausgeschlossen.
+  assert.deepEqual(
+    parsePermissionGroup('widget:a:b:c'),
+    { type: 'widget', key: 'a:b:c' },
+    'nur der erste Doppelpunkt trennt - alles danach gehoert dem Schluessel',
+  );
+
+  // Kein Doppelpunkt und leerer Rest liefern einen leeren Schluessel, damit der
+  // Aufrufer abbrechen kann. Vorher stand hier `undefined` und landete als
+  // Objektschluessel im Entwurf.
+  assert.deepEqual(parsePermissionGroup('module'), { type: 'module', key: '' });
+  assert.deepEqual(parsePermissionGroup('module:'), { type: 'module', key: '' });
+  assert.deepEqual(parsePermissionGroup(''), { type: '', key: '' });
+  assert.deepEqual(parsePermissionGroup(null), { type: '', key: '' });
+});
+
+test('die Rechtematrix zerlegt dataset.group nicht mehr selbst (#1009)', () => {
+  const src = fs.readFileSync(
+    new URL('../public/settings/pages/admin-permissions.js', import.meta.url),
+    'utf8',
+  );
+
+  // Die Gegenprobe zur Zeile oben: der Helfer kann richtig sein und die Seite
+  // ihn trotzdem nicht benutzen. Geprueft wird deshalb die Aufrufstelle selbst.
+  assert.doesNotMatch(
+    src,
+    /dataset\.group\s*\)?\s*\.split\s*\(/,
+    'dataset.group darf nicht mehr per split zerlegt werden - das schneidet ext:<id> ab',
+  );
+  assert.match(
+    src,
+    /import\s*\{\s*parsePermissionGroup\s*\}\s*from\s*'\/utils\/permission-group\.js'/,
+    'die Seite muss den gemeinsamen Helfer importieren',
+  );
+  assert.match(
+    src,
+    /parsePermissionGroup\s*\(\s*opt\.dataset\.group\s*\)/,
+    'und ihn auf dataset.group anwenden',
+  );
+
+  // Die Widget-Id-Zerlegung an anderer Stelle ist KORREKT und bleibt: dort ist
+  // die erste Komponente gesucht (die Modul-Id), nicht die letzte.
+  assert.match(src, /id\.split\(':'\)\[0\]/, 'widgetLabel darf weiterhin die Modul-Id abschneiden');
+});


### PR DESCRIPTION
Closes #1009

## The bug, and why it looked like a server problem

Saving an access level for a third-party module failed with `Unknown module: ext`, and extension widget permissions failed the same way. The error names the server, and the server is where `normalizePermissionInput` throws (`server/permissions.js:395`) - but the server is right. `moduleKeySet()` rebuilds the allowed keys on every call from `allPermissionModules()`, which mixes the extension catalog in (`permissions.js:162`, `:171`). The set knows the key.

The key was truncated in the browser.

## The chain

A third-party module's permission key is itself `ext:<moduleId>` (`extensionPermissionKey`, `server/services/module-capabilities.js:17`). The permissions page labels every segment control with its group:

```
module:tasks                -> core module
module:ext:my-module        -> third-party module
widget:countdown            -> core widget
widget:my-module:some-tile  -> third-party widget
```

`applySegment` parsed that with `const [type, key] = String(opt.dataset.group).split(':')`. For the two indented lines that keeps `ext` and `my-module` and drops the rest, so the draft carried `modules['ext']` and the server refused it - correctly.

## The fix

Split at the **first** colon: the type is one word, everything after it belongs to the key. The rule lives in `public/utils/permission-group.js`, a dependency-free module, so it can be unit-tested and so the comment explaining it sits with the code rather than at the call site.

The comment also records the other half, because it is the part someone will otherwise "fix" later: `id.split(':')[0]` on a *widget id* is correct and stays. There the first component is what you want (the module id). The two cases look identical and are opposite.

## What else this repairs

`rebuildModuleWidgets(container, key)` looks the widget group up with `.perm-modgroup[data-module="${moduleKey}"]`. It was being called with `'ext'`, matched nothing, and returned silently - so an extension module's widget rows never refreshed when its access level changed. Same cause, no error message.

An empty key now returns early instead of landing in the draft as `undefined`.

## Tests

Both in `test/test-extension-permissions.js`, where the `ext:` key story already lives - no new suite, no new entry in the `npm test` chain.

1. `parsePermissionGroup` itself: core module, core widget, extension module, extension widget, a four-part id, and the degenerate inputs (no colon, trailing colon, empty, null).
2. **That the call site uses it.** This is the one that matters: a correct helper the page does not call would be green. The guard asserts `dataset.group` is no longer split, that the helper is imported, and that it is applied to `opt.dataset.group` - and it also pins `id.split(':')[0]` as intentionally still present, so a later cleanup does not remove the correct one.

**Counterproof run:** the call site was reverted on its own, with the helper and the import left in place. Guard red, unit test green - which is the split the two tests are supposed to make. Restored, both green.

## Notes for review

- `public/sw.js` gains the new file in the precache list. The `test:sw-precache` transitive-module-graph check found it missing, which is also the proof that `/utils/permission-group.js` resolves from the page.
- No new UI strings, so no locale changes.
- `public/settings/` and `public/sw.js` are on the interface track, so this cannot be released before Tuesday under the cadence rule in CONTRIBUTING.md.

Suites run green: `sw-precache`, `layer-boundary`, `extension-permissions`, `extension-widgets`, `permissions`, `permissions-routes`, `frontend-audit`, `changelog`, `typography`, `i18n`.
