### PR TITLE
chore(deps): bump qs to 6.16.0 in the lockfile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "express": "^5.2.1",
         "express-rate-limit": "^8.7.0",
         "express-session": "^1.19.0",
-        "googleapis": "178.0.0",
         "helmet": "^8.3.0",
         "libphonenumber-js": "^1.13.12",
         "node-cron": "^4.6.0",
@@ -2452,9 +2451,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "es-define-property": "^1.0.1",


### PR DESCRIPTION
Closes the two open Dependabot alerts on `main` (both `first_patched: 6.16.0`).

## What changed

One lockfile bump, `qs 6.15.3 -> 6.16.0`. No `overrides` block, because every requirer's range
already covers 6.16.0:

| Requirer | Range on `qs` |
|---|---|
| `express@5.2.1` | `^6.14.0` |
| `body-parser@2.3.0` | `^6.15.2` |
| `googleapis-common@8.0.3` | `^6.7.0` |

Only the lockfile held the vulnerable version in place, and there is no patch route inside the
6.15 line: it ends at the vulnerable `.3` and has no backport tag. Sub-dependencies of 6.16.0 are
identical to 6.15.3.

The same install normalizes a lockfile drift that predates this branch: `googleapis` was listed in
the root `dependencies` block with an exact `178.0.0`, while `package.json` declares it under
`optionalDependencies` as `^178.0.0`.

## The advisories

- [GHSA-x5fp-wj9c-mxmx](https://github.com/advisories/GHSA-x5fp-wj9c-mxmx), moderate: `arrayLimit`
  bypass via bracket-key comma parsing.
- [GHSA-4mjr-xmp4-gh2g](https://github.com/advisories/GHSA-4mjr-xmp4-gh2g), moderate: denial of
  service via attacker-controlled `isBuffer`.

Neither is reachable in this codebase today, which is why this ships as an ordinary dependency
bump rather than through the security release path in `docs/RELEASING.md`:

- GHSA-x5fp requires `comma: true`. Nothing in the tree sets it; `qs` itself defaults it to
  `false`.
- GHSA-4mjr requires a parse with `allowPrototypes` followed by a `qs.stringify` round-trip of the
  same object. The parse half is live: `body-parser` sets `allowPrototypes: true`, and
  `express.urlencoded({ extended: true })` is mounted globally ahead of the session in
  `server/index.js`. The stringify half is missing: the only `qs.stringify` caller in the whole
  tree is `googleapis-common`, and it serializes query parameters built in code. A request body
  travels as `requestBody` into JSON, not through `qs`.

The second one is worth fixing now rather than later precisely because its parse half is already
live: only the absence of a stringify caller keeps it shut.

## Verification

- `npm ci`, then `npm audit`: `found 0 vulnerabilities`.
- Full chain: `npm test` green, exit code `0` read from the log file rather than a pipe.
- `qs` is not pinned in `allowScripts`, so no pin follows this bump; `test:allow-scripts-pins` is
  green in the chain above.
