### PR TITLE
test(i18n): catch a counting key that has no plural variant (#1010)

### DIFF
--- a/test/test-i18n-plural.js
+++ b/test/test-i18n-plural.js
@@ -153,9 +153,9 @@ test('jede Pluralvariante hat einen zählenden Basisschlüssel in allen Locales'
   for (const file of files) {
     const entries = flattenLocale(JSON.parse(readFileSync(new URL(file, LOCALE_DIR), 'utf8')));
     for (const [key, value] of entries) {
-      if (!/_(one|two|few|many|other)$/.test(key)) continue;
+      if (!/_(zero|one|two|few|many|other)$/.test(key)) continue;
       if (typeof value !== 'string' || !value.includes('{{count}}')) continue;
-      const base = key.replace(/_(one|two|few|many|other)$/, '');
+      const base = key.replace(/_(zero|one|two|few|many|other)$/, '');
       assert.ok(entries.has(base), `${file}: ${key} ohne Basisschlüssel ${base}`);
       assert.match(entries.get(base), /\{\{count\}\}/, `${file}: ${base} zählt nicht`);
     }
@@ -179,6 +179,14 @@ test('jede Pluralvariante hat einen zählenden Basisschlüssel in allen Locales'
 // Schluessel. Ein Guard, der beim ersten Lauf 70-mal scheitert, wird abgeschwaecht
 // statt erfuellt - danach prueft er wieder nichts. Die Karte friert den Bestand
 // ein; jeder NEUE zaehlende Schluessel ohne Variante ist ab sofort rot.
+//
+// BEKANNTE GRENZE: erkannt wird ein zaehlender Schluessel am `{{count}}` im WERT.
+// Ein Aufrufer darf `count` aber auch nur zur Pluralwahl uebergeben, waehrend der
+// Text andere Platzhalter interpoliert - `settings.addressbooksEnabledOfTotal` macht
+// genau das (`{{enabled}} von {{total}}`, Aufruf mit `count: addressbooks.length`,
+// sync-contacts.js:163). Solche Schluessel sieht dieser Guard nicht; sie zu finden
+// hiesse, jeden `t()`-Aufruf auf ein `count:`-Argument zu lesen. Bewusst offen
+// gelassen: die haeufige Luecke ist die hier gepruefte.
 //
 // Die Kategorie sagt, WARUM der Schluessel keine Variante braucht - und sie ist
 // am AUFRUFER belegt, nicht am Wortlaut. Ein String, der klingt, als koenne er
@@ -260,6 +268,9 @@ const PLURAL_EXCEPTIONS = {
   'subscriptions.everyCycle': 'GUARDED',
   // personal-calendar.js:214 - der Wert ist die Konstante MAX_DEFAULT_REMINDERS.
   'settings.calendarDefaultRemindersMax': 'GUARDED',
+  // subscriptions.js:150-154 - dueLabel() faengt d<0, d===0 und d===1 vorher ab,
+  // diese Zeile sieht nur noch d >= 2.
+  'subscriptions.dueInDays': 'GUARDED',
 
   // --- echte Luecken, eingefroren statt behoben ---------------------------
   // Alle unten sind bei n=1 grammatisch falsch und n=1 ist erreichbar.
@@ -288,7 +299,6 @@ const PLURAL_EXCEPTIONS = {
   'tasks.navLabelOverdue': 'TODO_ONE',              // router.js:1151, Guard ist `> 0`
   'subscriptions.listCount': 'TODO_ONE',
   'subscriptions.overdueDays': 'TODO_ONE',
-  'subscriptions.dueInDays': 'TODO_ONE',
   'subscriptions.reminderMeta': 'TODO_ONE',
   'subscriptions.metaInUseWarning': 'TODO_ONE',     // umgeht den Plural im String: „Abonnement(s)"
   'settings.recipeProviderDeleteAccountConfirm': 'TODO_ONE',
@@ -306,9 +316,13 @@ test('ein zaehlender Schluessel ohne Variante steht in der Ausnahmekarte (#1010)
   const entries = flattenLocale(localeFile('de'));
   const ohneVariante = [];
   for (const [key, value] of entries) {
-    if (/_(one|two|few|many|other)$/.test(key)) continue;
+    if (/_(zero|one|two|few|many|other)$/.test(key)) continue;
     if (typeof value !== 'string' || !value.includes('{{count}}')) continue;
-    if (entries.has(`${key}_one`)) continue;
+    // Nicht nur `has()`: ein `_one`, das null, eine Zahl oder ein leerer String ist,
+    // faellt zur Laufzeit auf den Plural-Basisschluessel zurueck (oder laesst `t()`
+    // `.replace()` auf einem Nicht-String rufen) - die Variante waere da und wirkungslos.
+    const variante = entries.get(`${key}_one`);
+    if (typeof variante === 'string' && variante.trim() !== '') continue;
     ohneVariante.push(key);
   }
 

--- a/test/test-i18n-plural.js
+++ b/test/test-i18n-plural.js
@@ -199,8 +199,12 @@ test('jede Pluralvariante hat einen zählenden Basisschlüssel in allen Locales'
  *
  * NO_NOUN        Auf die Zahl folgt kein Substantiv („3 ausgewaehlt", „3 aktiv").
  *                Im Deutschen numerusneutral, braucht keine Variante.
- * PARENTHETICAL  Die Zahl steht in Klammern oder hinter einem Doppelpunkt
- *                („Dateikonflikte (3)"). Ebenfalls neutral.
+ * PARENTHETICAL  Die Zahl steht in Klammern oder hinter einem Doppelpunkt UND der
+ *                uebrige Satz traegt keinen Numerus ("Importieren (3)",
+ *                "fehlgeschlagen: 3"). ACHTUNG: die Klammer allein macht nichts
+ *                neutral - "Dateikonflikte (1)" ist falsch, weil das Substantiv
+ *                davor im Plural steht. Vor dieser Kategorie den GANZEN String
+ *                lesen, nicht nur die Klammer.
  * ABBREV         Die Einheit ist eine numerusneutrale Abkuerzung („3 Min.").
  * PAIR_LEGACY    Handgebautes Paar aus der Zeit vor `_one` (Suffix `Plural`,
  *                `Many`/`One`, `Singular`). Heute korrekt, nur alte Schreibweise.
@@ -233,9 +237,6 @@ const PLURAL_EXCEPTIONS = {
   // --- Zahl in Klammern / hinter Doppelpunkt ------------------------------
   'category.errorInUse': 'PARENTHETICAL',
   'category.errorSubInUse': 'PARENTHETICAL',
-  'documents.folderUpload.fileConflictsTitle': 'PARENTHETICAL',
-  'documents.folderUpload.folderConflictsTitle': 'PARENTHETICAL',
-  'documents.folderUpload.rejectedTitle': 'PARENTHETICAL',
   'shopping.clearChecked': 'PARENTHETICAL',
   'contacts.importSubmit': 'PARENTHETICAL',
   'health.cycle.settings.applyToAllDone': 'PARENTHETICAL',
@@ -275,6 +276,11 @@ const PLURAL_EXCEPTIONS = {
   // --- echte Luecken, eingefroren statt behoben ---------------------------
   // Alle unten sind bei n=1 grammatisch falsch und n=1 ist erreichbar.
   'dashboard.housekeepingVisitsMonth': 'TODO_ONE',  // dashboard.js:2138, `visits` ungefiltert
+  // Diese drei standen faelschlich unter PARENTHETICAL: die Klammer ist neutral, das
+  // Substantiv davor nicht. renderFolderUploadPreview zeigt sie ab EINEM Konflikt.
+  'documents.folderUpload.fileConflictsTitle': 'TODO_ONE',
+  'documents.folderUpload.folderConflictsTitle': 'TODO_ONE',
+  'documents.folderUpload.rejectedTitle': 'TODO_ONE',
   'dashboard.shoppingMore': 'TODO_ONE',             // dashboard.js:1485/2987/3530, Guard ist `> 0`
   'calendar.moreEvents': 'TODO_ONE',
   'calendar.searchCount': 'TODO_ONE',
@@ -339,6 +345,33 @@ test('ein zaehlender Schluessel ohne Variante steht in der Ausnahmekarte (#1010)
   const veraltet = Object.keys(PLURAL_EXCEPTIONS).filter((k) => !ohneVariante.includes(k));
   assert.deepEqual(veraltet, [],
     `Ausnahmekarte veraltet - diese Schluessel brauchen keine Ausnahme mehr: ${veraltet.join(', ')}`);
+});
+
+// Die Pruefung oben misst `de.json` als Referenz. Das beantwortet die Frage, OB ein
+// Schluessel eine Variante braucht - nicht, ob die vorhandene Variante ueberall etwas
+// taugt: ein `_one`, das in de steht und in fr leer ist, faellt zur Laufzeit genau
+// dort auf den Plural zurueck, wo niemand hinsieht, und die Schluessel-Paritaet merkt
+// nichts davon. Der Bestand ist sauber (95 Varianten x 24 Locales, 0 unbrauchbar),
+// also darf diese Pruefung strikt sein und braucht keine Ausnahmekarte.
+test('jede _one-Variante traegt in JEDER Locale einen brauchbaren Wert (#1010)', () => {
+  const referenz = flattenLocale(localeFile('de'));
+  const varianten = [...referenz.keys()].filter((k) => k.endsWith('_one'));
+  assert.ok(varianten.length > 50,
+    `nur ${varianten.length} _one-Varianten gefunden - misst der Filter noch?`);
+
+  const kaputt = [];
+  for (const file of readdirSync(LOCALE_DIR).filter((f) => f.endsWith('.json'))) {
+    const entries = flattenLocale(JSON.parse(readFileSync(new URL(file, LOCALE_DIR), 'utf8')));
+    for (const key of varianten) {
+      const wert = entries.get(key);
+      if (wert === undefined) { kaputt.push(`${file}: ${key} fehlt`); continue; }
+      if (typeof wert !== 'string' || wert.trim() === '') {
+        kaputt.push(`${file}: ${key} = ${JSON.stringify(wert)}`);
+      }
+    }
+  }
+  assert.deepEqual(kaputt, [],
+    `unbrauchbare Singular-Varianten (leer, null oder keine Zeichenkette): ${kaputt.join(', ')}`);
 });
 
 // ---------------------------------------------------------------------------

--- a/test/test-i18n-plural.js
+++ b/test/test-i18n-plural.js
@@ -13,6 +13,16 @@ import { readFileSync, readdirSync } from 'node:fs';
 const LOCALE_DIR = new URL('../public/locales/', import.meta.url);
 const localeFile = (locale) => JSON.parse(readFileSync(new URL(`${locale}.json`, LOCALE_DIR), 'utf8'));
 
+/** Verschachtelte Locale-Datei zu einer flachen Map `a.b.c` -> Wert. */
+const flattenLocale = (obj, prefix = '', out = new Map()) => {
+  for (const [k, v] of Object.entries(obj)) {
+    const key = prefix ? `${prefix}.${k}` : k;
+    if (v && typeof v === 'object') flattenLocale(v, key, out);
+    else out.set(key, v);
+  }
+  return out;
+};
+
 // i18n.js ist Browser-Code: Umgebung stellen, bevor das Modul geladen wird.
 const store = new Map();
 global.localStorage = {
@@ -138,18 +148,10 @@ test('unbekannter Schlüssel liefert den Schlüssel selbst zurück - auch mit co
 
 test('jede Pluralvariante hat einen zählenden Basisschlüssel in allen Locales', () => {
   const files = readdirSync(LOCALE_DIR).filter((f) => f.endsWith('.json'));
-  const flatten = (obj, prefix = '', out = new Map()) => {
-    for (const [k, v] of Object.entries(obj)) {
-      const key = prefix ? `${prefix}.${k}` : k;
-      if (v && typeof v === 'object') flatten(v, key, out);
-      else out.set(key, v);
-    }
-    return out;
-  };
   // Pluralvariante = Suffix einer CLDR-Kategorie UND ein {{count}} im Wert.
   // Das trennt sie von echten Enum-Werten wie `budget.accountType_other`.
   for (const file of files) {
-    const entries = flatten(JSON.parse(readFileSync(new URL(file, LOCALE_DIR), 'utf8')));
+    const entries = flattenLocale(JSON.parse(readFileSync(new URL(file, LOCALE_DIR), 'utf8')));
     for (const [key, value] of entries) {
       if (!/_(one|two|few|many|other)$/.test(key)) continue;
       if (typeof value !== 'string' || !value.includes('{{count}}')) continue;
@@ -158,6 +160,171 @@ test('jede Pluralvariante hat einen zählenden Basisschlüssel in allen Locales'
       assert.match(entries.get(base), /\{\{count\}\}/, `${file}: ${base} zählt nicht`);
     }
   }
+});
+
+// ---------------------------------------------------------------------------
+// Die Gegenrichtung: ein zählender Schlüssel OHNE Variante (#1010)
+//
+// Der Test oben geht von der Variante aus und findet deshalb nur den Fehler
+// „Variante da, Basis fehlt". Der Fehler, den Menschen tatsächlich machen, ist
+// der andere: `{{count}}` schreiben und die `_one`-Variante vergessen. Zwei
+// unabhängige PRs lieferten am 2./3.09. je drei solcher Schlüssel bei gruener
+// CI - „1 Dateien hochladen".
+//
+// Gemessen wird `de.json`, die Referenz-Locale: was dort eine Variante braucht,
+// braucht sie ueberall. Der umgekehrte Fall (eine Sprache braucht eine Variante,
+// wo Deutsch keine braucht) ist eine groessere Frage und nicht die dieses Guards.
+//
+// WARUM EINE AUSNAHMEKARTE UND KEIN STRIKTES ROT: der Bestand traegt 70 solcher
+// Schluessel. Ein Guard, der beim ersten Lauf 70-mal scheitert, wird abgeschwaecht
+// statt erfuellt - danach prueft er wieder nichts. Die Karte friert den Bestand
+// ein; jeder NEUE zaehlende Schluessel ohne Variante ist ab sofort rot.
+//
+// Die Kategorie sagt, WARUM der Schluessel keine Variante braucht - und sie ist
+// am AUFRUFER belegt, nicht am Wortlaut. Ein String, der klingt, als koenne er
+// nicht bei 1 stehen, kann es meistens doch (#1010 nennt zwei Faelle, die genau
+// so durchgefallen sind).
+// ---------------------------------------------------------------------------
+
+/**
+ * Zaehlende Basisschluessel ohne `_one` - der eingefrorene Bestand.
+ *
+ * NO_NOUN        Auf die Zahl folgt kein Substantiv („3 ausgewaehlt", „3 aktiv").
+ *                Im Deutschen numerusneutral, braucht keine Variante.
+ * PARENTHETICAL  Die Zahl steht in Klammern oder hinter einem Doppelpunkt
+ *                („Dateikonflikte (3)"). Ebenfalls neutral.
+ * ABBREV         Die Einheit ist eine numerusneutrale Abkuerzung („3 Min.").
+ * PAIR_LEGACY    Handgebautes Paar aus der Zeit vor `_one` (Suffix `Plural`,
+ *                `Many`/`One`, `Singular`). Heute korrekt, nur alte Schreibweise.
+ *                Ein Umbau auf `_one` waere ein eigener Vorgang: 20+ Aufrufstellen.
+ * NOT_A_COUNT    `count` ist gar kein Zaehler, sondern ein Zahlenwert oder ein
+ *                bereits formatierter String. Plural-Regeln greifen hier nicht.
+ * GUARDED        n=1 ist AM AUFRUFER ausgeschlossen - mit Datei und Zeile belegt.
+ * DEAD_KEY       Der Schluessel wird nirgends aufgerufen (in allen Locales
+ *                vorhanden, im Code nicht). Aufraeumen ist eine eigene Aenderung -
+ *                24 Sprachdateien, und sie duerfen nicht reserialisiert werden.
+ * TODO_ONE       Echte Luecke: n=1 ist erreichbar und der Satz ist dann falsch.
+ *                Steht hier, damit der Guard scharf gestellt werden kann, ohne
+ *                24 Locales in derselben Aenderung anzufassen.
+ */
+const PLURAL_EXCEPTIONS = {
+  // --- kein Substantiv nach der Zahl -------------------------------------
+  'contacts.selectCount': 'NO_NOUN',
+  'contacts.importSelectedStatus': 'NO_NOUN',
+  'contacts.importDetailBirthday': 'NO_NOUN',
+  'contacts.importDetailFailed': 'NO_NOUN',
+  'documents.selectCount': 'NO_NOUN',
+  'tasks.bulkSelectedCount': 'NO_NOUN',
+  'dashboard.todayShoppingCount': 'NO_NOUN',
+  'dashboard.rewardsPending': 'NO_NOUN',
+  'dashboard.healthRefill': 'NO_NOUN',
+  'health.labs.abnormalBadge': 'NO_NOUN',
+  'subscriptions.activeCount': 'NO_NOUN',
+  'budget.loansSummary': 'NO_NOUN',
+
+  // --- Zahl in Klammern / hinter Doppelpunkt ------------------------------
+  'category.errorInUse': 'PARENTHETICAL',
+  'category.errorSubInUse': 'PARENTHETICAL',
+  'documents.folderUpload.fileConflictsTitle': 'PARENTHETICAL',
+  'documents.folderUpload.folderConflictsTitle': 'PARENTHETICAL',
+  'documents.folderUpload.rejectedTitle': 'PARENTHETICAL',
+  'shopping.clearChecked': 'PARENTHETICAL',
+  'contacts.importSubmit': 'PARENTHETICAL',
+  'health.cycle.settings.applyToAllDone': 'PARENTHETICAL',
+
+  // --- numerusneutrale Abkuerzung ----------------------------------------
+  'settings.calendarDurationMinutes': 'ABBREV',
+
+  // --- handgebaute Paare, alte Schreibweise -------------------------------
+  'search.resultCountOne': 'PAIR_LEGACY',
+  'search.resultCountMany': 'PAIR_LEGACY',
+  'contacts.countMany': 'PAIR_LEGACY',
+  'contacts.importedCountToast': 'PAIR_LEGACY',
+  'contacts.importedCountToastSingular': 'PAIR_LEGACY',
+  'dashboard.eventsChip': 'PAIR_LEGACY',
+  'dashboard.eventsChipPlural': 'PAIR_LEGACY',
+  'dashboard.urgentTasksChip': 'PAIR_LEGACY',
+  'dashboard.urgentTasksChipPlural': 'PAIR_LEGACY',
+  'dashboard.overdueTasksChip': 'PAIR_LEGACY',
+  'dashboard.overdueTasksChipPlural': 'PAIR_LEGACY',
+  'reminders.pendingBadgeTitle': 'PAIR_LEGACY',
+  'reminders.pendingBadgeTitlePlural': 'PAIR_LEGACY',
+
+  // --- `count` ist kein Zaehler ------------------------------------------
+  // fmtNum() (health.js:1256) liefert einen fertig formatierten String bzw. '–'.
+  // Eine Dosis „1,5×" ist kein Zaehlwert, Intl.PluralRules greift hier nicht.
+  'health.meds.doseQty': 'NOT_A_COUNT',
+
+  // --- n=1 am Aufrufer ausgeschlossen ------------------------------------
+  // subscriptions.js:135 - `cycle_interval === 1 ? t(key) : t('everyCycle', …)`.
+  'subscriptions.everyCycle': 'GUARDED',
+  // personal-calendar.js:214 - der Wert ist die Konstante MAX_DEFAULT_REMINDERS.
+  'settings.calendarDefaultRemindersMax': 'GUARDED',
+
+  // --- echte Luecken, eingefroren statt behoben ---------------------------
+  // Alle unten sind bei n=1 grammatisch falsch und n=1 ist erreichbar.
+  'dashboard.housekeepingVisitsMonth': 'TODO_ONE',  // dashboard.js:2138, `visits` ungefiltert
+  'dashboard.shoppingMore': 'TODO_ONE',             // dashboard.js:1485/2987/3530, Guard ist `> 0`
+  'calendar.moreEvents': 'TODO_ONE',
+  'calendar.searchCount': 'TODO_ONE',
+  'contacts.bulkDeletedToast': 'TODO_ONE',
+  'contacts.importSkippedNote': 'TODO_ONE',
+  'birthdays.importSelected': 'TODO_ONE',
+  'birthdays.importSubmit': 'TODO_ONE',
+  'birthdays.importSuccess': 'TODO_ONE',
+  'documents.bulkArchivedToast': 'TODO_ONE',
+  'documents.bulkDeleteConfirm': 'TODO_ONE',
+  'documents.bulkDeletedToast': 'TODO_ONE',
+  'documents.bulkMovedToast': 'TODO_ONE',
+  'documents.bulkRestoredToast': 'TODO_ONE',
+  'documents.bulkUploadedToast': 'TODO_ONE',
+  'documents.selectedFilesLabel': 'TODO_ONE',
+  'budget.chartSummary': 'TODO_ONE',
+  'budget.statsDonutSummary': 'TODO_ONE',
+  'health.labs.analyteCount': 'TODO_ONE',
+  'health.cycle.status.inDays': 'TODO_ONE',
+  'health.cycle.status.overdue': 'TODO_ONE',
+  'inventory.navLabelAttention': 'TODO_ONE',        // router-Badge, Guard ist `> 0`
+  'tasks.navLabelOverdue': 'TODO_ONE',              // router.js:1151, Guard ist `> 0`
+  'subscriptions.listCount': 'TODO_ONE',
+  'subscriptions.overdueDays': 'TODO_ONE',
+  'subscriptions.dueInDays': 'TODO_ONE',
+  'subscriptions.reminderMeta': 'TODO_ONE',
+  'subscriptions.metaInUseWarning': 'TODO_ONE',     // umgeht den Plural im String: „Abonnement(s)"
+  'settings.recipeProviderDeleteAccountConfirm': 'TODO_ONE',
+
+  // --- tote Schluessel: in allen Locales, im Code nirgends ----------------
+  // Gemessen am 06.09.2026: 0 Treffer ausserhalb von public/locales/, auch
+  // nicht dynamisch zusammengesetzt. Aufraeumen: eigener Vorgang.
+  'housekeeping.monthTotal': 'DEAD_KEY',
+  'housekeeping.moreWorkers': 'DEAD_KEY',
+  'tasks.overdueDay': 'DEAD_KEY',
+  'tasks.bulkDeleteConfirm': 'DEAD_KEY',
+};
+
+test('ein zaehlender Schluessel ohne Variante steht in der Ausnahmekarte (#1010)', () => {
+  const entries = flattenLocale(localeFile('de'));
+  const ohneVariante = [];
+  for (const [key, value] of entries) {
+    if (/_(one|two|few|many|other)$/.test(key)) continue;
+    if (typeof value !== 'string' || !value.includes('{{count}}')) continue;
+    if (entries.has(`${key}_one`)) continue;
+    ohneVariante.push(key);
+  }
+
+  const neu = ohneVariante.filter((k) => !(k in PLURAL_EXCEPTIONS));
+  assert.deepEqual(neu, [],
+    'Neue zaehlende Schluessel ohne `_one`-Variante. Entweder eine Variante anlegen '
+    + '(public/locales/*.json, alle Sprachen) oder mit begruendeter Kategorie in '
+    + `PLURAL_EXCEPTIONS eintragen: ${neu.join(', ')}`);
+
+  // Die Karte darf nicht verrotten: ein Eintrag, der keine Ausnahme mehr ist -
+  // weil der Schluessel eine Variante bekam oder geloescht wurde -, muss raus.
+  // Ohne diese Haelfte waechst die Karte und niemand raeumt sie je auf
+  // (dasselbe Muster wie INTENTIONALLY_NOT_IN_INSTALLER).
+  const veraltet = Object.keys(PLURAL_EXCEPTIONS).filter((k) => !ohneVariante.includes(k));
+  assert.deepEqual(veraltet, [],
+    `Ausnahmekarte veraltet - diese Schluessel brauchen keine Ausnahme mehr: ${veraltet.join(', ')}`);
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1010.

`test:i18n-plural` only walked from the variant to the base key. That catches "variant without base" and is blind to the mistake people actually make: writing `{{count}}` and forgetting the `_one` variant. Two PRs shipped three such keys each on 2-3 September with green CI - the submit button read *"1 Dateien hochladen"*.

## Why a map instead of a strict assertion

The stock carries **70** such keys. A guard that fails 70 times on its first run gets weakened rather than satisfied, and then it checks nothing again. So the stock is frozen in `PLURAL_EXCEPTIONS` and every **new** counting key without a variant is red from now on.

Note the number: #1010 measured **67** on 3 September. It is 70 today. The stock grows while nothing holds it.

## The categories say *why*, and they come from the caller

The issue's own warning was worth heeding - both keys it first listed as "n=1 cannot happen" turned out to be reachable once the call site was read. So each entry is classified by what the caller does, not by how the string sounds:

| Category | Meaning |
|---|---|
| `NO_NOUN` / `PARENTHETICAL` / `ABBREV` | the German string is number-neutral (`"3 ausgewählt"`, `"Dateikonflikte (3)"`, `"3 Min."`) |
| `PAIR_LEGACY` | hand-built pair from before `_one` existed - correct today, older spelling |
| `NOT_A_COUNT` | `count` carries a formatted string, not a count - `health.meds.doseQty` receives `fmtNum()` output |
| `GUARDED` | n=1 excluded at the caller, with file and line - `subscriptions.everyCycle` is the clean case (`cycle_interval === 1 ? … : …`) |
| `TODO_ONE` | a real gap: n=1 is reachable and the sentence is wrong there. Frozen, not fixed here |
| `DEAD_KEY` | the key exists in all 24 locales and is called nowhere |

## The half that keeps the map from rotting

An entry whose key later gains a variant, or disappears, fails the test. Without that half the map only grows and nobody ever cleans it out - same shape as `INTENTIONALLY_NOT_IN_INSTALLER`.

## Measured

| Case | Result |
|---|---|
| untouched | 15 pass, 0 fail |
| a new counting key without `_one` | 14 pass, **1 fail**, names the key and says what to do |
| a mapped key given a `_one` variant | 14 pass, **1 fail**, "map is stale" |
| full `npm test` | exit 0, 280 suite links, 6058 assertions, 0 failures |

The guard found a mistake in my own map on its first run (`tasks.bulkDeleteConfirm` missing), which is exactly what it is for.

## Side finding, deliberately not fixed here

Four locale keys are dead - present in all 24 language files, called nowhere (0 hits outside `public/locales/`, not assembled dynamically either):

- `housekeeping.monthTotal`
- `housekeeping.moreWorkers`
- `tasks.overdueDay`
- `tasks.bulkDeleteConfirm`

Removing them touches 24 files that must not be reserialised, so they are recorded as `DEAD_KEY` rather than deleted in passing. The `TODO_ONE` entries are likewise left alone: adding `_one` variants means real translations in 24 languages, which is its own change.

`flatten()` became a shared `flattenLocale()` so both tests use one walker.
