### PR TITLE
fix(dashboard): widget-id-schreibweise gehoert zur zusammensetzung

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   hung off it, so the household kept getting notified for an event that no longer existed. The
   orphan is now removed with the event.
 
+- **A dashboard layout containing a third-party widget can be saved again** (#1013). With an
+  extension module that declares a dashboard widget, moving a tile, hiding one or resizing one
+  failed with `400`, and so did publishing the household default - it was not the extension widget
+  that got dropped, the whole request was refused. The storage check for a widget id lived in the
+  preferences route and knew nothing of the colon that `<module-id>:<widget-id>` carries, the form
+  this project documents for third-party widgets and builds itself. The check now lives beside the
+  function that composes those ids, so that widening one without the other is no longer possible,
+  and a guard asserts the round trip at the maximum lengths a module id and a widget id may reach.
+  Reported after the fix above had already closed its thread.
+
 - **An extension module's access level can be saved again** (#1009). Changing the access level for
   a third-party module under Settings → Administration → Roles & permissions failed with
   `Unknown module: ext`, and extension widget permissions failed the same way. The server was

--- a/server/routes/preferences.js
+++ b/server/routes/preferences.js
@@ -12,6 +12,7 @@ import { str, MAX_SHORT } from '../middleware/validate.js';
 import { getSupportedLocales, isSupportedLocale, resolveHouseholdLocale } from '../utils/i18n.js';
 import { householdTimeZone, isValidTimeZone } from '../utils/timezone.js';
 import { retitleBirthdayEvents } from '../services/birthdays.js';
+import { isWidgetId } from '../services/module-capabilities.js';
 // Geteilte isomorphe Util (#620, Allowlist in test/test-layer-boundary.js):
 // dasselbe Kennungsformat, das Event-Modal und Einstellungen verwenden.
 import { parseSyncTargetValue } from '../../public/utils/sync-target.js';
@@ -147,8 +148,10 @@ const COUNTRY_ISO_RE = /^[A-Z]{2}$/;
 const SUBDIVISION_RE = /^[A-Z]{2}-[A-Z0-9-]{1,10}$/;
 
 // Widget identifiers are client-owned. The server validates only a safe storage shape,
-// so adding or removing dashboard widgets never requires a matching backend registry change.
-const WIDGET_ID_RE = /^[a-z][a-z0-9-]{0,63}$/;
+// so adding or removing dashboard widgets never requires a matching backend registry
+// change. Die Schreibweise selbst steht in services/module-capabilities.js - dort, wo
+// `fullWidgetId()` sie zusammensetzt. Eine zweite Fassung hier hat #1013 verursacht:
+// sie kannte den Doppelpunkt der Fremdmodul-Ids nicht.
 const MAX_DASHBOARD_WIDGETS = 64;
 const VALID_WIDGET_SIZES = ['1x1', '1x2', '1x3', '1x4', '2x1', '2x2', '2x3', '2x4', '3x1', '3x2', '3x3', '3x4', '4x1', '4x2', '4x3', '4x4'];
 const DEFAULT_WIDGET_CONFIG = '[]';
@@ -423,7 +426,7 @@ function normalizeWidgetConfig(input) {
   const normalized = [];
   for (const [index, widget] of input.entries()) {
     if (!widget || typeof widget !== 'object' || Array.isArray(widget)) return null;
-    if (typeof widget.id !== 'string' || !WIDGET_ID_RE.test(widget.id) || seenIds.has(widget.id)) return null;
+    if (!isWidgetId(widget.id) || seenIds.has(widget.id)) return null;
     if (widget.visible !== undefined && typeof widget.visible !== 'boolean') return null;
     if (widget.order !== undefined && !Number.isFinite(Number(widget.order))) return null;
     if (widget.size !== undefined && !VALID_WIDGET_SIZES.includes(widget.size)) return null;

--- a/server/services/module-capabilities.js
+++ b/server/services/module-capabilities.js
@@ -5,7 +5,23 @@
 
 import path from 'node:path';
 
-const WIDGET_SHORT_ID_RE = /^[a-z][a-z0-9-]{0,31}$/;
+// DIE SCHREIBWEISE DER EXTENSION-IDS WOHNT HIER, WEIL HIER ZUSAMMENGESETZT WIRD.
+//
+// Bis #1013 lagen die Teile und die Zusammensetzung an vier Stellen, die
+// einander nicht kannten: `ID_RE` in modules.js (Modul-Id), das
+// WIDGET_SHORT_ID_RE hier (Kurz-Id), `fullWidgetId()` setzte beide zusammen -
+// und `WIDGET_ID_RE` in routes/preferences.js pruefte das Ergebnis, ohne die
+// Zusammensetzung je gesehen zu haben. Deshalb kannte es keinen Doppelpunkt und
+// wies jedes Layout mit einem Fremdmodul-Widget ab; nicht das Widget fiel weg,
+// der ganze Speichervorgang scheiterte.
+//
+// Wer eine der drei Formen aendert, aendert sie hier - und `isWidgetId()` faellt
+// mit, weil es aus ihnen gebaut ist statt sie nachzuahmen. Der Guard in
+// test/test-modules.js prueft genau diese Zusicherung an den Laengengrenzen:
+// was `fullWidgetId()` baut, muss die Speicherform annehmen.
+export const MODULE_ID_RE = /^[a-z0-9][a-z0-9-]{1,62}[a-z0-9]$/;
+export const WIDGET_SHORT_ID_RE = /^[a-z][a-z0-9-]{0,31}$/;
+export const CORE_WIDGET_ID_RE = /^[a-z][a-z0-9-]{0,63}$/;
 const OPTION_KEY_RE = /^[a-z][a-z0-9_]{0,31}$/;
 const LABEL_KEY_RE = /^[a-z][a-z0-9._-]{0,79}$/;
 const VALID_WIDGET_SIZES = new Set([
@@ -20,6 +36,31 @@ export function extensionPermissionKey(moduleId) {
 
 export function fullWidgetId(moduleId, widgetId) {
   return `${moduleId}:${widgetId}`;
+}
+
+/**
+ * Traegt `id` die Namensraum-Form `<modulId>:<widgetId>` aus MODULES.md?
+ *
+ * Getrennt wird am ERSTEN Doppelpunkt - dieselbe Regel wie
+ * `parsePermissionGroup()` aus #1009. Eine Modul-Id darf keinen Doppelpunkt
+ * enthalten, ein zweiter bedeutet also nicht Verschachtelung, sondern eine
+ * kaputte Id: `a:b:c` faellt hier durch, weil `b:c` keine Kurz-Id ist.
+ */
+export function isNamespacedWidgetId(id) {
+  if (typeof id !== 'string') return false;
+  const sep = id.indexOf(':');
+  if (sep < 0) return false;
+  return MODULE_ID_RE.test(id.slice(0, sep)) && WIDGET_SHORT_ID_RE.test(id.slice(sep + 1));
+}
+
+/**
+ * Die Speicherform einer Dashboard-Widget-Id: eine Kern-Id oder die
+ * dokumentierte Namensraum-Form. Bewusst eine SCHREIBWEISEN-Pruefung und keine
+ * Registry-Abfrage - welche Widgets es gibt, weiss weiterhin allein das
+ * Frontend, und ein neues Kern-Widget braucht deshalb keine Server-Aenderung.
+ */
+export function isWidgetId(id) {
+  return typeof id === 'string' && (CORE_WIDGET_ID_RE.test(id) || isNamespacedWidgetId(id));
 }
 
 function parseWidgetShortId(value, label) {

--- a/server/services/modules.js
+++ b/server/services/modules.js
@@ -9,7 +9,7 @@ import path from 'node:path';
 import * as db from '../db.js';
 import { createLogger } from '../logger.js';
 import { getSupportedLocales } from '../utils/i18n.js';
-import { normalizeCapabilities, buildExtensionCatalog } from './module-capabilities.js';
+import { normalizeCapabilities, buildExtensionCatalog, MODULE_ID_RE as ID_RE } from './module-capabilities.js';
 import { setExtensionScopeModules } from '../scopes.js';
 import { setExtensionPermissionCatalog } from '../permissions.js';
 
@@ -23,7 +23,6 @@ const DISABLED_KEY = 'third_party_disabled_modules';
 // Anhebung: ein aelteres Modul laesst sie weg und verhaelt sich wie zuvor.
 export const SUPPORTED_MANIFEST_VERSION = 1;
 
-const ID_RE = /^[a-z0-9][a-z0-9-]{1,62}[a-z0-9]$/;
 const SAFE_RELATIVE_RE = /^[a-zA-Z0-9][a-zA-Z0-9._/-]*$/;
 const MENU_LABEL_KEY_RE = /^[a-z][a-z0-9._-]{0,79}$/;
 const MODULE_LOCALE_FILE_RE = /^([a-z]{2,3})\.json$/;

--- a/test/test-modules.js
+++ b/test/test-modules.js
@@ -139,7 +139,7 @@ import express from 'express';
 const dbmod = await import('../server/db.js');
 const svc = await import('../server/services/modules.js');
 const { SUPPORTED_MANIFEST_VERSION } = svc;
-const { normalizeCapabilities } = await import('../server/services/module-capabilities.js');
+const { normalizeCapabilities, fullWidgetId, isWidgetId, isNamespacedWidgetId, MODULE_ID_RE, WIDGET_SHORT_ID_RE } = await import('../server/services/module-capabilities.js');
 const { default: modulesRouter } = await import('../server/routes/modules.js');
 const db = dbmod.get();
 
@@ -522,4 +522,51 @@ test('page.composition wird normalisiert und page.width folgt dem Modus', () => 
   assert.equal(norm({ navigation: 'tabs' }).navigation, 'standard', 'eine unbekannte navigation faellt auf standard');
   assert.equal(norm({ responsive: 'collapse' }).responsive, 'standard', 'ein unbekanntes responsive faellt auf standard');
   assert.equal(norm({ navigation: 'standard', responsive: 'standard' }).navigation, 'standard', 'standard bleibt standard');
+});
+
+// ── Die Speicherform einer Widget-Id (#1013) ─────────────────────────────────
+//
+// DER EIGENTLICHE GUARD IST DER ERSTE: was `fullWidgetId()` baut, muss
+// `isWidgetId()` annehmen - und zwar an den LAENGENGRENZEN, nicht an einem
+// huebschen Beispiel. Genau daran ist #1013 gescheitert: die Speicherform stand
+// in einer anderen Datei und kannte den Doppelpunkt nicht, den die
+// Zusammensetzung erzeugt. Ein Beispiel-Test mit 'my-addon:chart' waere auch mit
+// einer Schranke von 64 Zeichen gruen geblieben, obwohl eine legale volle Id 97
+// erreichen kann.
+test('was fullWidgetId baut, nimmt die Speicherform an - auch am Rand (#1013)', () => {
+  const maxModuleId = 'm'.repeat(64);
+  const maxShortId = 'w'.repeat(32);
+  assert.ok(MODULE_ID_RE.test(maxModuleId), 'Voraussetzung: 64 Zeichen sind eine legale Modul-Id');
+  assert.ok(WIDGET_SHORT_ID_RE.test(maxShortId), 'Voraussetzung: 32 Zeichen sind eine legale Kurz-Id');
+
+  const longest = fullWidgetId(maxModuleId, maxShortId);
+  assert.equal(longest.length, 97, 'die laengste legale Widget-Id ist 97 Zeichen lang');
+  assert.ok(isWidgetId(longest), 'die laengste legale Id muss speicherbar sein');
+
+  // Eine Modul-Id darf mit einer ZIFFER beginnen (ID_RE), eine Kern-Widget-Id
+  // nicht. Wer die Namensraum-Form aus der Kern-Form ableitet, verliert das.
+  assert.ok(MODULE_ID_RE.test('7up'), 'Voraussetzung: eine Modul-Id darf mit einer Ziffer beginnen');
+  assert.ok(isWidgetId(fullWidgetId('7up', 'chart')), 'auch eine Modul-Id mit fuehrender Ziffer bleibt speicherbar');
+});
+
+test('isWidgetId nimmt Kern- und Namensraum-Ids an und weist kaputte ab (#1013)', () => {
+  for (const id of ['weather', 'tasks', 'my-addon', 'my-addon:chart', '7up:chart']) {
+    assert.ok(isWidgetId(id), `${id} muss angenommen werden`);
+  }
+  for (const id of [
+    'mo:chart',                       // Modul-Id kuerzer als drei Zeichen
+    `${'m'.repeat(65)}:chart`,        // Modul-Id zu lang
+    `my-addon:${'w'.repeat(33)}`,     // Kurz-Id zu lang
+    'a:b:c',                          // zweiter Doppelpunkt: kaputt, nicht verschachtelt
+    'my-addon:', ':chart', '::',
+    '../weather', 'My-Addon:chart', 'my-addon:Chart', 'my-addon:1chart',
+    '-my-addon:chart', 'my-addon-:chart',
+    null, undefined, 42, {},
+  ]) {
+    assert.equal(isWidgetId(id), false, `${String(id)} darf nicht angenommen werden`);
+  }
+  // Eine Kern-Id ist NICHT namensraumbehaftet - sonst wuerde jede Kachel als
+  // Fremdmodul-Widget gelten, sobald jemand die beiden Pruefungen verwechselt.
+  assert.equal(isNamespacedWidgetId('weather'), false);
+  assert.equal(isNamespacedWidgetId('my-addon:chart'), true);
 });

--- a/test/test-preferences-dashboard.js
+++ b/test/test-preferences-dashboard.js
@@ -21,6 +21,9 @@ import test from 'node:test';
 
 const { get } = await import('../server/db.js');
 const { default: preferencesRouter } = await import('../server/routes/preferences.js');
+// Die Id wird gebaut statt getippt: der Test prueft die ZUSAGE aus MODULES.md,
+// nicht eine Zeichenkette, die zufaellig heute passt (#1013).
+const { fullWidgetId } = await import('../server/services/module-capabilities.js');
 
 let currentUserId = 1;
 let currentRole = 'admin';
@@ -309,6 +312,63 @@ test('die Prüfung gilt auch für die Vorgabe', async () => {
     assert.equal((await write(baseUrl, { dashboard_today_glance_default: '0' })).status, 400);
     assert.equal(householdValue('dashboard_widgets_default'), null,
       'eine abgewiesene Vorgabe darf nichts hinterlassen');
+  } finally {
+    await close();
+  }
+});
+
+// ── Fremdmodul-Widgets in der Anordnung (#1013) ──────────────────────────────
+//
+// Die Speicherform kannte den Doppelpunkt nicht, den `fullWidgetId()` baut. Der
+// Preis war nicht "das fremde Widget faellt weg", sondern 400 fuer das GANZE
+// Array: wer ein Extension-Widget auf der Uebersicht hatte, konnte keine Kachel
+// mehr verschieben, ausblenden oder in der Groesse aendern.
+//
+// WARUM DIESER TEST NEBEN DEM UNIT-TEST STEHT: `isWidgetId()` in
+// test/test-modules.js zu pruefen beweist nur, dass der Helfer richtig ist. Ein
+// richtiger Helfer, den die Route nicht aufruft, waere gruen - dieselbe Trennung
+// wie bei #1009. Dieser Test haengt an der Route.
+
+test('ein Fremdmodul-Widget ueberlebt Speichern und Lesen (#1013)', async () => {
+  const { baseUrl, close } = await startApp();
+  try {
+    const withExtension = [
+      { id: 'tasks', visible: true, order: 0, size: '2x2' },
+      { id: fullWidgetId('my-addon', 'chart'), visible: true, order: 1, size: '1x2' },
+    ];
+    const written = await write(baseUrl, { dashboard_widgets: withExtension });
+    assert.equal(written.status, 200);
+    assert.deepEqual(written.data.dashboard_widgets.map((w) => w.id), ['tasks', 'my-addon:chart']);
+    assert.deepEqual((await read(baseUrl)).dashboard_widgets.map((w) => w.id), ['tasks', 'my-addon:chart']);
+  } finally {
+    await close();
+  }
+});
+
+test('die Vorgabe des Haushalts nimmt dieselbe Form an (#1013)', async () => {
+  const { baseUrl, close } = await startApp();
+  try {
+    const written = await write(baseUrl, {
+      dashboard_widgets_default: [{ id: fullWidgetId('my-addon', 'chart'), visible: true, order: 0, size: '1x2' }],
+    });
+    assert.equal(written.status, 200);
+    assert.deepEqual(written.data.dashboard_widgets_default.map((w) => w.id), ['my-addon:chart']);
+  } finally {
+    await close();
+  }
+});
+
+test('eine kaputte Namensraum-Id bleibt abgewiesen (#1013)', async () => {
+  const { baseUrl, close } = await startApp();
+  try {
+    // Zwei Doppelpunkte heissen nicht Verschachtelung, sondern kaputte Id, und
+    // eine Modul-Id unter drei Zeichen gibt es nicht. Der Fix weitet die
+    // Schreibweise, er schaltet sie nicht ab.
+    assert.equal((await write(baseUrl, { dashboard_widgets: [{ id: 'a:b:c', size: '1x1' }] })).status, 400);
+    assert.equal((await write(baseUrl, { dashboard_widgets: [{ id: 'my-addon:', size: '1x1' }] })).status, 400);
+    assert.equal((await write(baseUrl, { dashboard_widgets: [{ id: 'mo:chart', size: '1x1' }] })).status, 400);
+    assert.equal(householdValue('dashboard_widgets:user:1'), null,
+      'eine abgewiesene Anordnung darf nichts hinterlassen');
   } finally {
     await close();
   }


### PR DESCRIPTION
Closes #1013.

A dashboard layout containing a third-party widget could not be saved at all: moving a tile, hiding
one, resizing one, or publishing the household default returned `400`. It was not the extension
widget that got dropped - `normalizeWidgetConfig` returns `null` for the whole array on one invalid
entry, so the entire request was refused. Live since v2.63.0, reported by @aitor-imaz as a follow-up
in #1009 after that issue had already been closed.

## Why this is not a wider regex

The storage check knew nothing of the colon that `<module-id>:<widget-id>` carries - the form
`MODULES.md` documents for third-party widgets and `fullWidgetId()` builds. Widening the character
class would have worked today and broken again later, because the format lived in four places that
did not know each other:

| Where | Owned |
|---|---|
| `services/modules.js` `ID_RE` | the module id |
| `services/module-capabilities.js` `WIDGET_SHORT_ID_RE` | the widget short id |
| `services/module-capabilities.js` `fullWidgetId()` | composed the two |
| `routes/preferences.js` `WIDGET_ID_RE` | validated the composition, having never seen it |

`module-capabilities.js` already composes both of this project's colon-joined keys, so it now owns
the parts and the matching acceptor as well. `modules.js` imports `MODULE_ID_RE as ID_RE` in its
existing import (one line, no call site changes); the route asks `isWidgetId()` instead of
describing the format a second time.

**Both moved regexes are character-identical to the ones they replace**, so nothing changes for core
widget ids. The only new acceptance is the documented namespaced form. Splitting happens at the
first colon, the same rule as `parsePermissionGroup()` from #1009 - `a:b:c` stays refused, because a
module id may not contain a colon.

## Two traps the obvious fix falls into

Both measured, both avoided by composing the acceptor from the real regexes rather than hand-tuning
a third pattern:

1. A legal module id reaches 64 characters and a legal short id 32, so a legal full id reaches
   **97**. The old bound was 64 - adding `:` to the class would still have rejected it.
2. Module ids may start with a digit, so `7up:chart` is legal and `^[a-z]…` rejects it.

## Guards

Two, because one does not cover it:

- **`test/test-modules.js`** asserts the round trip at the length limits: whatever `fullWidgetId()`
  builds, the storage shape has to accept. An example-based test with `my-addon:chart` would have
  stayed green against the old 64-character bound. Plus a 21-case matrix for `isWidgetId`.
- **`test/test-preferences-dashboard.js`** asserts that the route actually calls the helper, for
  `dashboard_widgets` and `dashboard_widgets_default`, and that malformed namespaced ids stay
  refused. A correct helper the route never calls would be green otherwise - the same split as in
  #1009.

**Counter-check run:** reverting only the call site in `preferences.js` while leaving the helper and
the import in place turns the two route tests red and leaves every unit test green. That is the
separation the two guards are meant to provide.

## Notes

- No data migration. The write path never accepted such an id, so no stored configuration can
  contain one.
- The change is entirely under `server/`, which is not the weekly-train track. That does not make it
  ship earlier: the cadence guard judges the whole release, and `main` has carried interface work
  since v2.64.0 (84 files, 20 of them on the interface). This rides the Tuesday train with the
  #1009 fix.
- Deliberately out of scope: tightening the client's `isExtensionWidget` (`id.includes(':')`) to the
  same rule, and aligning `normalizeMobileNavOrder`, which silently drops unknown ids instead of
  refusing the list. Both are behaviour decisions, not part of this fix; the reasoning is in #1013.

Suites run green: modules, extension-permissions, extension-widgets, preferences-dashboard,
preferences-routes, preferences-navigation, preferences-hidden-modules, module-registry-parity,
dashboard-permissions, layer-boundary, permissions, permissions-routes, mcp-router-permissions,
frontend-audit, changelog.
