### PR TITLE
docs(calendar): explain delete reconciliation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -217,7 +217,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   delete reloads the visible range so an older in-flight response cannot bring the event back.
   Calendar loads now share one ordering guard, including quick out-and-back navigation, and
   concurrent deletes of one series reach the server in user-action order. This covers one event,
-  one recurring occurrence, this-and-following, and whole-series deletion.
+  one recurring occurrence, this-and-following, and whole-series deletion. A failed range load
+  also clears schedule warnings from the previous range instead of leaving stale warnings visible.
 - **Authorized caregivers can now correct a cared-for person's medication log entries** (#999).
   The log row now follows the same explicit care grant as recording, taking and skipping a dose;
   other family members still see it read-only, and scheduled entries keep their existing

--- a/public/pages/calendar.js
+++ b/public/pages/calendar.js
@@ -1331,7 +1331,15 @@ async function reloadCalendarEventsOnly() {
   }
 }
 
-/** Reconcile every calendar layer after a delayed destructive commit. */
+/**
+ * Reconcile every calendar layer after a delayed destructive commit.
+ *
+ * A delete changes only events, but this intentionally uses the full range
+ * loader: it makes events, range bounds, load/offline state and every rendered
+ * layer one authoritative snapshot after the five-second delay. Reusing the
+ * event-only loader would leave the next reader tempted to restore the old
+ * partial-state race this path exists to close.
+ */
 async function reloadCalendarRangeAfterDelete() {
   const { from, to } = getRangeForView(state.view, state.cursor);
   await loadRange(from, to);
@@ -4727,6 +4735,9 @@ async function deleteThisAndFollowing(event) {
     schedule: scheduleUndoableDelete,
     requestDelete: async ({ keepalive }) => {
       await api.put(`/calendar/${event.id}`, { recurrence_rule: newRule }, { keepalive });
+      // The former client-side loop patched recurrence_rule on the remaining
+      // expanded rows. The authoritative range reload below now obtains the
+      // truncated rule from the server instead of guessing that response.
     },
     isViewActive: () => Boolean(_container?.isConnected),
     reloadEvents: reloadCalendarRangeAfterDelete,


### PR DESCRIPTION
## Summary

Carries the documentation-only follow-up that was pushed to the source branch of #1032 after that PR had already merged.

## Changes

- Explains why the delayed-delete commit deliberately performs a full authoritative range reload instead of a partial event refresh.
- Records why the former client-side recurrence-rule patch loop is gone.
- Completes the existing changelog entry with the stale schedule-warning cleanup already implemented by #1032.

There is no behavior change. The diff is limited to `CHANGELOG.md` and comments in `public/pages/calendar.js`.

Refs #1032
Refs #975

## Verification

- `npm run test:calendar` - 112/112 calendar checks plus 22/22 delete-lifecycle checks.
- `npm run test:changelog` - 28/28.
- `git diff --check` - clean.

## AI assistance

This documentation was drafted with OpenAI Codex and reviewed against the merged implementation.

## Checklist

- [x] `npm test` already passed for the implementation in #1032; the affected focused suites pass here
- [x] Follows [CONTRIBUTING.md](../CONTRIBUTING.md) conventions
- [x] No new frontend dependencies
- [x] No UI strings added
- [x] CHANGELOG.md updated
