### PR TITLE
test(ui): bound the undo restore tests with an explicit timeout

### DIFF
--- a/test/test-ux-utils.js
+++ b/test/test-ux-utils.js
@@ -229,7 +229,7 @@ test('scheduleUndoableDelete: ohne Undo läuft der Delete nach dem Fenster', asy
   assert.equal(keepaliveFlag, false, 'der reguläre Commit läuft ohne keepalive');
 });
 
-test('scheduleUndoableDelete: pagehide-Fehler kann den optimistischen Zustand einmalig zurücksetzen', async () => {
+test('scheduleUndoableDelete: pagehide-Fehler kann den optimistischen Zustand einmalig zurücksetzen', { timeout: 5000 }, async () => {
   const previousWindow = global.window;
   const listeners = new Map();
   let capturedUndo = null;
@@ -278,7 +278,7 @@ test('scheduleUndoableDelete: pagehide-Fehler kann den optimistischen Zustand ei
   }
 });
 
-test('scheduleUndoableDelete: regulärer Commit-Fehler wird einmalig zurückgesetzt und gemeldet', async () => {
+test('scheduleUndoableDelete: regulärer Commit-Fehler wird einmalig zurückgesetzt und gemeldet', { timeout: 5000 }, async () => {
   const previousWindow = global.window;
   const listeners = new Map();
   let capturedUndo = null;


### PR DESCRIPTION
Follow-up to #1016.

Both new `scheduleUndoableDelete` tests wait on a promise that only the
`restore` callback resolves:

```js
let resolveRestored;
const restored = new Promise((resolve) => { resolveRestored = resolve; });
// ...
restore: (err) => { resolveRestored(); },
// ...
await restored;
```

If the behaviour they guard regresses, `restore` is never called, and Node has no
default per-test timeout. The suite hangs instead of failing.

Measured while counterproofing #1016 before merging it: reverting
`restoreOnKeepaliveError` in `public/utils/ux.js` turned a 300 ms suite into a
run of over three minutes with no output at all. The runner prints its summary
only at the end, so there was nothing to read while it hung. In CI that is a job
timeout rather than a named failing test.

With `{ timeout: 5000 }` the same counterproof now exits 1 after five seconds and
names the test:

```
✖ scheduleUndoableDelete: pagehide-Fehler kann den optimistischen Zustand einmalig zurücksetzen (5003.29ms)
```

The second counterproof (regular commit failure never restoring) behaves the same
way for the other test.

The guarded behaviour itself is unchanged; this only makes its failure legible.

**Verification:** `test:ux-utils` 33/33 green and still ~300 ms, plus
`test:suite-chain`, `test:typography`, `test:changelog` and `test:frontend-audit`
(359/359) green.
